### PR TITLE
only override with story alt link when episode link is null

### DIFF
--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -34,7 +34,7 @@ class EpisodeStoryHandler
   def update_from_story(story)
     self.story = story
     episode.prx_uri = story.links['self'].href
-    episode.url = story.links['alternate'].try(:href)
+    episode.url ||= story.links['alternate'].try(:href)
 
     update_attributes
     update_audio


### PR DESCRIPTION
Small fix, just don't override the episode url when it is already set.