### PR TITLE
Prevent item from showing up in feed while audio still processing

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -179,12 +179,12 @@ class Episode < BaseModel
   end
 
   def media?
-    media_files.size > 0
+    enclosure.blank? && all_contents.blank?
   end
 
   def media_ready?
     (!enclosure.blank? && enclosure.complete?) ||
-    (!contents.blank? && contents.all?{ |a| a.complete? })
+    (!all_contents.blank? && all_contents.all?{ |a| a.complete? })
   end
 
   def enclosure_template

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -179,11 +179,11 @@ class Episode < BaseModel
   end
 
   def media?
-    enclosure.blank? && all_contents.blank?
+    !(enclosures.blank? && all_contents.blank?)
   end
 
   def media_ready?
-    (!enclosure.blank? && enclosure.complete?) ||
+    (!enclosures.blank? && enclosure) ||
     (!all_contents.blank? && all_contents.all?{ |a| a.complete? })
   end
 

--- a/test/models/episode_entry_handler_test.rb
+++ b/test/models/episode_entry_handler_test.rb
@@ -177,14 +177,14 @@ describe EpisodeEntryHandler do
   it 'returns nil for media_url when there is no audio' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_no_enclosure)
-    episode.contents.clear
+    episode.all_contents.clear
     episode.media_url.must_equal nil
   end
 
   it 'return include in feed and has_media false when no audio' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_no_enclosure)
-    episode.contents.clear
+    episode.all_contents.clear
     episode.wont_be :media?
     episode.wont_be :media_ready?
     episode.must_be :include_in_feed?

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -38,9 +38,11 @@ describe Episode do
   it 'knows if audio is ready' do
     episode.enclosures = [create(:enclosure, episode: episode, status: 'created')]
     episode.enclosures.first.wont_be :complete?
+    episode.must_be :media?
     episode.wont_be :media_ready?
     episode.enclosures.first.complete!
     episode.enclosure.must_be :complete?
+    episode.must_be :media?
     episode.must_be :media_ready?
   end
 


### PR DESCRIPTION
#178 
feeder was not correctly checking to see if an episode had audio in a processing state, and was showing episodes with no complete audio just as it would an episode which has no audio at all (it is ok in feeder to show an episode which lacks any audio, it just isn't ok to show one with audio that is still processing).