### PR TITLE
Fix resource attribute case

### DIFF
--- a/app/models/concerns/feeder_storage.rb
+++ b/app/models/concerns/feeder_storage.rb
@@ -1,6 +1,0 @@
-require 'active_support/concern'
-
-module FeederStorage
-  extend ActiveSupport::Concern
-
-end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -54,7 +54,7 @@ class Episode < ActiveRecord::Base
     series_uri = story.links['series'].href
     story_uri = story.links['self'].href
     podcast = Podcast.find_by!(prx_uri: series_uri)
-    published = story.attributes[:publishedAt]
+    published = story.attributes[:published_at]
     published = Time.parse(published) if published
     create!(podcast: podcast, prx_uri: story_uri, published_at: published)
   end

--- a/app/models/episode_builder.rb
+++ b/app/models/episode_builder.rb
@@ -29,14 +29,14 @@ class EpisodeBuilder
       story_info = HashWithIndifferentAccess.new(
         link: link(@story),
         title: sa[:title],
-        subtitle: Sanitize.fragment(sa[:shortDescription] || '').strip,
+        subtitle: Sanitize.fragment(sa[:short_description] || '').strip,
         description: Sanitize.fragment(sa[:description] || '').strip,
         summary: sa[:description],
         content: sa[:description],
-        explicit: sa[:contentAdvisory] ? 'yes' : 'clean',
+        explicit: sa[:content_advisory] ? 'yes' : 'clean',
         keywords: sa[:tags],
         categories: sa[:tags],
-        published: sa[:publishedAt]
+        published: sa[:published_at]
       )
       info.merge!(story_info)
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -3,7 +3,6 @@ require 'prx_access'
 
 class Task < ActiveRecord::Base
   include PRXAccess
-  include FeederStorage
 
   enum status: [ :started, :created, :processing, :complete, :error, :retrying, :cancelled ]
 

--- a/lib/prx_access.rb
+++ b/lib/prx_access.rb
@@ -1,4 +1,11 @@
 module PRXAccess
+
+  class PRXHyperResource < HyperResource
+    def incoming_body_filter(hash)
+      super(hash.deep_transform_keys { |key| key.to_s.underscore })
+    end
+  end
+
   def api(options = {})
     opts = { root: cms_root }.merge(options)
     if account = opts.delete(:account)
@@ -6,17 +13,17 @@ module PRXAccess
       opts[:headers] = { 'Authorization' =>  "Bearer #{token}" }
     end
 
-    HyperResource.new(opts)
+    PRXHyperResource.new(opts)
   end
 
   def api_resource(body, root = cms_root)
     href = body['_links']['self']['href']
     resource = api(root: root)
-    link = HyperResource::Link.new(resource, href: href)
+    link = PRXHyperResource::Link.new(resource, href: href)
     # puts "href: #{href}"
     # puts "resource: #{resource.inspect}"
     # puts "link: #{link.inspect}"
-    HyperResource.new_from(body: body, resource: resource, link: link)
+    PRXHyperResource.new_from(body: body, resource: resource, link: link)
   end
 
   def get_account_token(account)

--- a/test/fixtures/crier_entry.json
+++ b/test/fixtures/crier_entry.json
@@ -1,8 +1,8 @@
 {
   "guid": "57 at http://serialpodcast.org",
-  "is_perma_link": false,
+  "isPermaLink": false,
   "url": "http://feeds.serialpodcast.org/~r/serialpodcast/~3/_LnOrNUV5n4/",
-  "feedburner_orig_link": "http://serialpodcast.org",
+  "feedburnerOrigLink": "http://serialpodcast.org",
   "author": {
     "name": "This American Life",
     "email": null
@@ -17,7 +17,7 @@
     "length": 27485957
   },
   "duration": 3360,
-  "is_closed_captioned": false,
+  "isClosedCaptioned": false,
   "position": 12,
   "block": false,
   "published": "2014-12-18T10:30:00.000Z",
@@ -25,7 +25,7 @@
     "position": 1,
     "url": "https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio.mp3",
     "type": "audio/mpeg",
-    "file_size": 26017749,
+    "fileSize": 26017749,
     "medium": "audio",
     "expression": "sample",
     "bitrate": 64,
@@ -37,7 +37,7 @@
     "position": 2,
     "url": "https://s3.amazonaws.com/prx-dovetail/testserial/serial_credits.mp3",
     "type": "audio/mpeg",
-    "file_size": 162376,
+    "fileSize": 162376,
     "medium": "audio",
     "expression": "sample",
     "bitrate": 64,
@@ -49,10 +49,10 @@
   "keywords": [],
   "_embedded": {
     "prx:feed": {
-      "feed_url": "https://s3.amazonaws.com/prx-dovetail/testserial/serialpodcast.xml",
+      "feedUrl": "https://s3.amazonaws.com/prx-dovetail/testserial/serialpodcast.xml",
       "url": "http://serialpodcast.org",
-      "image_url": "http://serialpodcast.org/sites/all/modules/custom/serial/img/serial-itunes-logo.png",
-      "hub_url": "http://pubsubhubbub.appspot.com/",
+      "imageUrl": "http://serialpodcast.org/sites/all/modules/custom/serial/img/serial-itunes-logo.png",
+      "hubUrl": "http://pubsubhubbub.appspot.com/",
       "title": "Serial",
       "subtitle": "A new podcast from the creators of This American Life",
       "description": "Serial is a new podcast from the creators of This American Life, hosted by Sarah Koenig. Serial unfolds one story - a true story - over the course of a whole season. The show follows the plot and characters wherever they lead, through\n      many surprising twists and turns. Sarah won't know what happens at the end of the story until she gets there, not long before you get there with her. Each week she'll bring you the latest chapter, so it's important to listen in, starting with Episode\n      1. New episodes are released on Thursday mornings.",
@@ -60,7 +60,7 @@
         "name": null,
         "email": "rich@strangebirdlabs.com"
       }],
-      "managing_editor": {
+      "managingEditor": {
         "name": "This American Life",
         "email": "chad@thislife.org"
       },
@@ -71,10 +71,10 @@
       "language": "en",
       "copyright": "Copyright 2015 Ira Glass",
       "complete": false,
-      "feedburner_name": "serialpodcast",
+      "feedburnerName": "serialpodcast",
       "block": false,
       "published": "2014-12-18T10:30:00.000Z",
-      "last_modified": "2014-12-18T10:30:00.000Z",
+      "lastModified": "2014-12-18T10:30:00.000Z",
       "keywords": [],
       "categories": ["News \u0026 Politics"],
       "_links": {

--- a/test/jobs/story_update_job_test.rb
+++ b/test/jobs/story_update_job_test.rb
@@ -18,7 +18,7 @@ describe StoryUpdateJob do
 
   it 'creates a story resource' do
     story = job.api_resource(JSON.parse(body))
-    story.must_be_instance_of HyperResource
+    story.must_be_instance_of PRXAccess::PRXHyperResource
   end
 
   it 'can create an episode' do

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -264,9 +264,9 @@ describe Episode do
       msg = json_file(:prx_story_small)
       body = JSON.parse(msg)
       href = body['_links']['self']['href']
-      resource = HyperResource.new(root: 'https://cms.prx.org/api/vi/')
-      link = HyperResource::Link.new(resource, href: href)
-      HyperResource.new_from(body: body, resource: resource, link: link)
+      resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
+      link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
+      PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)
     end
 
     it 'can be created from a story' do


### PR DESCRIPTION
old crier was sending underscore, cms has always been camel.
update feeder to handle either input from hal api responses, and convert to underscore keys for use in ruby.