### PR TITLE
Add external keyword to episodes for tracking purposes

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -216,7 +216,7 @@ class Episode < BaseModel
     identifiers = []
     [:title, :published_at, :guid].each do |attr|
       # Adzerk does not allow commas or colons in keywords
-      identifiers << self.send(attr).slice(0, 10).gsub(/[:,]/,'')
+      identifiers << self.send(attr).to_s.slice(0, 10).gsub(/[:,]/,'')
     end
     self.adzerk_keyword = identifiers.join('_')
   end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -30,7 +30,7 @@ class Episode < BaseModel
 
   validates :podcast_id, :guid, presence: true
 
-  before_validation :initialize_guid, :set_adzerk_keyword
+  before_validation :initialize_guid, :set_external_keyword
 
   after_save :publish_updated, if: -> (e) { e.published_at_changed? }
 
@@ -211,13 +211,14 @@ class Episode < BaseModel
     media_files
   end
 
-  def set_adzerk_keyword
-    return unless published? && adzerk_keyword.nil?
+  def set_external_keyword
+    return unless !published_at.nil? && keyword_xid.nil?
     identifiers = []
-    [:title, :published_at, :guid].each do |attr|
-      # Adzerk does not allow commas or colons in keywords
-      identifiers << self.send(attr).to_s.slice(0, 10).gsub(/[:,]/,'')
+    [:published_at, :guid].each do |attr|
+      # Adzerk does not allow commas or colons in keywords; omitting dashes for space
+      identifiers << self.send(attr).to_s.slice(0, 10).gsub(/[:,-]/,'')
     end
-    self.adzerk_keyword = identifiers.join('_')
+    identifiers << title.slice(0, 20)
+    self.keyword_xid = identifiers.join('_')
   end
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -30,7 +30,7 @@ class Episode < BaseModel
 
   validates :podcast_id, :guid, presence: true
 
-  before_validation :initialize_guid
+  before_validation :initialize_guid, :set_adzerk_keyword
 
   after_save :publish_updated, if: -> (e) { e.published_at_changed? }
 
@@ -209,5 +209,15 @@ class Episode < BaseModel
 
   def audio_files
     media_files
+  end
+
+  def set_adzerk_keyword
+    return unless published? && adzerk_keyword.nil?
+    identifiers = []
+    [:title, :published_at, :guid].each do |attr|
+      # Adzerk does not allow commas or colons in keywords
+      identifiers << self.send(attr).slice(0, 10).gsub(/[:,]/,'')
+    end
+    self.adzerk_keyword = identifiers.join('_')
   end
 end

--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -12,6 +12,9 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   property :prx_uri
   property :published_at
 
+  # combo of title, published_at, and guid at time of first pub
+  property :adzerk_keyword
+
   property :url
   property :image_url
 

--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -12,8 +12,8 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   property :prx_uri
   property :published_at
 
-  # combo of title, published_at, and guid at time of first pub
-  property :adzerk_keyword
+  # combo of published_at, guid, and title at time of first scheduling for publication
+  property :keyword_xid, writeable: false
 
   property :url
   property :image_url

--- a/db/migrate/20170123205547_add_adzerk_keyword.rb
+++ b/db/migrate/20170123205547_add_adzerk_keyword.rb
@@ -1,0 +1,5 @@
+class AddAdzerkKeyword < ActiveRecord::Migration
+  def change
+    add_column :episodes, :adzerk_keyword, :string
+  end
+end

--- a/db/migrate/20170123205547_add_adzerk_keyword.rb
+++ b/db/migrate/20170123205547_add_adzerk_keyword.rb
@@ -1,5 +1,0 @@
-class AddAdzerkKeyword < ActiveRecord::Migration
-  def change
-    add_column :episodes, :adzerk_keyword, :string
-  end
-end

