### PR TITLE
include deleted records only with find requests

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -31,7 +31,7 @@ class Api::EpisodesController < Api::BaseController
     visible
   end
 
-  def scoped(relation)
+  def included(relation)
     relation.with_deleted
   end
 

--- a/app/controllers/api/podcasts_controller.rb
+++ b/app/controllers/api/podcasts_controller.rb
@@ -33,7 +33,7 @@ class Api::PodcastsController < Api::BaseController
 
   private
 
-  def scoped(relation)
+  def included(relation)
     relation.with_deleted
   end
 

--- a/test/controllers/api/podcasts_controller_test.rb
+++ b/test/controllers/api/podcasts_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 describe Api::PodcastsController do
   let(:account_id) { 123 }
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }
+  let(:podcast_deleted) { create(:podcast, path: 'deleted', deleted_at: Time.now) }
   let(:podcast_redirect) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", published_at: nil) }
   let(:token) { StubToken.new(account_id, ['member']) }
   let(:bad_token) { StubToken.new(account_id + 100, ['member']) }
@@ -108,9 +109,12 @@ describe Api::PodcastsController do
   end
 
   it 'should list' do
+    podcast_deleted.id.wont_be_nil
     podcast.id.wont_be_nil
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
+    ids = JSON.parse(response.body)['_embedded']['prx:items'].map { |p| p['id'] }
+    ids.wont_include(podcast_deleted.id)
   end
 
   it 'should list podcasts for an account' do


### PR DESCRIPTION
fixes #239 
the `included()` method is only used when calling find on a single resource, so by moving the `with_deleted` scope to that, we avoid having it affect the listing/index actions, and so deleted records don't come back.