### PR TITLE
Sanitize text

### DIFF
--- a/app/helpers/podcasts_helper.rb
+++ b/app/helpers/podcasts_helper.rb
@@ -1,4 +1,8 @@
+require 'text_sanitizer'
+
 module PodcastsHelper
+  include TextSanitizer
+
   def full_contact(type, item)
     name = item.try("#{type}_name")
     email = item.try("#{type}_email")
@@ -12,5 +16,9 @@ module PodcastsHelper
 
   def first_nonblank(type, items)
     items.find { |item| !item.send("#{type}").blank? }
+  end
+
+  def itunes_summary(model)
+    model.summary || sanitize_links_only(model.description)
   end
 end

--- a/app/helpers/podcasts_helper.rb
+++ b/app/helpers/podcasts_helper.rb
@@ -18,6 +18,10 @@ module PodcastsHelper
     items.find { |item| !item.send("#{type}").blank? }
   end
 
+  def show_itunes_summary?(model)
+    model.summary || model.description
+  end
+
   def itunes_summary(model)
     model.summary || sanitize_links_only(model.description)
   end

--- a/app/models/concerns/text_sanitizer.rb
+++ b/app/models/concerns/text_sanitizer.rb
@@ -1,0 +1,26 @@
+require 'active_support/concern'
+require 'loofah'
+
+module TextSanitizer
+  extend ActiveSupport::Concern
+
+  def sanitize_white_list(text)
+    return nil if text.blank?
+    sanitizer = Rails::Html::WhiteListSanitizer.new
+    sanitizer.sanitize(Loofah.fragment(text).scrub!(:prune).to_s)
+  end
+
+  def sanitize_links_only(text)
+    return nil if text.blank?
+    scrubber = Rails::Html::PermitScrubber.new
+    scrubber.tags = %w(a)
+    scrubber.attributes = %w(href target nofollow)
+    Loofah.fragment(text).scrub!(:prune).scrub!(scrubber).to_s
+  end
+
+  def sanitize_text_only(text)
+    return nil if text.blank?
+    sanitizer = Rails::Html::FullSanitizer.new
+    sanitizer.sanitize(text)
+  end
+end

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -50,9 +50,8 @@ class EpisodeStoryHandler
     end
 
     episode.title = sa[:title]
-    episode.subtitle = Sanitize.fragment(sa[:short_description] || '').strip
-    episode.description = Sanitize.fragment(sa[:description] || '').strip
-    episode.summary = sa[:description]
+    episode.subtitle = sa[:short_description]
+    episode.description = sa[:description]
     episode.content = sa[:description]
     episode.categories = sa[:tags]
     episode.published_at = sa[:published_at] ? Time.parse(sa[:published_at]) : nil

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -1,4 +1,8 @@
+require 'text_sanitizer'
+
 class Podcast < BaseModel
+  include TextSanitizer
+
   serialize :categories, JSON
   serialize :keywords, JSON
 
@@ -24,7 +28,7 @@ class Podcast < BaseModel
 
   acts_as_paranoid
 
-  before_validation :set_defaults
+  before_validation :set_defaults, :sanitize_text
 
   scope :published, -> { where('published_at IS NOT NULL AND published_at <= now()') }
 
@@ -139,6 +143,13 @@ class Podcast < BaseModel
 
   def published_url
     "#{base_published_url}/feed-rss.xml"
+  end
+
+  def sanitize_text
+    self.description = sanitize_white_list(description) if description_changed?
+    self.subtitle = sanitize_text_only(subtitle) if subtitle_changed?
+    self.summary = sanitize_links_only(summary) if summary_changed?
+    self.title = sanitize_text_only(title) if title_changed?
   end
 
   def feeder_cdn_host

--- a/app/representers/api/base_representer.rb
+++ b/app/representers/api/base_representer.rb
@@ -1,9 +1,12 @@
 # encoding: utf-8
 require 'hal_api/representer'
 require 'prx_access'
+require 'text_sanitizer'
 
 class Api::BaseRepresenter < HalApi::Representer
   include PRXAccess
+  include TextSanitizer
+
   self.alternate_host = ENV['PRX_HOST'] || 'www.prx.org'
   self.profile_host = ENV['META_HOST'] || 'meta.prx.org'
 
@@ -13,5 +16,9 @@ class Api::BaseRepresenter < HalApi::Representer
       href: "http://#{profile_host}/relation/{rel}",
       templated: true
     }]
+  end
+
+  def summary_preview
+    sanitize_links_only(represented.description)
   end
 end

--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -20,9 +20,10 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
 
   property :title
   property :subtitle
