### PR TITLE
Fix error in JSON parsing

### DIFF
--- a/app/jobs/story_update_job.rb
+++ b/app/jobs/story_update_job.rb
@@ -19,7 +19,7 @@ class StoryUpdateJob < ActiveJob::Base
   def receive_story_update(data)
     load_resources(data)
     # don't allow invalid episodes to do anything but unpublish or delete
-    return if ['create', 'update', 'publish'].include?(action) && body[:status] != 'complete'
+    return if ['create', 'update', 'publish'].include?(action) && story.status != 'complete'
 
     episode ? update_episode : create_episode
     episode.try(:copy_media)


### PR DESCRIPTION
We were trying to access check `body[:status]` instead of `body['status']`, and so all async episode updates were rejected. Instead, since we're turning the data into a Story anyway, just check the story's `status`. 
