### PR TITLE
Import script fixes

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -5,6 +5,7 @@ class Api::EpisodesController < Api::BaseController
   find_method :find_by_guid
 
   after_action :publish, only: [:create, :update, :destroy]
+  after_action :process_media, only: [:create, :update]
 
   def show
     return respond_with_error(HalApi::Errors::NotFound.new) if !show_resource
@@ -19,6 +20,10 @@ class Api::EpisodesController < Api::BaseController
   end
 
   private
+
+  def process_media
+    resource.copy_media if resource
+  end
 
   def publish
     resource.podcast.publish! if resource && resource.podcast

--- a/app/controllers/api/podcasts_controller.rb
+++ b/app/controllers/api/podcasts_controller.rb
@@ -4,6 +4,7 @@ class Api::PodcastsController < Api::BaseController
   api_versions :v1
   represent_with Api::PodcastRepresenter
   after_action :publish, only: [:create, :update, :destroy]
+  filter_resources_by :prx_account_uri
 
   def show
     return respond_with_error(HalApi::Errors::NotFound.new) if !show_resource

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -4,9 +4,10 @@ class MediaResource < BaseModel
 
   enum status: [ :started, :created, :processing, :complete, :error, :retrying, :cancelled ]
 
-  before_validation :initialize_guid_and_url
+  before_validation :initialize_attributes, on: :create
 
-  def initialize_guid_and_url
+  def initialize_attributes
+    self.status ||= :created
     guid
     url
   end

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -75,7 +75,9 @@ describe Api::EpisodesController do
 
     it 'can create a new episode' do
       @controller.stub(:publish, true) do
-        post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
+        @controller.stub(:process_media, true) do
+          post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
+        end
       end
       assert_response :success
       id = JSON.parse(response.body)['id']
@@ -93,7 +95,9 @@ describe Api::EpisodesController do
       episode_update.all_contents.size.must_equal 0
 
       @controller.stub(:publish, true) do
-        put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
+        @controller.stub(:process_media, true) do
+          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
+        end
       end
       assert_response :success
 
@@ -101,7 +105,9 @@ describe Api::EpisodesController do
 
       # updating with a dupe should not insert it
       @controller.stub(:publish, true) do
-        put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
+        @controller.stub(:process_media, true) do
+          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
+        end
       end
       assert_response :success
 
@@ -111,7 +117,9 @@ describe Api::EpisodesController do
 
       # updating with a different url should insert it, with same position value of 1
       @controller.stub(:publish, true) do
-        put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
+        @controller.stub(:process_media, true) do
+          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
+        end
       end
       assert_response :success
 

--- a/test/controllers/api/podcasts_controller_test.rb
+++ b/test/controllers/api/podcasts_controller_test.rb
@@ -106,4 +106,19 @@ describe Api::PodcastsController do
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
   end
+
+  it 'should list podcasts for an account' do
+    podcast.id.wont_be_nil
+    get(:index, { api_version: 'v1', format: 'json', prx_account_uri: "/api/v1/accounts/#{account_id}" } )
+    assert_response :success
+    podcasts = JSON.parse(response.body)['_embedded']['prx:items']
+    podcasts.count.must_equal 1
+  end
+
+  it 'should not list podcasts for a different account' do
+    get(:index, { api_version: 'v1', format: 'json', prx_account_uri: "/api/v1/accounts/#{account_id}99" } )
+    assert_response :success
+    podcasts = JSON.parse(response.body)['_embedded']['prx:items']
+    podcasts.count.must_equal 0
+  end
 end

--- a/test/controllers/api/podcasts_controller_test.rb
+++ b/test/controllers/api/podcasts_controller_test.rb
@@ -116,6 +116,7 @@ describe Api::PodcastsController do
   end
 
   it 'should not list podcasts for a different account' do
+    podcast.id.wont_be_nil
     get(:index, { api_version: 'v1', format: 'json', prx_account_uri: "/api/v1/accounts/#{account_id}99" } )
     assert_response :success
     podcasts = JSON.parse(response.body)['_embedded']['prx:items']

--- a/test/factories/media_resource_factory.rb
+++ b/test/factories/media_resource_factory.rb
@@ -11,6 +11,7 @@ FactoryGirl.define do
     duration 48
     bit_rate 64
     original_url 'audio.mp3'
+    status 'created'
 
     after(:create) do |media_resource, evaluator|
       create_list(:copy_media_task, 1, owner: media_resource)

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -36,7 +36,8 @@ describe Episode do
   end
 
   it 'knows if audio is ready' do
-    episode.enclosures = [create(:enclosure, episode: episode, status: 'created')]
+    episode.enclosures = [create(:enclosure, episode: episode)]
+    episode.enclosures.first.status.must_equal 'created'
     episode.enclosures.first.wont_be :complete?
     episode.must_be :media?
     episode.wont_be :media_ready?

--- a/test/models/media_resource_test.rb
+++ b/test/models/media_resource_test.rb
@@ -14,10 +14,12 @@ describe MediaResource do
     }}}}
   end
 
-  it 'initializes guid and url' do
+  it 'initializes attributes' do
     mr = MediaResource.new(episode: episode)
+    mr.validate
     mr.guid.wont_be_nil
     mr.url.wont_be_nil
+    mr.status.must_equal 'created'
   end
 
   it 'answers if it is processed' do


### PR DESCRIPTION
Found some issues while working on using the API directly to publish episodes
- [x] Need to start media files processing after an API episode save, like with message handlers
- [x] Audio files need a default status on create to have an episode status, otherwise all nil
- [x] Add a filter param on api podcasts controller to get the podcasts for a certain prx account