+  property :description
   property :content
   property :summary
-  property :description
+  property :summary_preview, exec_context: :decorator, if: ->(_o) { !represented.summary }
 
   property :explicit
   property :block

--- a/app/representers/api/podcast_representer.rb
+++ b/app/representers/api/podcast_representer.rb
@@ -21,6 +21,7 @@ class Api::PodcastRepresenter < Api::BaseRepresenter
   property :subtitle
   property :description
   property :summary
+  property :summary_preview, exec_context: :decorator, if: ->(_o) { !represented.summary }
 
   property :explicit
   property :complete

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -59,7 +59,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
     end
 
     xml.itunes :subtitle, @podcast.subtitle unless @podcast.subtitle.blank?
-    xml.itunes(:summary) { xml.cdata!(@podcast.summary) } unless @podcast.summary.blank?
+    xml.itunes(:summary) { xml.cdata!(itunes_summary(@podcast)) }
     xml.itunes :keywords, @podcast.keywords.join(',') unless @podcast.keywords.blank?
 
     xml.media :copyright, @podcast.copyright unless @podcast.copyright.blank?
@@ -96,7 +96,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
           has_au_name = first_nonblank('author_name', [ep, @podcast])
           xml.itunes :author, has_au_name.author_name if has_au_name.author_name
 
-          xml.itunes(:summary) { xml.cdata!(ep.summary) } unless ep.summary.blank?
+          xml.itunes(:summary) { xml.cdata!(itunes_summary(ep)) }
 
           if ep.image
             xml.itunes :image, href: ep.image.url

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -59,7 +59,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
     end
 
     xml.itunes :subtitle, @podcast.subtitle unless @podcast.subtitle.blank?
-    xml.itunes(:summary) { xml.cdata!(itunes_summary(@podcast)) }
+    xml.itunes(:summary) { xml.cdata!(itunes_summary(@podcast)) } if show_itunes_summary?(@podcast)
     xml.itunes :keywords, @podcast.keywords.join(',') unless @podcast.keywords.blank?
 
     xml.media :copyright, @podcast.copyright unless @podcast.copyright.blank?
@@ -96,7 +96,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
           has_au_name = first_nonblank('author_name', [ep, @podcast])
           xml.itunes :author, has_au_name.author_name if has_au_name.author_name
 
-          xml.itunes(:summary) { xml.cdata!(itunes_summary(ep)) }
+          xml.itunes(:summary) { xml.cdata!(itunes_summary(ep)) } if show_itunes_summary?(ep)
 
           if ep.image
             xml.itunes :image, href: ep.image.url

--- a/config/initializers/white_list.rb
+++ b/config/initializers/white_list.rb
@@ -1,0 +1,2 @@
+Rails::Html::WhiteListSanitizer.allowed_tags += %w(table thead tbody tr th td caption tfoot)
+Rails::Html::WhiteListSanitizer.allowed_attributes += %w(rel target)

--- a/db/migrate/20170309181410_podcast_str_to_text.rb
+++ b/db/migrate/20170309181410_podcast_str_to_text.rb
@@ -1,0 +1,13 @@
+class PodcastStrToText < ActiveRecord::Migration
+  def up
+    change_column :podcasts, :title, :text
+    change_column :podcasts, :subtitle, :text
+    change_column :podcasts, :summary, :text
+  end
+
+  def down
+    change_column :podcasts, :title, :string
+    change_column :podcasts, :subtitle, :string
+    change_column :podcasts, :summary, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223174042) do
+ActiveRecord::Schema.define(version: 20170309181410) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -161,14 +161,14 @@ ActiveRecord::Schema.define(version: 20170223174042) do
   create_table "podcasts", force: :cascade do |t|
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "title"
+    t.text     "title"
     t.string   "link"
     t.text     "description"
     t.string   "language"
     t.string   "managing_editor_name"
     t.string   "categories"
-    t.string   "subtitle"
-    t.string   "summary"
+    t.text     "subtitle"
+    t.text     "summary"
     t.string   "keywords"
     t.string   "update_period"
     t.integer  "update_frequency"

--- a/test/factories/episode_factory.rb
+++ b/test/factories/episode_factory.rb
@@ -7,11 +7,11 @@ FactoryGirl.define do
     sequence(:title) { |n| "Episode #{n}" }
     sequence(:published_at) { |n| Date.today - n.days }
 
-    description "Tina McElroy Ansa is a little girl when her father's business goes under and her family must leave their beloved, expansive home."
+    description "<div><a href='/tina'>Tina</a> McElroy Ansa is a little girl when her father's business goes under and her family must leave their beloved, expansive home.</div>"
 
