### PR TITLE
Fix episode link from libsyn to go to the enclosure

### DIFF
--- a/app/models/episode_entry_handler.rb
+++ b/app/models/episode_entry_handler.rb
@@ -62,7 +62,7 @@ class EpisodeEntryHandler
   def update_link
     self.episode.url = overrides[:feedburner_orig_link] || overrides[:url] || overrides[:link]
     # libsyn sets the link to a libsyn url, instead set to media file or page
-    self.episode.url = episode.media_url if episode.url && episode.url.match(/libsyn\.com/)
+    self.episode.url = nil if episode.url && episode.url.match(/libsyn\.com/)
   end
 
   def update_enclosure

--- a/app/models/episode_entry_handler.rb
+++ b/app/models/episode_entry_handler.rb
@@ -61,7 +61,7 @@ class EpisodeEntryHandler
   # as it depends on media_url
   def update_link
     self.episode.url = overrides[:feedburner_orig_link] || overrides[:url] || overrides[:link]
-    # libsyn sets the link to a libsyn url, instead set to media file or page
+    # libsyn sets link to the libsyn mp3; nil it out (in rss, will fallback on the enclosure url)
     self.episode.url = nil if episode.url && episode.url.match(/libsyn\.com/)
   end
 

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -34,7 +34,6 @@ class EpisodeStoryHandler
   def update_from_story(story)
     self.story = story
     episode.prx_uri = story.links['self'].href
-    episode.url ||= story.links['alternate'].try(:href)
 
     update_attributes
     update_audio

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -78,7 +78,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
         xml.guid(ep.item_guid, isPermaLink: !!ep.is_perma_link)
         xml.title(ep.title)
         xml.pubDate ep.published_at.utc.rfc2822
-        xml.link ep.url
+        xml.link ep.url || ep.media_url
         xml.description { xml.cdata!(ep.description || '') }
         xml.enclosure(url: ep.media_url, type: ep.content_type, length: ep.file_size) if ep.media?
 

--- a/test/models/episode_entry_handler_test.rb
+++ b/test/models/episode_entry_handler_test.rb
@@ -37,7 +37,7 @@ describe EpisodeEntryHandler do
 
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry)
-    episode.url.must_equal episode.media_url
+    episode.url.must_equal nil
   end
 
   it 'sets all attributes' do


### PR DESCRIPTION
When a feed uses libsyn, like twww, then the episode links are to the mp3 at libsyn.com
In cms, when these are imported, they get blanked out.
- [x] Change feeder story handler to leave these blank.
- [x] Change feeder entry handler to also blank these out from crier.
- [x] Change feeder rss view to fallback on enclosure url for the link when none is present
