### PR TITLE
Use storage audio urls

### DIFF
--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -63,7 +63,7 @@ class EpisodeStoryHandler
     audio.each do |a|
       next unless a.status == 'complete'
 
-      existing_content = episode.find_existing_content(a.position, a.links['enclosure'].href)
+      existing_content = episode.find_existing_content(a.position, a.links['prx:storage'].href)
       if existing_content
         update_content(existing_content, a)
       else
@@ -88,8 +88,8 @@ class EpisodeStoryHandler
 
   def update_content(c, audio)
     c.position = audio.attributes['position']
-    c.href = cms_url(audio.links['enclosure'].href)
-    c.mime_type = audio.links['enclosure'].type || audio.attributes['content_type']
+    c.href = audio.links['prx:storage'].href
+    c.mime_type = audio.links['prx:storage'].type || audio.attributes['content_type']
     c.file_size = audio.attributes['size']
     c.duration = audio.attributes['duration']
     c.bit_rate = audio.attributes['bit_rate']

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -75,7 +75,7 @@ class EpisodeStoryHandler
   end
 
   def update_image
-    if image_url = cms_url(story.objects['prx:image'].links['original'].href) rescue nil
+    if image_url = story.objects['prx:image'].links['original'].href rescue nil
       episode.images.build(original_url: image_url) if !episode.find_existing_image(image_url)
     else
       episode.images.destroy_all
@@ -95,22 +95,6 @@ class EpisodeStoryHandler
     c.bit_rate = audio.attributes['bit_rate']
     c.sample_rate = audio.attributes['frequency'] * 1000 if audio.attributes['frequency']
     c
-  end
-
-  def cms_url(url)
-    if url =~ /^http/
-      url
-    else
-      path_to_url(ENV['CMS_HOST'], url)
-    end
-  end
-
-  def path_to_url(host, path)
-    if host =~ /\.org/ # TODO: should .tech's be here too?
-      URI::HTTPS.build(host: host, path: path).to_s
-    else
-      URI::HTTP.build(host: host, path: path).to_s
-    end
   end
 
   def get_story(account = nil)

--- a/app/models/podcast_series_handler.rb
+++ b/app/models/podcast_series_handler.rb
@@ -53,7 +53,7 @@ class PodcastSeriesHandler
     images = series.objects['prx:images'].objects['prx:items'] rescue []
     { feed: 'thumbnail', itunes: 'profile' }.each do |type, purpose|
       if image = images.detect { |i| i.attributes['purpose'] == purpose }
-        image_url = cms_url(image.links['original'].href)
+        image_url = image.links['original'].href
         if !podcast.find_existing_image(type, image_url)
           podcast.send("#{type}_images").build(original_url: image_url)
         end
@@ -66,21 +66,5 @@ class PodcastSeriesHandler
   def get_series(account = nil)
     return nil unless podcast.prx_uri
     api(account: account).tap { |a| a.href = podcast.prx_uri }.get
-  end
-
-  def cms_url(url)
-    if url =~ /^http/
-      url
-    else
-      path_to_url(ENV['CMS_HOST'], url)
-    end
-  end
-
-  def path_to_url(host, path)
-    if host =~ /\.org/ # TODO: should .tech's be here too?
-      URI::HTTPS.build(host: host, path: path).to_s
-    else
-      URI::HTTP.build(host: host, path: path).to_s
-    end
   end
 end

