### PR TITLE
Redirect authorized access to unpublished instead of returning 404

### DIFF
--- a/app/controllers/api/auth/episodes_controller.rb
+++ b/app/controllers/api/auth/episodes_controller.rb
@@ -8,14 +8,9 @@ class Api::Auth::EpisodesController < Api::BaseController
   find_method :find_by_guid
 
   def show
-    res = show_resource
-    if !res
-      respond_with_error(HalApi::Errors::NotFound.new)
-    elsif res.deleted?
-      respond_with_error(ResourceGone.new)
-    else
-      super
-    end
+    return respond_with_error(HalApi::Errors::NotFound.new) if !show_resource
+    return respond_with_error(ResourceGone.new) if show_resource.deleted?
+    super
   end
 
   def scoped(relation)

--- a/app/controllers/api/auth/podcasts_controller.rb
+++ b/app/controllers/api/auth/podcasts_controller.rb
@@ -1,11 +1,24 @@
 # encoding: utf-8
 
-class Api::Auth::PodcastsController < Api::PodcastsController
+class Api::Auth::PodcastsController < Api::BaseController
   include ApiAuthenticated
   api_versions :v1
   represent_with Api::PodcastRepresenter
+  after_action :publish, only: [:create, :update, :destroy]
+
+  def show
+    return respond_with_error(HalApi::Errors::NotFound.new) if !show_resource
+    return respond_with_error(ResourceGone.new) if show_resource.deleted?
+    super
+  end
+
+  private
+
+  def publish
+    resource.publish! if resource
+  end
 
   def scoped(relation)
-    relation
+    relation.with_deleted
   end
 end

--- a/app/controllers/api/podcasts_controller.rb
+++ b/app/controllers/api/podcasts_controller.rb
@@ -1,7 +1,21 @@
+# encoding: utf-8
+
 class Api::PodcastsController < Api::BaseController
   api_versions :v1
   represent_with Api::PodcastRepresenter
   after_action :publish, only: [:create, :update, :destroy]
+
+  def show
+    return respond_with_error(HalApi::Errors::NotFound.new) if !show_resource
+    return respond_with_error(ResourceGone.new) if show_resource.deleted?
+    return super if show_resource.published?
+
+    if PodcastPolicy.new(pundit_user, show_resource).update?
+      redirect_to api_authorization_podcast_path(api_version, show_resource)
+    else
+      respond_with_error(HalApi::Errors::NotFound.new)
+    end
+  end
 
   private
 
@@ -10,6 +24,6 @@ class Api::PodcastsController < Api::BaseController
   end
 
   def scoped(relation)
-    relation.published
+    relation.with_deleted
   end
 end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -20,6 +20,10 @@ class Podcast < BaseModel
     update_column(:published_at, max_episode_published_at)
   end
 
+  def published?
+    !published_at.nil? && published_at <= Time.now
+  end
+
   def pub_date
     published_at
   end

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -52,12 +52,19 @@ describe Api::EpisodesController do
   describe 'with a valid token' do
     let(:account_id) { 123 }
     let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }
+    let(:episode_redirect) { create(:episode, podcast: podcast, published_at: nil) }
     let(:token) { StubToken.new(account_id, ['member']) }
 
     before do
       class << @controller; attr_accessor :prx_auth_token; end
       @controller.prx_auth_token = token
       @request.env['CONTENT_TYPE'] = 'application/json'
+    end
+
+    it 'should redirect for authorized request of unpublished resource' do
+      episode_redirect.id.wont_be_nil
+      get(:show, { api_version: 'v1', format: 'json', id: episode_redirect.guid } )
+      assert_response :redirect
     end
 
     it 'can create a new episode' do

--- a/test/controllers/api/podcasts_controller_test.rb
+++ b/test/controllers/api/podcasts_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 describe Api::PodcastsController do
   let(:account_id) { 123 }
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }
+  let(:podcast_redirect) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", published_at: nil) }
   let(:token) { StubToken.new(account_id, ['member']) }
   let(:podcast_hash) do
     {
@@ -18,6 +19,12 @@ describe Api::PodcastsController do
       class << @controller; attr_accessor :prx_auth_token; end
       @controller.prx_auth_token = token
       @request.env['CONTENT_TYPE'] = 'application/json'
+    end
+
+    it 'should redirect for authorized request of unpublished resource' do
+      podcast_redirect.id.wont_be_nil
+      get(:show, { api_version: 'v1', format: 'json', id: podcast_redirect.id } )
+      assert_response :redirect
     end
 
     it 'can create a new podcast' do


### PR DESCRIPTION
#170 

- [x] Send redirect to authorized version of resource instead of 404 when unpublished, but auth token allows update access
- [x] Make podcasts work the same way as episodes for handling publishing and authorized access