-    content "<div>Tina McElroy Ansa is a little girl when her father&rsquo;s business goes under and her family must leave their beloved, expansive home.</div>"
+    content "<div><a href='/tina'>Tina</a> McElroy Ansa is a little girl when her father's business goes under and her family must leave their beloved, expansive home.</div>"
 
-    summary "<div>Tina McElroy Ansa is a little girl when her father&rsquo;s business goes under and her family must leave their beloved, expansive home.</div>"
+    summary "<a href='/tina'>Tina</a> McElroy Ansa is a little girl when her father's business goes under and her family must leave their beloved, expansive home."
 
     after(:create) do |episode, evaluator|
       episode.enclosures << create(:enclosure, episode: episode, status: 'complete')

--- a/test/integration/podcast_request_test.rb
+++ b/test/integration/podcast_request_test.rb
@@ -12,12 +12,6 @@ describe 'RSS feed Integration Test' do
     @channel_image = @podcast.feed_image
     @itunes_image = @podcast.itunes_image
     @episodes = create_list(:episode, 4, podcast: @podcast).reverse
-
-    @episodes.each do |e|
-      stub_request(:get, "https://cms.prx.org#{e.prx_uri}").
-        to_return(status: 200, body: json_file(:prx_story), headers: {})
-    end
-
     @category = create(:itunes_category, podcast: @podcast)
 
     get "/podcasts/#{@podcast.id}"
@@ -72,8 +66,8 @@ describe 'RSS feed Integration Test' do
 
   it 'displays plaintext and richtext descriptions' do
     node = @feed.css('item')[0]
-    node.css('description').text.strip[0..3].must_equal "Tina"
-    node.css('itunes|summary').text.strip[0..4].must_equal "<div>"
+    node.css('description').text.strip[0..4].must_equal "<div>"
+    node.css('itunes|summary').text.strip[0..6].must_equal "<a href"
   end
 
   it 'returns limited number of episodes' do

--- a/test/models/concerns/text_sanitizer_test.rb
+++ b/test/models/concerns/text_sanitizer_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+
+class TestSanitizer
+  include TextSanitizer
+end
+
+describe TextSanitizer do
+  let(:model) { TestSanitizer.new }
+  let(:text) do
+    '<!-- Sorry! --><p>my</p> <b>dog</b> <a href="/">ate</a> ' +
+    '<span><div>my</div></span> <script>homework</script>'
+  end
+
+  it 'scrubs all tags' do
+    model.sanitize_text_only(text).must_equal 'my dog ate my '
+  end
+
+  it 'scrubs all but links' do
+    r = 'my dog <a href="/">ate</a> my '
+    model.sanitize_links_only(text).must_equal r
+  end
+
+  it 'scrubs all but white listed' do
+    r = '<p>my</p> <b>dog</b> <a href="/">ate</a> <span><div>my</div></span> '
+    model.sanitize_white_list(text).must_equal r
+  end
+
+  it 'white lists tables' do
+    text = "<table>\n<thead></thead>\n<tbody>\n<tr>\n<th></th>\n<td></td>\n</tr>\n" +
+           "<caption></caption>\n</tbody>\n<tfoot></tfoot>\n</table>"
+    model.sanitize_white_list(text).must_equal text
+  end
+end

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -8,6 +8,23 @@ describe Api::EpisodeRepresenter do
 
   it 'includes basic properties' do
     json['prxUri'].must_match /\/api\/v1\/stories\//
+    json['summary'].must_match /<a href="\/tina">Tina<\/a>/
+  end
+
+  it 'uses summary when not blank' do
+    episode.summary = 'summary has <a href="/">a link</a>'
+    episode.description = '<b>tags</b> removed, <a href="/">links remain</a>'
+    json['summary'].must_equal episode.summary
+    json['summaryPreview'].must_be_nil
+    json['description'].must_equal episode.description
+  end
+
+  it 'uses sanitized description for nil summary' do
+    episode.summary = nil
+    episode.description = '<b>tags</b> removed, <a href="/">links remain</a>'
+    json['summary'].must_be_nil
+    json['summaryPreview'].must_equal 'tags removed, <a href="/">links remain</a>'
+    json['description'].must_equal episode.description
   end
 
   it 'has links' do


### PR DESCRIPTION
- [x] #225 fixes summary having only links, and sanitizes all the other text fields too
- [x] #226 adds a `summaryPreview` to the api responses when there is no summary
- [x] Fixes podcasts columns that should have been text to match episodes (summary, title, subtitle)
- [x] Do not override the summary with the story.description