--- a/db/migrate/20170123205547_add_external_keyword.rb
+++ b/db/migrate/20170123205547_add_external_keyword.rb
@@ -1,0 +1,6 @@
+class AddExternalKeyword < ActiveRecord::Migration
+  def change
+    add_column :episodes, :keyword_xid, :string
+    add_index :episodes, :keyword_xid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -44,10 +44,11 @@ ActiveRecord::Schema.define(version: 20170123205547) do
     t.string   "feedburner_orig_link"
     t.string   "feedburner_orig_enclosure_link"
     t.boolean  "is_perma_link"
-    t.string   "adzerk_keyword"
+    t.string   "keyword_xid"
   end
 
   add_index "episodes", ["guid"], name: "index_episodes_on_guid", unique: true, using: :btree
+  add_index "episodes", ["keyword_xid"], name: "index_episodes_on_keyword_xid", unique: true, using: :btree
   add_index "episodes", ["original_guid", "podcast_id"], name: "index_episodes_on_original_guid_and_podcast_id", unique: true, where: "((deleted_at IS NULL) AND (original_guid IS NOT NULL))", using: :btree
   add_index "episodes", ["prx_uri"], name: "index_episodes_on_prx_uri", unique: true, using: :btree
   add_index "episodes", ["published_at", "podcast_id"], name: "index_episodes_on_published_at_and_podcast_id", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170110154352) do
+ActiveRecord::Schema.define(version: 20170123205547) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20170110154352) do
     t.string   "feedburner_orig_link"
     t.string   "feedburner_orig_enclosure_link"
     t.boolean  "is_perma_link"
+    t.string   "adzerk_keyword"
   end
 
   add_index "episodes", ["guid"], name: "index_episodes_on_guid", unique: true, using: :btree

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -107,6 +107,7 @@ describe Episode do
     episode.run_callbacks :save do
       episode.save
     end
+    episode.reload.adzerk_keyword.wont_be_nil
     episode.reload.adzerk_keyword.must_equal orig_keyword
   end
 

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -101,14 +101,14 @@ describe Episode do
     podcast.reload.published_at.to_i.must_equal now.to_i
   end
 
-  it 'sets one unique identifying episode keyword for Adzerk' do
-    orig_keyword = episode.adzerk_keyword
+  it 'sets one unique identifying episode keyword for tracking purposes' do
+    orig_keyword = episode.keyword_xid
     episode.update_attributes(published_at: 1.day.from_now, title: 'A different title')
     episode.run_callbacks :save do
       episode.save
     end
-    episode.reload.adzerk_keyword.wont_be_nil
-    episode.reload.adzerk_keyword.must_equal orig_keyword
+    episode.reload.keyword_xid.wont_be_nil
+    episode.reload.keyword_xid.must_equal orig_keyword
   end
 
   describe 'enclosure template' do

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -101,6 +101,15 @@ describe Episode do
     podcast.reload.published_at.to_i.must_equal now.to_i
   end
 
+  it 'sets one unique identifying episode keyword for Adzerk' do
+    orig_keyword = episode.adzerk_keyword
+    episode.update_attributes(published_at: 1.day.from_now, title: 'A different title')
+    episode.run_callbacks :save do
+      episode.save
+    end
+    episode.reload.adzerk_keyword.must_equal orig_keyword
+  end
+
   describe 'enclosure template' do
     before {
       episode.guid = 'guid'


### PR DESCRIPTION
#102
Adds a unique + unchanging identifying keyword to each published episode (combo of title, published_at, and guid at time of first publishing). 
Adzerk keywords are case-insensitive, can contain spaces, but can't contain commas or colons; and are capped at 512 characters for all keywords for a given request. I've limited this adzerk keyword (which we'll use for identifying + [reporting](http://dev.adzerk.com/docs/keyword-targeting#section-reporting-on-keywords) purposes) to 30 characters, to leave plenty of space for us to potentially use other keywords for [targeting](http://dev.adzerk.com/docs/keyword-targeting) purposes down the line. 