### PR TITLE
Strip query params from the fixer source url

### DIFF
--- a/app/models/tasks/copy_media_task.rb
+++ b/app/models/tasks/copy_media_task.rb
@@ -40,8 +40,8 @@ class Tasks::CopyMediaTask < ::Task
   def episode_options
     return nil if episode && episode.prx_uri
     {
-      source: media_resource.original_url,
-      audio_uri: media_resource.original_url
+      source: episode_audio_uri,
+      audio_uri: episode_audio_uri
     }
   end
 
@@ -55,12 +55,16 @@ class Tasks::CopyMediaTask < ::Task
   end
 
   def new_audio_file?(story = nil)
-    options[:audio_uri] != (media_resource.original_url || story_audio_uri(story))
+    options[:audio_uri] != (episode_audio_uri || story_audio_uri(story))
   end
 
   def story_audio_uri(story = nil)
     story ||= get_story
     story.audio[0].body['_links']['self']['href']
+  end
+
+  def episode_audio_uri
+    media_resource.original_url.gsub(/\?.*/, '')
   end
 
   def get_story(account = nil)

--- a/test/models/tasks/copy_media_task_test.rb
+++ b/test/models/tasks/copy_media_task_test.rb
@@ -39,6 +39,13 @@ describe Tasks::CopyMediaTask do
     end
   end
 
+  it 'remove query string from audio url' do
+    task.media_resource.wont_be_nil
+    original = task.media_resource.original_url
+    task.media_resource.original_url = original + '?remove=this'
+    task.episode_audio_uri.must_equal original
+  end
+
   it 'alias owner as episode' do
     task.episode.must_equal task.owner.episode
   end


### PR DESCRIPTION
This fixes the issues where fixer doesn't analyze the mp3 files correctly.