--- a/test/fixtures/prx_story_all.json
+++ b/test/fixtures/prx_story_all.json
@@ -93,11 +93,11 @@
         "prx:image": {
           "_links": {
             "enclosure": {
-              "href": "/pub/438b16f02cfe5fc547e8109f6cf4c132/0/web/user_image/38940/medium/run.jpg",
+              "href": "https://cms.prx.org/pub/438b16f02cfe5fc547e8109f6cf4c132/0/web/user_image/38940/medium/run.jpg",
               "type": "image/jpeg"
             },
             "original": {
-              "href": "/pub/6d38cef16bb79d4eb8cc07d7acdedbe3/0/web/user_image/38940/original/run.jpg",
+              "href": "https://cms.prx.org/pub/6d38cef16bb79d4eb8cc07d7acdedbe3/0/web/user_image/38940/original/run.jpg",
               "type": "image/jpeg"
             },
             "profile": {
@@ -161,7 +161,7 @@
           {
             "_links": {
               "enclosure": {
-                "href": "/pub/e3718718a9a6c83a2cc077ee6ecb5a63/0/web/audio_file/1200648/broadcast/lcs_spring16_act1.mp3",
+                "href": "https://cms.prx.org/pub/e3718718a9a6c83a2cc077ee6ecb5a63/0/web/audio_file/1200648/broadcast/lcs_spring16_act1.mp3",
                 "type": "audio/mpeg"
               },
               "original": {
@@ -191,7 +191,7 @@
           {
             "_links": {
               "enclosure": {
-                "href": "/pub/d357caa1057739c1f20b81df111c4aab/0/web/audio_file/1200655/broadcast/t03.mp3",
+                "href": "https://cms.prx.org/pub/d357caa1057739c1f20b81df111c4aab/0/web/audio_file/1200655/broadcast/t03.mp3",
                 "type": "audio/mpeg"
               },
               "original": {
@@ -221,7 +221,7 @@
           {
             "_links": {
               "enclosure": {
-                "href": "/pub/db970cd89f4cc82cc339b7cb8b46c4ad/0/web/audio_file/1200656/broadcast/t05.mp3",
+                "href": "https://cms.prx.org/pub/db970cd89f4cc82cc339b7cb8b46c4ad/0/web/audio_file/1200656/broadcast/t05.mp3",
                 "type": "audio/mpeg"
               },
               "original": {
@@ -251,7 +251,7 @@
           {
             "_links": {
               "enclosure": {
-                "href": "/pub/8d5b5626a6ed4798fffa71e48e80fca2/0/web/audio_file/1200657/broadcast/t01.mp3",
+                "href": "https://cms.prx.org/pub/8d5b5626a6ed4798fffa71e48e80fca2/0/web/audio_file/1200657/broadcast/t01.mp3",
                 "type": "audio/mpeg"
               },
               "original": {
@@ -295,11 +295,11 @@
     "prx:image": {
       "_links": {
         "enclosure": {
-          "href": "/pub/407692d270782e6a857df61219743752/0/web/story_image/437192/medium/lindsay.png",
+          "href": "https://cms.prx.org/pub/407692d270782e6a857df61219743752/0/web/story_image/437192/medium/lindsay.png",
           "type": "image/png"
         },
         "original": {
-          "href": "/pub/cb424d43e437b348551eee7ac191474c/0/web/story_image/437192/original/lindsay.png",
+          "href": "https://cms.prx.org/pub/cb424d43e437b348551eee7ac191474c/0/web/story_image/437192/original/lindsay.png",
           "type": "image/png"
         },
         "profile": {
@@ -339,11 +339,11 @@
         "prx:image": {
           "_links": {
             "enclosure": {
-              "href": "/pub/4585c860463e3e4e41b15096099c9faa/0/web/series_image/16622/medium/tobias.jpeg",
+              "href": "https://cms.prx.org/pub/4585c860463e3e4e41b15096099c9faa/0/web/series_image/16622/medium/tobias.jpeg",
               "type": "image/jpeg"
             },
             "original": {
-              "href": "/pub/fdfc8c9e2c0754d822161d24c72b3656/0/web/series_image/16622/original/tobias.jpeg",
+              "href": "https://cms.prx.org/pub/fdfc8c9e2c0754d822161d24c72b3656/0/web/series_image/16622/original/tobias.jpeg",
               "type": "image/jpeg"
             },
             "profile": {
@@ -372,7 +372,7 @@
                         {
                           "_links": {
                             "enclosure": {
-                              "href": "/pub/e3718718a9a6c83a2cc077ee6ecb5a63/0/web/audio_file/1200648/broadcast/lcs_spring16_act1.mp3",
+                              "href": "https://cms.prx.org/pub/e3718718a9a6c83a2cc077ee6ecb5a63/0/web/audio_file/1200648/broadcast/lcs_spring16_act1.mp3",
                               "type": "audio/mpeg"
                             },
                             "original": {
@@ -398,7 +398,7 @@
                         {
                           "_links": {
                             "enclosure": {
-                              "href": "/pub/d357caa1057739c1f20b81df111c4aab/0/web/audio_file/1200655/broadcast/t03.mp3",
+                              "href": "https://cms.prx.org/pub/d357caa1057739c1f20b81df111c4aab/0/web/audio_file/1200655/broadcast/t03.mp3",
                               "type": "audio/mpeg"
                             },
                             "original": {
@@ -424,7 +424,7 @@
                         {
                           "_links": {
                             "enclosure": {
-                              "href": "/pub/db970cd89f4cc82cc339b7cb8b46c4ad/0/web/audio_file/1200656/broadcast/t05.mp3",
+                              "href": "https://cms.prx.org/pub/db970cd89f4cc82cc339b7cb8b46c4ad/0/web/audio_file/1200656/broadcast/t05.mp3",
                               "type": "audio/mpeg"
                             },
                             "original": {
@@ -450,7 +450,7 @@
                         {
                           "_links": {
                             "enclosure": {
-                              "href": "/pub/8d5b5626a6ed4798fffa71e48e80fca2/0/web/audio_file/1200657/broadcast/t01.mp3",
+                              "href": "https://cms.prx.org/pub/8d5b5626a6ed4798fffa71e48e80fca2/0/web/audio_file/1200657/broadcast/t01.mp3",
                               "type": "audio/mpeg"
                             },
                             "original": {
@@ -490,11 +490,11 @@
                   "prx:image": {
                     "_links": {
                       "enclosure": {
-                        "href": "/pub/407692d270782e6a857df61219743752/0/web/story_image/437192/medium/lindsay.png",
+                        "href": "https://cms.prx.org/pub/407692d270782e6a857df61219743752/0/web/story_image/437192/medium/lindsay.png",
                         "type": "image/png"
                       },
                       "original": {
-                        "href": "/pub/cb424d43e437b348551eee7ac191474c/0/web/story_image/437192/original/lindsay.png",
+                        "href": "https://cms.prx.org/pub/cb424d43e437b348551eee7ac191474c/0/web/story_image/437192/original/lindsay.png",
                         "type": "image/png"
                       },
                       "profile": {

--- a/test/fixtures/prx_story_all.json
+++ b/test/fixtures/prx_story_all.json
@@ -1,4 +1,75 @@
 {
+  "appVersion": "v4",
+  "createdAt": "2016-09-29T22:05:33.000Z",
+  "description": "this is a description",
+  "duration": 3346,
+  "id": 186751,
+  "points": 0,
+  "publishedAt": "2016-09-29T22:14:13.000Z",
+  "shortDescription": "With a teaser of the story",
+  "tags": [
+    "Business",
+    "Careers"
+  ],
+  "title": "Here is a new story in my brand new series",
+  "updatedAt": "2016-10-18T22:16:40.000Z",
+  "_links": {
+    "alternate": {
+      "href": "https://beta.prx.org/stories/186751",
+      "type": "text/html"
+    },
+    "curies": [
+      {
+        "href": "http://meta.prx.org/relation/{rel}",
+        "name": "prx",
+        "templated": true
+      }
+    ],
+    "profile": {
+      "href": "http://meta.prx.org/model/story"
+    },
+    "prx:account": {
+      "href": "/api/v1/accounts/208391",
+      "profile": "http://meta.prx.org/model/account/individual",
+      "title": "Ryan Cavis"
+    },
+    "prx:audio": {
+      "count": 4,
+      "href": "/api/v1/stories/186751/audio_files"
+    },
+    "prx:audio-versions": {
+      "count": 1,
+      "href": "/api/v1/stories/186751/audio_versions"
+    },
+    "prx:image": {
+      "href": "/api/v1/stories/186751/images/437192",
+      "title": "lindsay.png"
+    },
+    "prx:images": {
+      "count": 1,
+      "href": "/api/v1/stories/186751/images"
+    },
+    "prx:musical-works": {
+      "count": 0,
+      "href": "/api/v1/stories/186751/musical_works{?page,per,zoom,filters,sorts}",
+      "templated": true
+    },
+    "prx:promos": {
+      "count": 0,
+      "href": "/api/v1/stories/186751/promos"
+    },
+    "prx:series": {
+      "href": "/api/v1/series/36501",
+      "title": "Really really cool series on stuff"
+    },
+    "prx:unpublish": {
+      "href": "/api/v1/stories/186751/unpublish"
+    },
+    "self": {
+      "href": "/api/v1/stories/186751",
+      "profile": "http://meta.prx.org/model/story"
+    }
+  },
   "_embedded": {
     "prx:account": {
       "_embedded": {
@@ -101,6 +172,10 @@
               "profile": {
                 "href": "http://meta.prx.org/model/audio-file"
               },
+              "prx:storage": {
+                "href": "s3://mediajoint.production.prx.org/public/audio_files/1200648/lcs_spring16_act1.mp3",
+                "type": "audio/mpeg"
+              },
               "self": {
                 "href": "/api/v1/audio_files/1200648",
                 "profile": "http://meta.prx.org/model/audio-file"
@@ -126,6 +201,10 @@
               },
               "profile": {
                 "href": "http://meta.prx.org/model/audio-file"
+              },
+              "prx:storage": {
+                "href": "s3://mediajoint.production.prx.org/public/audio_files/1200655/broadcast/t03.mp3",
+                "type": "audio/mpeg"
               },
               "self": {
                 "href": "/api/v1/audio_files/1200655",
@@ -153,6 +232,10 @@
               "profile": {
                 "href": "http://meta.prx.org/model/audio-file"
               },
+              "prx:storage": {
+                "href": "s3://mediajoint.production.prx.org/public/audio_files/1200656/broadcast/t05.mp3",
+                "type": "audio/mpeg"
+              },
               "self": {
                 "href": "/api/v1/audio_files/1200656",
                 "profile": "http://meta.prx.org/model/audio-file"
@@ -178,6 +261,10 @@
               },
               "profile": {
                 "href": "http://meta.prx.org/model/audio-file"
+              },
+              "prx:storage": {
+                "href": "s3://mediajoint.production.prx.org/public/audio_files/1200657/broadcast/t01.mp3",
+                "type": "audio/mpeg"
               },
               "self": {
                 "href": "/api/v1/audio_files/1200657",
@@ -534,76 +621,5 @@
       "shortDescription": "And this is my description of the series.",
       "title": "Really really cool series on stuff"
     }
-  },
-  "_links": {
-    "alternate": {
-      "href": "https://beta.prx.org/stories/186751",
-      "type": "text/html"
-    },
-    "curies": [
-      {
-        "href": "http://meta.prx.org/relation/{rel}",
-        "name": "prx",
-        "templated": true
-      }
-    ],
-    "profile": {
-      "href": "http://meta.prx.org/model/story"
-    },
-    "prx:account": {
-      "href": "/api/v1/accounts/208391",
-      "profile": "http://meta.prx.org/model/account/individual",
-      "title": "Ryan Cavis"
-    },
-    "prx:audio": {
-      "count": 4,
-      "href": "/api/v1/stories/186751/audio_files"
-    },
-    "prx:audio-versions": {
-      "count": 1,
-      "href": "/api/v1/stories/186751/audio_versions"
-    },
-    "prx:image": {
-      "href": "/api/v1/stories/186751/images/437192",
-      "title": "lindsay.png"
-    },
-    "prx:images": {
-      "count": 1,
-      "href": "/api/v1/stories/186751/images"
-    },
-    "prx:musical-works": {
-      "count": 0,
-      "href": "/api/v1/stories/186751/musical_works{?page,per,zoom,filters,sorts}",
-      "templated": true
-    },
-    "prx:promos": {
-      "count": 0,
-      "href": "/api/v1/stories/186751/promos"
-    },
-    "prx:series": {
-      "href": "/api/v1/series/36501",
-      "title": "Really really cool series on stuff"
-    },
-    "prx:unpublish": {
-      "href": "/api/v1/stories/186751/unpublish"
-    },
-    "self": {
-      "href": "/api/v1/stories/186751",
-      "profile": "http://meta.prx.org/model/story"
-    }
-  },
-  "appVersion": "v4",
-  "createdAt": "2016-09-29T22:05:33.000Z",
-  "description": "this is a description",
-  "duration": 3346,
-  "id": 186751,
-  "points": 0,
-  "publishedAt": "2016-09-29T22:14:13.000Z",
-  "shortDescription": "With a teaser of the story",
-  "tags": [
-    "Business",
-    "Careers"
-  ],
-  "title": "Here is a new story in my brand new series",
-  "updatedAt": "2016-10-18T22:16:40.000Z"
+  }
 }

--- a/test/models/episode_story_handler_test.rb
+++ b/test/models/episode_story_handler_test.rb
@@ -28,8 +28,8 @@ describe EpisodeStoryHandler do
     episode.published_at.must_equal Time.parse(story.attributes[:published_at])
     first_audio = episode.all_contents.first.original_url
     last_audio = episode.all_contents.last.original_url
-    first_audio.must_equal 'https://cms.prx.org/pub/e3718718a9a6c83a2cc077ee6ecb5a63/0/web/audio_file/1200648/broadcast/lcs_spring16_act1.mp3'
-    last_audio.must_equal 'https://cms.prx.org/pub/8d5b5626a6ed4798fffa71e48e80fca2/0/web/audio_file/1200657/broadcast/t01.mp3'
+    first_audio.must_equal 's3://mediajoint.production.prx.org/public/audio_files/1200648/lcs_spring16_act1.mp3'
+    last_audio.must_equal 's3://mediajoint.production.prx.org/public/audio_files/1200657/broadcast/t01.mp3'
     episode.description.must_equal 'this is a description'
   end
 end

--- a/test/models/tasks/copy_media_task_test.rb
+++ b/test/models/tasks/copy_media_task_test.rb
@@ -3,38 +3,22 @@ require 'test_helper'
 describe Tasks::CopyMediaTask do
   let(:task) { create(:copy_media_task) }
 
-  let(:msg) { json_file(:prx_story_small) }
-
   let(:audio_msg) { json_file(:prx_story_with_audio) }
 
   let(:story) do
-    body = JSON.parse(msg)
+    body = JSON.parse(json_file(:prx_story_small))
     href = body['_links']['self']['href']
     resource = task.api
     link = HyperResource::Link.new(resource, href: href)
     HyperResource.new_from(body: body, resource: resource, link: link)
   end
 
-  before do
-    if use_webmock?
-      stub_request(:get, "https://cms.prx.org/api/v1/stories/80548").
-        to_return(status: 200, body: msg, headers: {})
-
-      stub_request(:get, "https://cms.prx.org/api/v1/stories/80548/audio_files").
-        to_return(status: 200, body: audio_msg, headers: {})
-
-      stub_request(:get, "https://cms.prx.org/api/v1/audio_files/406322/original?expiration=604800").
-        to_return(status: 301, body: '', headers: { location: 'http://final/location.mp3' } )
-    end
-  end
-
   it 'can start the job' do
     Task.stub :new_fixer_sqs_client, SqsMock.new do
       task.stub(:get_account_token, "token") do
         task.start!
-        task.options[:source].must_equal 'http://final/location.mp3'
+        task.options[:source].must_equal task.media_resource.original_url
         task.options[:destination].must_match /s3:\/\/test-prx-feed\/jjgo\/ba047dce-9df5-4132-a04b-31d24c7c55a(\d+)\/ca047dce-9df5-4132-a04b-31d24c7c55a(\d+).mp3/
-        task.options[:audio_uri].must_equal '/api/v1/audio_files/406322'
       end
     end
   end
@@ -43,7 +27,7 @@ describe Tasks::CopyMediaTask do
     task.media_resource.wont_be_nil
     original = task.media_resource.original_url
     task.media_resource.original_url = original + '?remove=this'
-    task.episode_audio_uri.must_equal original
+    task.task_options[:source].must_equal original
   end
 
   it 'alias owner as episode' do
@@ -64,8 +48,8 @@ describe Tasks::CopyMediaTask do
     url.must_equal 's3://test-prx-feed/path/guid/audio.mp3?x-fixer-public=true'
   end
 
-  it 'determines the story audio uri' do
-    task.story_audio_uri(story).must_equal '/api/v1/audio_files/406322'
+  it 'use original url as the source url' do
+    task.source_url(task.media_resource).must_equal task.media_resource.original_url
   end
 
   it 'can publish on complete' do
@@ -85,11 +69,6 @@ describe Tasks::CopyMediaTask do
         task.task_status_changed({}, 'complete')
       end
     end
-  end
-
-  it 'can detect if the audio file has changed' do
-    task.options = {}
-    assert task.new_audio_file?(story)
   end
 
   it 'does not throw errors when owner is missing on callback' do


### PR DESCRIPTION
- [x] From story messages, set audio_file.original url from `prx:storage` href (e.g. s3://bucket/path/file.mp3)
- [x] Always use the original url on the audio file to send to fixer, instead of calling cms api
- [x] Stop worrying about relative cms api urls, this is long fixed