### PR TITLE
Call publish on actions that change podcasts and episodes

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -4,6 +4,8 @@ class Api::EpisodesController < Api::BaseController
   filter_resources_by :podcast_id
   find_method :find_by_guid
 
+  after_action :publish, only: [:create, :update, :destroy]
+
   def show
     res = show_resource
     if !res || !res.published? || !res.released?
@@ -13,6 +15,12 @@ class Api::EpisodesController < Api::BaseController
     else
       super
     end
+  end
+
+  private
+
+  def publish
+    resource.podcast.publish! if resource && resource.podcast
   end
 
   def scoped(relation)

--- a/app/controllers/api/podcasts_controller.rb
+++ b/app/controllers/api/podcasts_controller.rb
@@ -1,6 +1,13 @@
 class Api::PodcastsController < Api::BaseController
   api_versions :v1
   represent_with Api::PodcastRepresenter
+  after_action :publish, only: [:create, :update, :destroy]
+
+  private
+
+  def publish
+    resource.publish! if resource
+  end
 
   def scoped(relation)
     relation.published

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -61,7 +61,9 @@ describe Api::EpisodesController do
     end
 
     it 'can create a new episode' do
-      post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
+      @controller.stub(:publish, true) do
+        post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
+      end
       assert_response :success
       id = JSON.parse(response.body)['id']
       new_episode = Episode.find_by_guid(id)

--- a/test/controllers/api/podcasts_controller_test.rb
+++ b/test/controllers/api/podcasts_controller_test.rb
@@ -21,7 +21,9 @@ describe Api::PodcastsController do
     end
 
     it 'can create a new podcast' do
-      post :create, podcast_hash.to_json, api_version: 'v1', format: 'json'
+      @controller.stub(:publish, true) do
+        post :create, podcast_hash.to_json, api_version: 'v1', format: 'json'
+      end
       assert_response :success
       id = JSON.parse(response.body)['id']
       new_podcast = Podcast.find(id)


### PR DESCRIPTION
fixes #155 

Basically, when feeder was created, all changes came in async SQS messages SQS via `announce`.
Now that we are also affecting records via the API, need to also republish the rss xml feed when there is a change to related records via the API.