### PR TITLE
Add original urls, episode images

### DIFF
--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -16,7 +16,6 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   property :keyword_xid, writeable: false
 
   property :url
-  property :image_url
 
   property :title
   property :subtitle
@@ -43,6 +42,10 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
     as: :media,
     decorator: MediaResourceRepresenter,
     class: MediaResource
+
+  collection :images,
+    decorator: ImageRepresenter,
+    class: EpisodeImage
 
   def self_url(episode)
     api_episode_path(id: episode.guid)

--- a/app/representers/api/image_representer.rb
+++ b/app/representers/api/image_representer.rb
@@ -4,6 +4,7 @@ class Api::ImageRepresenter < Roar::Decorator
   include Roar::JSON
 
   property :url
+  property :original_url, writeable: false
   property :link
   property :description
   property :format

--- a/app/representers/api/media_resource_representer.rb
+++ b/app/representers/api/media_resource_representer.rb
@@ -4,6 +4,7 @@ class Api::MediaResourceRepresenter < Roar::Decorator
   include Roar::JSON
 
   property :href
+  property :original_url, writeable: false
   property :mime_type, as: :type
   property :file_size, as: :size
   property :duration

--- a/db/migrate/20170921182535_remove_episodes_image_url.rb
+++ b/db/migrate/20170921182535_remove_episodes_image_url.rb
@@ -1,0 +1,5 @@
+class RemoveEpisodesImageUrl < ActiveRecord::Migration
+  def change
+    remove_column :episodes, :image_url
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170621213139) do
+ActiveRecord::Schema.define(version: 20170921182535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,7 +54,6 @@ ActiveRecord::Schema.define(version: 20170621213139) do
     t.text     "subtitle"
     t.text     "content"
     t.text     "summary"
-    t.string   "image_url"
     t.string   "explicit"
     t.text     "keywords"
     t.text     "description"

--- a/test/factories/episode_image_factory.rb
+++ b/test/factories/episode_image_factory.rb
@@ -11,6 +11,10 @@ FactoryGirl.define do
     format 'png'
     status 'complete'
 
+    after(:create) do |episode_image, evaluator|
+      episode_image.url = episode_image.published_url if episode_image.status == 'complete'
+    end
+
     factory :episode_image_with_episode, class: EpisodeImage do
       episode
     end

--- a/test/models/episode_image_test.rb
+++ b/test/models/episode_image_test.rb
@@ -29,7 +29,7 @@ describe EpisodeImage do
     it 'updates from fixer callback' do
       old_image = create(:episode_image_with_episode, episode: episode, created_at: 1.year.ago)
       episode.images.must_be :include?, old_image
-      image.url.must_be_nil
+      image.url = nil
       image.update_from_fixer({})
       image.url.must_equal image.published_url
       episode.images(true).wont_be :include?, old_image

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -36,6 +36,13 @@ describe Api::EpisodeRepresenter do
   it 'has media' do
     json['media'].size.must_equal 1
     json['media'].first['href'].must_equal episode.enclosure.url
+    json['media'].first['original_url'].must_equal episode.enclosure.original_url
+  end
+
+  it 'has image' do
+    json['images'].size.must_equal 1
+    json['images'].first['url'].must_equal episode.image.url
+    json['images'].first['original_url'].must_equal episode.image.original_url
   end
 
   it 'has enclosure' do


### PR DESCRIPTION
Fixing some things to make the feeder import -> cms work better
- [x] Remove old `episodes.image_url` db column - this is not used
- [x] Add images to the episode representer instead
- [x] Include original urls for images and media files