### PR TITLE
Do not add the uuid extension

### DIFF
--- a/db/migrate/20170223114125_create_episode_images.rb
+++ b/db/migrate/20170223114125_create_episode_images.rb
@@ -17,7 +17,9 @@ class CreateEpisodeImages < ActiveRecord::Migration
       t.timestamps null: false
     end
 
+    enable_extension 'uuid-ossp' if Rails.env.test? || Rails.env.development?
     execute 'INSERT into episode_images (guid, original_url, url, episode_id, status, created_at, updated_at) SELECT uuid_generate_v4(), image_url, image_url, id, 3, created_at, updated_at FROM episodes'
+    disable_extension 'uuid-ossp' if Rails.env.test? || Rails.env.development?
   end
 
   def down

--- a/db/migrate/20170223114125_create_episode_images.rb
+++ b/db/migrate/20170223114125_create_episode_images.rb
@@ -17,9 +17,7 @@ class CreateEpisodeImages < ActiveRecord::Migration
       t.timestamps null: false
     end
 
-    enable_extension "uuid-ossp"
     execute 'INSERT into episode_images (guid, original_url, url, episode_id, status, created_at, updated_at) SELECT uuid_generate_v4(), image_url, image_url, id, 3, created_at, updated_at FROM episodes'
-    disable_extension "uuid-ossp"
   end
 
   def down


### PR DESCRIPTION
In RDS, it must be added by a superuser before this migration is run.
#202 