### PR TITLE
Extend the properties available to enclosure URI templates

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -116,4 +116,8 @@ class Episode < ActiveRecord::Base
   def enclosure_template
     podcast.enclosure_template
   end
+
+  def podcast_slug
+    podcast.path
+  end
 end

--- a/app/models/episode_builder.rb
+++ b/app/models/episode_builder.rb
@@ -57,7 +57,11 @@ class EpisodeBuilder
     return url if et.blank?
 
     url_info = Addressable::URI.parse(url).to_hash
-    url_info[:extension] = url_info[:path].split('.').pop
+    url_info.merge!(
+      extension: url_info[:path].split('.').pop,
+      slug: @ep.podcast_slug,
+      guid: @ep.guid
+    )
     template = Addressable::Template.new(et)
     template.expand(url_info).to_str
   end

--- a/test/models/episode_builder_test.rb
+++ b/test/models/episode_builder_test.rb
@@ -48,11 +48,15 @@ describe EpisodeBuilder do
       episode.expect(:prx_uri, nil)
       episode.expect(:overrides, {})
       episode.expect(:enclosure_template, 'http://foo.com/r.{extension}/b/n/{host}{+path}')
+      episode.expect(:podcast_slug, "slug")
+      episode.expect(:guid, "guid")
 
       builder = EpisodeBuilder.new(episode)
       url = 'http://test-f.prxu.org/podcast/episode/filename.mp3'
       new_url = builder.rewrite_audio_url(url)
       new_url.must_equal('http://foo.com/r.mp3/b/n/test-f.prxu.org/podcast/episode/filename.mp3')
+
+      episode.verify
 
       # link = '/podcast/episode/filename.mp3'
       # prefix = EpisodeBuilder.new(episode).prefix + 'mp3'
@@ -60,6 +64,44 @@ describe EpisodeBuilder do
       # eb[:audio][:url].must_equal prefix + '/test-f.prxu.org' + link
     end
   end
+
+  describe 'enclosure templates' do
+    it 'can include the slug from the podcast' do
+      episode = build_stubbed(:episode, podcast: build_stubbed(:podcast,
+        enclosure_template: "{slug}",
+        path: "foo"
+      ))
+      builder = EpisodeBuilder.new(episode)
+      builder.rewrite_audio_url("http://example.com/foo.mp3").must_equal("foo")
+    end
+
+    it 'can include the guid' do
+      episode = build_stubbed(:episode,
+        guid: "guid",
+        podcast: build_stubbed(:podcast,
+          enclosure_template: "{guid}",
+          path: "foo"
+        )
+      )
+      builder = EpisodeBuilder.new(episode)
+      builder.rewrite_audio_url("http://example.com/foo.mp3").must_equal("guid")
+    end
+
+    it 'can include all properties' do
+      episode = build_stubbed(:episode,
+        guid: "guid",
+        podcast: build_stubbed(:podcast,
+          enclosure_template: "http://fake.host/{slug}/{guid}.{extension}{?host}",
+          path: "slug"
+        )
+      )
+      builder = EpisodeBuilder.new(episode)
+      url = builder.rewrite_audio_url("http://example.com/path/filename.extension")
+      url.must_equal("http://fake.host/slug/guid.extension?host=example.com")
+    end
+  end
+
+
 
   describe 'with overrides' do
     it 'includes overrides' do

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -63,6 +63,14 @@ describe Episode do
     end
   end
 
+  it 'proxies podcast_slug to #podcast' do
+    podcast = build_stubbed(:podcast)
+    episode = build_stubbed(:episode, podcast: podcast)
+    podcast.stub(:path, 'podcast path!') do
+      episode.podcast_slug.must_equal('podcast path!')
+    end
+  end
+
   describe 'prx story' do
     let(:story) do
       msg = json_file(:prx_story_small)

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -23,7 +23,9 @@ class TaskTest < ActiveSupport::TestCase
   end
 
   it 'uses an sqs queue for callbacks' do
+    r, ENV['AWS_REGION'], ENV['FIXER_CALLBACK_QUEUE'], q = ENV['AWS_REGION'], 'us-east-1', nil, ENV['FIXER_CALLBACK_QUEUE']
     task.fixer_call_back_queue.must_equal 'sqs://us-east-1/test_feeder_fixer_callback'
+    ENV['AWS_REGION'], ENV['FIXER_CALLBACK_QUEUE'] = r, q
   end
 
   it 'creates a fixer job' do


### PR DESCRIPTION
In order to be more intentional about how we pass URLs to various services,
and to feel more comfortable encoding dovetail to expect a specific format of
URL which includes the program slug (shared) and a feeder-specific ID, add those
properties as specifically selectable within the context of the enclosure URI
templates rather than relying on the fact that we generate something that looks
sort of like that at the moment.
