### PR TITLE
Only show prx cms links for feeds and episodes connected to the cms

### DIFF
--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -46,6 +46,6 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   end
 
   link :story do
-    URI.join(cms_root, represented.prx_uri).to_s if represented.id
+    URI.join(cms_root, represented.prx_uri).to_s if represented.prx_uri
   end
 end

--- a/app/representers/api/podcast_representer.rb
+++ b/app/representers/api/podcast_representer.rb
@@ -58,10 +58,10 @@ class Api::PodcastRepresenter < Api::BaseRepresenter
   end
 
   link :series do
-    URI.join(cms_root, represented.prx_uri).to_s if represented.id
+    URI.join(cms_root, represented.prx_uri).to_s if represented.prx_uri
   end
 
   link :account do
-    URI.join(cms_root, represented.prx_account_uri).to_s if represented.id
+    URI.join(cms_root, represented.prx_account_uri).to_s if represented.prx_account_uri
   end
 end


### PR DESCRIPTION
fixes a bug where the representer throws an error when the prx related uris are null.