### PR TITLE
Parse data JSON before checking its validity status

### DIFF
--- a/app/jobs/story_update_job.rb
+++ b/app/jobs/story_update_job.rb
@@ -17,10 +17,10 @@ class StoryUpdateJob < ActiveJob::Base
   end
 
   def receive_story_update(data)
-    # don't allow invalid episodes to do anything but unpublish or delete
-    return if ['create', 'update', 'publish'].include?(action) && data[:status] != 'complete'
-
     load_resources(data)
+    # don't allow invalid episodes to do anything but unpublish or delete
+    return if ['create', 'update', 'publish'].include?(action) && body[:status] != 'complete'
+
     episode ? update_episode : create_episode
     episode.try(:copy_media)
     podcast.try(:publish!)

--- a/test/jobs/story_update_job_test.rb
+++ b/test/jobs/story_update_job_test.rb
@@ -110,7 +110,7 @@ describe StoryUpdateJob do
             Episode.stub(:by_prx_story, episode) do
               lbd = episode.podcast.last_build_date
               uat = episode.updated_at
-              job.perform(subject: 'story', action: 'update', body: JSON.parse(invalid_update_body))
+              job.perform(subject: 'story', action: 'update', body: invalid_update_body)
               episode.podcast.last_build_date.wont_be :>, lbd
               episode.updated_at.wont_be :>, uat
             end
@@ -127,7 +127,7 @@ describe StoryUpdateJob do
             Episode.stub(:by_prx_story, episode) do
               lbd = episode.podcast.last_build_date
               uat = episode.updated_at
-              job.perform(subject: 'story', action: 'unpublish', body: JSON.parse(invalid_update_body))
+              job.perform(subject: 'story', action: 'unpublish', body: invalid_update_body)
               job.episode.wont_be :published?
               job.episode.podcast.last_build_date.must_be :>, lbd
               job.episode.updated_at.must_be :>, uat


### PR DESCRIPTION
Should fix the TypeError we're seeing on New Relic. 
```
TypeError: no implicit conversion of Symbol into Integer
/app/app/jobs/story_update_job.rb:  21:in `[]'
/app/app/jobs/story_update_job.rb:  21:in `receive_story_update'
```