### PR TITLE
Support new Apple Podcasts tags for iOS11

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -46,6 +46,9 @@ class Episode < BaseModel
 
   scope :published, -> { where('published_at IS NOT NULL AND published_at <= now()') }
 
+  alias_attribute :number, :episode_number
+
+
   def self.release_episodes!(options = {})
     podcasts = []
     episodes_to_release.each do |e|

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -39,6 +39,8 @@ class Episode < BaseModel
 
   validates :podcast_id, :guid, presence: true
   validates :itunes_type, inclusion: { in: %w(full trailer bonus) }
+  validates :episode_number, numericality: { only_integer: true }, allow_nil: true
+  validates :season_number, numericality: { only_integer: true }, allow_nil: true
 
   before_validation :initialize_guid, :set_external_keyword, :sanitize_text
 
@@ -47,7 +49,7 @@ class Episode < BaseModel
   scope :published, -> { where('published_at IS NOT NULL AND published_at <= now()') }
 
   alias_attribute :number, :episode_number
-
+  alias_attribute :season, :season_number
 
   def self.release_episodes!(options = {})
     podcasts = []

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -342,4 +342,11 @@ class Episode < BaseModel
   def feeder_cdn_host
     ENV['FEEDER_CDN_HOST']
   end
+
+  def full_title
+    ft = ''
+    ft += "Season #{season} " if season
+    ft += "Episode #{number}: " if number
+    ft + title
+  end
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -342,11 +342,4 @@ class Episode < BaseModel
   def feeder_cdn_host
     ENV['FEEDER_CDN_HOST']
   end
-
-  def full_title
-    ft = ''
-    ft += "Season #{season} " if season
-    ft += "Episode #{number}: " if number
-    ft + title
-  end
 end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -38,6 +38,7 @@ class Episode < BaseModel
     dependent: :destroy
 
   validates :podcast_id, :guid, presence: true
+  validates :itunes_type, inclusion: { in: %w(full trailer bonus) }
 
   before_validation :initialize_guid, :set_external_keyword, :sanitize_text
 

--- a/app/models/episode_entry_handler.rb
+++ b/app/models/episode_entry_handler.rb
@@ -4,7 +4,7 @@ class EpisodeEntryHandler
   ENTRY_ATTRIBUTES = %w(author block categories content description explicit
     feedburner_orig_enclosure_link feedburner_orig_link is_closed_captioned
     is_perma_link keywords position subtitle summary title url
-    season_number episode_number).freeze
+    season_number episode_number clean_title).freeze
 
   attr_accessor :episode
   delegate :overrides, to: :episode

--- a/app/models/episode_entry_handler.rb
+++ b/app/models/episode_entry_handler.rb
@@ -3,7 +3,8 @@ require 'episode'
 class EpisodeEntryHandler
   ENTRY_ATTRIBUTES = %w(author block categories content description explicit
     feedburner_orig_enclosure_link feedburner_orig_link is_closed_captioned
-    is_perma_link keywords position subtitle summary title url).freeze
+    is_perma_link keywords position subtitle summary title url
+    season_number episode_number).freeze
 
   attr_accessor :episode
   delegate :overrides, to: :episode

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -60,6 +60,11 @@ class EpisodeStoryHandler
     episode.content = sa[:description]
     episode.categories = sa[:tags]
     episode.published_at = sa[:published_at] ? Time.parse(sa[:published_at]) : nil
+
+    season_num = sa[:season_identifier].to_i
+    episode.season_number = season_num unless season_num.blank? || season_num.zero?
+    episode_num = sa[:episode_identifier].to_i
+    episode.episode_number = episode_num unless episode_num.blank? || episode_num.zero?
   end
 
   def update_audio

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -55,6 +55,7 @@ class EpisodeStoryHandler
     end
 
     episode.title = sa[:title]
+    episode.clean_title = sa[:clean_title]
     episode.subtitle = sa[:short_description]
     episode.description = sa[:description]
     episode.content = sa[:description]

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -61,10 +61,10 @@ class EpisodeStoryHandler
     episode.categories = sa[:tags]
     episode.published_at = sa[:published_at] ? Time.parse(sa[:published_at]) : nil
 
-    season_num = sa[:season_identifier].to_i
-    episode.season_number = season_num unless season_num.blank? || season_num.zero?
-    episode_num = sa[:episode_identifier].to_i
-    episode.episode_number = episode_num unless episode_num.blank? || episode_num.zero?
+    %w(season episode).each do |time|
+      id = sa["#{time}_identifier"]
+      episode["#{time}_number"] = id.to_i if id && (!id.to_i.zero? || [0, '0'].include?(id))
+    end
   end
 
   def update_audio

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -145,6 +145,10 @@ class Podcast < BaseModel
     "#{base_published_url}/feed-rss.xml"
   end
 
+  def itunes_type
+    serial_order ? 'serial' : 'episodic'
+  end
+
   def sanitize_text
     self.description = sanitize_white_list(description) if description_changed?
     self.subtitle = sanitize_text_only(subtitle) if subtitle_changed?

--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -18,6 +18,7 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   property :url
 
   property :title
+  property :clean_title
   property :subtitle
   property :description
   property :content

--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -23,6 +23,9 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   property :content
   property :summary
   property :summary_preview, exec_context: :decorator, if: ->(_o) { !represented.summary }
+  property :season_number
+  property :episode_number
+  property :itunes_type
 
   property :explicit
   property :block

--- a/app/representers/api/podcast_representer.rb
+++ b/app/representers/api/podcast_representer.rb
@@ -24,6 +24,7 @@ class Api::PodcastRepresenter < Api::BaseRepresenter
   property :summary_preview, exec_context: :decorator, if: ->(_o) { !represented.summary }
 
   property :explicit
+  property :serial_order
   property :complete
   property :copyright
   property :language

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -38,6 +38,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
     end
 
     xml.itunes :author, @podcast.author_name unless @podcast.author_name.blank?
+    xml.itunes :type, @podcast.itunes_type unless @podcast.itunes_type.blank?
 
     @podcast.itunes_categories[0, 3].each do |cat|
       if cat.subcategories.blank?
@@ -82,8 +83,12 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
         xml.description { xml.cdata!(ep.description || '') }
         xml.enclosure(url: ep.media_url, type: ep.content_type, length: ep.file_size) if ep.media?
 
+        xml.itunes :title, ep.title unless ep.title.blank?
         xml.itunes :subtitle, ep.subtitle unless ep.subtitle.blank?
         xml.itunes :explicit, ep.explicit unless ep.explicit.blank?
+        xml.itunes :episodeType, ep.itunes_type unless ep.itunes_type.blank?
+        xml.itunes :season, ep.season if ep.season?
+        xml.itunes :episode, ep.number if ep.number?
         xml.itunes :duration, ep.duration.to_i.to_time_summary if ep.media?
 
         if @podcast.display_full_episodes_count.to_i <= 0 || index < @podcast.display_full_episodes_count.to_i

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -83,7 +83,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
         xml.description { xml.cdata!(ep.description || '') }
         xml.enclosure(url: ep.media_url, type: ep.content_type, length: ep.file_size) if ep.media?
 
-        xml.itunes :title, ep.title unless ep.title.blank?
+        xml.itunes :title, ep.clean_title unless ep.clean_title.blank?
         xml.itunes :subtitle, ep.subtitle unless ep.subtitle.blank?
         xml.itunes :explicit, ep.explicit unless ep.explicit.blank?
         xml.itunes :episodeType, ep.itunes_type unless ep.itunes_type.blank?

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -77,7 +77,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
     @episodes.each_with_index do |ep, index|
       xml.item do
         xml.guid(ep.item_guid, isPermaLink: !!ep.is_perma_link)
-        xml.title(ep.full_title)
+        xml.title(ep.title)
         xml.pubDate ep.published_at.utc.rfc2822
         xml.link ep.url || ep.media_url
         xml.description { xml.cdata!(ep.description || '') }

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -76,7 +76,7 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
     @episodes.each_with_index do |ep, index|
       xml.item do
         xml.guid(ep.item_guid, isPermaLink: !!ep.is_perma_link)
-        xml.title(ep.title)
+        xml.title(ep.full_title)
         xml.pubDate ep.published_at.utc.rfc2822
         xml.link ep.url || ep.media_url
         xml.description { xml.cdata!(ep.description || '') }

--- a/db/migrate/20170926204117_add_podcast_tags.rb
+++ b/db/migrate/20170926204117_add_podcast_tags.rb
@@ -1,0 +1,10 @@
+class AddPodcastTags < ActiveRecord::Migration
+  def up
+    add_column :podcasts, :serial_order, :boolean, default: false
+    execute "UPDATE podcasts SET serial_order = false"
+  end
+
+  def down
+    remove_column :podcasts, :serial_order
+  end
+end

--- a/db/migrate/20170926210603_add_episode_tags.rb
+++ b/db/migrate/20170926210603_add_episode_tags.rb
@@ -1,0 +1,16 @@
+class AddEpisodeTags < ActiveRecord::Migration
+  def up
+    add_column :episodes, :season, :integer
+    add_column :episodes, :number, :integer
+    add_column :episodes, :itunes_type, :string, default: 'full'
+    execute "UPDATE episodes SET itunes_type = 'full'"
+    execute "UPDATE episodes SET itunes_type = 'bonus' WHERE title LIKE %bonus%"
+    execute "UPDATE episodes SET itunes_type = 'trailer' WHERE title LIKE %trailer%"
+  end
+
+  def down
+    remove_column :episodes, :season
+    remove_column :episodes, :number
+    remove_column :episodes, :itunes_type
+  end
+end

--- a/db/migrate/20170926210603_add_episode_tags.rb
+++ b/db/migrate/20170926210603_add_episode_tags.rb
@@ -4,8 +4,6 @@ class AddEpisodeTags < ActiveRecord::Migration
     add_column :episodes, :episode_number, :integer
     add_column :episodes, :itunes_type, :string, default: 'full'
     execute "UPDATE episodes SET itunes_type = 'full'"
-    execute "UPDATE episodes SET itunes_type = 'bonus' WHERE title LIKE '%bonus%'"
-    execute "UPDATE episodes SET itunes_type = 'trailer' WHERE title LIKE '%trailer%'"
   end
 
   def down

--- a/db/migrate/20170926210603_add_episode_tags.rb
+++ b/db/migrate/20170926210603_add_episode_tags.rb
@@ -1,16 +1,16 @@
 class AddEpisodeTags < ActiveRecord::Migration
   def up
-    add_column :episodes, :season, :integer
-    add_column :episodes, :number, :integer
+    add_column :episodes, :season_number, :integer
+    add_column :episodes, :episode_number, :integer
     add_column :episodes, :itunes_type, :string, default: 'full'
     execute "UPDATE episodes SET itunes_type = 'full'"
-    execute "UPDATE episodes SET itunes_type = 'bonus' WHERE title LIKE %bonus%"
-    execute "UPDATE episodes SET itunes_type = 'trailer' WHERE title LIKE %trailer%"
+    execute "UPDATE episodes SET itunes_type = 'bonus' WHERE title LIKE '%bonus%'"
+    execute "UPDATE episodes SET itunes_type = 'trailer' WHERE title LIKE '%trailer%'"
   end
 
   def down
-    remove_column :episodes, :season
-    remove_column :episodes, :number
+    remove_column :episodes, :season_number
+    remove_column :episodes, :episode_number
     remove_column :episodes, :itunes_type
   end
 end

--- a/db/migrate/20170928174959_add_clean_title_to_episodes.rb
+++ b/db/migrate/20170928174959_add_clean_title_to_episodes.rb
@@ -1,0 +1,9 @@
+class AddCleanTitleToEpisodes < ActiveRecord::Migration
+  def up
+    add_column :episodes, :clean_title, :text
+  end
+
+  def down
+    remove_column :episodes, :clean_title
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926210603) do
+ActiveRecord::Schema.define(version: 20170928174959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 20170926210603) do
     t.integer  "season_number"
     t.integer  "episode_number"
     t.string   "itunes_type",                    default: "full"
+    t.text     "clean_title"
   end
 
   add_index "episodes", ["guid"], name: "index_episodes_on_guid", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926204117) do
+ActiveRecord::Schema.define(version: 20170926210603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,6 +66,9 @@ ActiveRecord::Schema.define(version: 20170926204117) do
     t.boolean  "is_perma_link"
     t.datetime "source_updated_at"
     t.string   "keyword_xid"
+    t.integer  "season"
+    t.integer  "number"
+    t.string   "itunes_type",                    default: "full"
   end
 
   add_index "episodes", ["guid"], name: "index_episodes_on_guid", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -66,8 +66,8 @@ ActiveRecord::Schema.define(version: 20170926210603) do
     t.boolean  "is_perma_link"
     t.datetime "source_updated_at"
     t.string   "keyword_xid"
-    t.integer  "season"
-    t.integer  "number"
+    t.integer  "season_number"
+    t.integer  "episode_number"
     t.string   "itunes_type",                    default: "full"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170921182535) do
+ActiveRecord::Schema.define(version: 20170926204117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -196,6 +196,7 @@ ActiveRecord::Schema.define(version: 20170921182535) do
     t.datetime "published_at"
     t.string   "enclosure_prefix"
     t.datetime "source_updated_at"
+    t.boolean  "serial_order",                default: false
   end
 
   add_index "podcasts", ["path"], name: "index_podcasts_on_path", unique: true, using: :btree

--- a/lib/prx_access.rb
+++ b/lib/prx_access.rb
@@ -93,7 +93,7 @@ module PRXAccess
   end
 
   def api_resource(body, root = cms_root)
-    href = body['_links']['self']['href']
+    href = body.dig(:_links, :self, :href)
     resource = api(root: root)
     link = PRXHyperResource::Link.new(resource, href: href)
     PRXHyperResource.new_from(body: body, resource: resource, link: link)

--- a/test/factories/episode_factory.rb
+++ b/test/factories/episode_factory.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     sequence(:prx_uri) { |n| "/api/v1/stories/#{(87683 + n)}" }
 
     sequence(:season_number) { |n| n * 2 }
+    sequence(:episode_number) { |n| n }
     sequence(:guid) { |n| "ba047dce-9df5-4132-a04b-31d24c7c55a#{n}" }
     sequence(:title) { |n| "Episode #{n}" }
     sequence(:published_at) { |n| Date.today - n.days }

--- a/test/factories/episode_factory.rb
+++ b/test/factories/episode_factory.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     sequence(:episode_number) { |n| n }
     sequence(:guid) { |n| "ba047dce-9df5-4132-a04b-31d24c7c55a#{n}" }
     sequence(:title) { |n| "Episode #{n}" }
+    sequence(:clean_title) { |n| "Clean title #{n}" }
     sequence(:published_at) { |n| Date.today - n.days }
 
     description "<div><a href='/tina'>Tina</a> McElroy Ansa is a little girl when her father's business goes under and her family must leave their beloved, expansive home.</div>"

--- a/test/factories/episode_factory.rb
+++ b/test/factories/episode_factory.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     podcast
     sequence(:prx_uri) { |n| "/api/v1/stories/#{(87683 + n)}" }
 
+    sequence(:season_number) { |n| n * 2 }
     sequence(:guid) { |n| "ba047dce-9df5-4132-a04b-31d24c7c55a#{n}" }
     sequence(:title) { |n| "Episode #{n}" }
     sequence(:published_at) { |n| Date.today - n.days }

--- a/test/fixtures/prx_story_all.json
+++ b/test/fixtures/prx_story_all.json
@@ -4,6 +4,8 @@
   "description": "this is a description",
   "duration": 3346,
   "id": 186751,
+  "episodeIdentifier": 4,
+  "seasonIdentifier": 2,
   "points": 0,
   "publishedAt": "2016-09-29T22:14:13.000Z",
   "shortDescription": "With a teaser of the story",

--- a/test/fixtures/prx_story_all.json
+++ b/test/fixtures/prx_story_all.json
@@ -14,6 +14,7 @@
     "Careers"
   ],
   "title": "Here is a new story in my brand new series",
+  "clean_title": "Stripped-down title",
   "updatedAt": "2016-10-18T22:16:40.000Z",
   "_links": {
     "alternate": {

--- a/test/fixtures/prx_story_invalid_identifiers.json
+++ b/test/fixtures/prx_story_invalid_identifiers.json
@@ -1,0 +1,35 @@
+{
+  "id": 80548,
+  "publishedAt": "2015-05-18T23:12:38.000Z",
+  "title": "Title",
+  "episodeIdentifier": "The first one",
+  "seasonIdentifier": "Second season",
+  "_links": {
+    "curies": [{
+      "name": "prx",
+      "href": "http://meta.prx.org/relation/{rel}",
+      "templated": true
+    }],
+    "self": {
+      "href": "/api/v1/stories/80548",
+      "profile": "http://meta.prx.org/model/story"
+    },
+    "alternate": {
+      "href": "https://beta.prx.org/stories/80548",
+      "type": "text/html"
+    },
+    "prx:account": {
+      "href": "/api/v1/accounts/125347",
+      "title": "American Routes",
+      "profile": "http://meta.prx.org/model/account/group"
+    },
+    "prx:series": {
+      "href": "/api/v1/series/32165",
+      "title": "American Routes"
+    },
+    "prx:audio": {
+      "href": "/api/v1/stories/80548/audio_files",
+      "count": 2
+    }
+  }
+}

--- a/test/fixtures/prx_story_zero_identifiers.json
+++ b/test/fixtures/prx_story_zero_identifiers.json
@@ -1,0 +1,35 @@
+{
+  "id": 80548,
+  "publishedAt": "2015-05-18T23:12:38.000Z",
+  "title": "Title",
+  "episodeIdentifier": "0",
+  "seasonIdentifier": 0,
+  "_links": {
+    "curies": [{
+      "name": "prx",
+      "href": "http://meta.prx.org/relation/{rel}",
+      "templated": true
+    }],
+    "self": {
+      "href": "/api/v1/stories/80548",
+      "profile": "http://meta.prx.org/model/story"
+    },
+    "alternate": {
+      "href": "https://beta.prx.org/stories/80548",
+      "type": "text/html"
+    },
+    "prx:account": {
+      "href": "/api/v1/accounts/125347",
+      "title": "American Routes",
+      "profile": "http://meta.prx.org/model/account/group"
+    },
+    "prx:series": {
+      "href": "/api/v1/series/32164",
+      "title": "American Routes"
+    },
+    "prx:audio": {
+      "href": "/api/v1/stories/80548/audio_files",
+      "count": 2
+    }
+  }
+}

--- a/test/integration/podcast_request_test.rb
+++ b/test/integration/podcast_request_test.rb
@@ -105,7 +105,6 @@ describe 'RSS feed Integration Test' do
     @feed.at_css('itunes|type').text.must_equal @podcast.itunes_type
     @feed.css('item').reverse.each_with_index do |node, ind|
       node.css('title').text.must_match /Season \d+ Episode \d+/
-      node.css('itunes|title').text.wont_match /Season/
       node.css('itunes|title').text.must_equal "Stripped-down title"
       node.css('itunes|season').text.to_i.must_equal ind + 1
       node.css('itunes|episode').text.to_i.must_equal ind + 1

--- a/test/integration/podcast_request_test.rb
+++ b/test/integration/podcast_request_test.rb
@@ -58,7 +58,7 @@ describe 'RSS feed Integration Test' do
 
   it 'displays correct episode titles' do
     @feed.css('item').each_with_index do |node, i|
-      node.css('title').text.must_match /Season \d+ Episode \d+/
+      node.css('title').text.must_match /Episode \d+/
       node.at_css('enclosure').attributes['length'].value.must_equal '774059'
       node.css('itunes|duration').text.must_equal '0:48'
     end
@@ -95,7 +95,8 @@ describe 'RSS feed Integration Test' do
     @episodes.each_with_index do |e, i|
       e.update_attributes(season_number: i + 1,
                           episode_number: i + 1,
-                          title: 'Stripped-down title')
+                          title: 'Season 2 Episode 3 Stripped-down title',
+                          clean_title: 'Stripped-down title')
     end
     @podcast.update_attributes(serial_order: false)
     get "/podcasts/#{@podcast.id}"

--- a/test/integration/podcast_request_test.rb
+++ b/test/integration/podcast_request_test.rb
@@ -59,7 +59,6 @@ describe 'RSS feed Integration Test' do
   it 'displays correct episode titles' do
     @feed.css('item').each_with_index do |node, i|
       node.css('title').text.must_match /Season \d+ Episode \d+/
-      node.css('itunes|title').text.wont_match /Season/
       node.at_css('enclosure').attributes['length'].value.must_equal '774059'
       node.css('itunes|duration').text.must_equal '0:48'
     end
@@ -90,6 +89,27 @@ describe 'RSS feed Integration Test' do
     get "/podcasts/#{@podcast.id}"
     @feed.at_css('itunes|owner').css('itunes|email').text.must_equal @podcast.author_email
     @feed.at_css('itunes|owner').css('itunes|name').text.must_equal @podcast.author_name
+  end
+
+  it 'supports iTunes tags new in iOS11' do
+    @episodes.each_with_index do |e, i|
+      e.update_attributes(season_number: i + 1,
+                          episode_number: i + 1,
+                          title: 'Stripped-down title')
+    end
+    @podcast.update_attributes(serial_order: false)
+    get "/podcasts/#{@podcast.id}"
+    @feed = Nokogiri::XML(response.body).css('channel')
+
+    @feed.at_css('itunes|type').text.must_equal @podcast.itunes_type
+    @feed.css('item').reverse.each_with_index do |node, ind|
+      node.css('title').text.must_match /Season \d+ Episode \d+/
+      node.css('itunes|title').text.wont_match /Season/
+      node.css('itunes|title').text.must_equal "Stripped-down title"
+      node.css('itunes|season').text.to_i.must_equal ind + 1
+      node.css('itunes|episode').text.to_i.must_equal ind + 1
+      node.css('itunes|episodeType').text.must_match 'full'
+    end
   end
 
   describe 'with a guest author' do

--- a/test/integration/podcast_request_test.rb
+++ b/test/integration/podcast_request_test.rb
@@ -58,7 +58,8 @@ describe 'RSS feed Integration Test' do
 
   it 'displays correct episode titles' do
     @feed.css('item').each_with_index do |node, i|
-      node.css('title').text.must_match /Episode \d+/
+      node.css('title').text.must_match /Season \d+ Episode \d+/
+      node.css('itunes|title').text.wont_match /Season/
       node.at_css('enclosure').attributes['length'].value.must_equal '774059'
       node.css('itunes|duration').text.must_equal '0:48'
     end

--- a/test/models/episode_story_handler_test.rb
+++ b/test/models/episode_story_handler_test.rb
@@ -35,4 +35,48 @@ describe EpisodeStoryHandler do
     episode.season_number.must_equal 2
     episode.episode_number.must_equal 4
   end
+
+  describe 'with episode identifiers' do
+
+    let(:zero_identifiers_story) do
+      msg = json_file(:prx_story_zero_identifiers)
+      body = JSON.parse(msg)
+      href = body['_links']['self']['href']
+      resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
+      link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
+      PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)
+    end
+
+    let(:invalid_identifiers_story) do
+      msg = json_file(:prx_story_invalid_identifiers)
+      body = JSON.parse(msg)
+      href = body['_links']['self']['href']
+      resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
+      link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
+      PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)
+    end
+
+    it 'sets episode and season numbers from identifiers' do
+      podcast = create(:podcast, prx_uri: '/api/v1/series/36501')
+      episode = EpisodeStoryHandler.create_from_story!(story)
+      episode.season_number.must_equal 2
+      episode.episode_number.must_equal 4
+    end
+
+    it 'wont use string identifiers' do
+      podcast = create(:podcast, prx_uri: '/api/v1/series/32165')
+      episode = EpisodeStoryHandler.create_from_story!(invalid_identifiers_story)
+      episode.season_number.must_be_nil
+      episode.episode_number.must_be_nil
+
+    end
+
+   it 'allows identifiers to be zero' do
+     podcast = create(:podcast, prx_uri: '/api/v1/series/32164')
+     episode = EpisodeStoryHandler.create_from_story!(zero_identifiers_story)
+     episode.season_number.must_equal 0
+     episode.episode_number.must_equal 0
+   end
+  end
+
 end

--- a/test/models/episode_story_handler_test.rb
+++ b/test/models/episode_story_handler_test.rb
@@ -34,6 +34,7 @@ describe EpisodeStoryHandler do
     episode.description.must_equal 'this is a description'
     episode.season_number.must_equal 2
     episode.episode_number.must_equal 4
+    episode.clean_title.must_equal 'Stripped-down title'
   end
 
   describe 'with episode identifiers' do

--- a/test/models/episode_story_handler_test.rb
+++ b/test/models/episode_story_handler_test.rb
@@ -32,5 +32,7 @@ describe EpisodeStoryHandler do
     first_audio.must_equal 's3://mediajoint.production.prx.org/public/audio_files/1200648/lcs_spring16_act1.mp3'
     last_audio.must_equal 's3://mediajoint.production.prx.org/public/audio_files/1200657/broadcast/t01.mp3'
     episode.description.must_equal 'this is a description'
+    episode.season_number.must_equal 2
+    episode.episode_number.must_equal 4
   end
 end

--- a/test/models/episode_story_handler_test.rb
+++ b/test/models/episode_story_handler_test.rb
@@ -9,7 +9,7 @@ describe EpisodeStoryHandler do
   let(:story) do
     msg = json_file(:prx_story_all)
     body = JSON.parse(msg)
-    href = body['_links']['self']['href']
+    href = body.dig(:_links, :self, :href)
     resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
     link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
     PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)
@@ -42,7 +42,7 @@ describe EpisodeStoryHandler do
     let(:zero_identifiers_story) do
       msg = json_file(:prx_story_zero_identifiers)
       body = JSON.parse(msg)
-      href = body['_links']['self']['href']
+      href = body.dig(:_links, :self, :href)
       resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
       link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
       PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)
@@ -51,7 +51,7 @@ describe EpisodeStoryHandler do
     let(:invalid_identifiers_story) do
       msg = json_file(:prx_story_invalid_identifiers)
       body = JSON.parse(msg)
-      href = body['_links']['self']['href']
+      href = body.dig(:_links, :self, :href)
       resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
       link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
       PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -138,6 +138,12 @@ describe Episode do
     episode.wont_be(:valid?)
   end
 
+  it 'concats identifying information for full version of title' do
+    episode.update_attributes(season_number: 2, episode_number: 3, title: 'The Thing Happened')
+    episode.title.wont_include 'Season'
+    episode.full_title.must_equal 'Season 2 Episode 3: The Thing Happened'
+  end
+
   describe 'release episodes' do
 
     let(:podcast) { episode.podcast }

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -252,7 +252,7 @@ describe Episode do
     let(:story) do
       msg = json_file(:prx_story_small)
       body = JSON.parse(msg)
-      href = body['_links']['self']['href']
+      href = body.dig(:_links, :self, :href)
       resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
       link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
       PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -132,6 +132,12 @@ describe Episode do
     episode.keywords.each { |k| k.wont_match(/['?!,']/) }
   end
 
+  it 'has a valid itunes episode type' do
+    episode.itunes_type.must_equal('full')
+    episode.itunes_type = 'foo'
+    episode.wont_be(:valid?)
+  end
+
   describe 'release episodes' do
 
     let(:podcast) { episode.podcast }

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -138,12 +138,6 @@ describe Episode do
     episode.wont_be(:valid?)
   end
 
-  it 'concats identifying information for full version of title' do
-    episode.update_attributes(season_number: 2, episode_number: 3, title: 'The Thing Happened')
-    episode.title.wont_include 'Season'
-    episode.full_title.must_equal 'Season 2 Episode 3: The Thing Happened'
-  end
-
   describe 'release episodes' do
 
     let(:podcast) { episode.podcast }

--- a/test/models/podcast_series_handler_test.rb
+++ b/test/models/podcast_series_handler_test.rb
@@ -11,7 +11,7 @@ describe PodcastSeriesHandler do
   let(:series) do
     msg = json_file(:prx_series)
     body = JSON.parse(msg)
-    href = body['_links']['self']['href']
+    href = body.dig(:_links, :self, :href)
     resource = PRXAccess::PRXHyperResource.new(root: 'https://cms.prx.org/api/vi/')
     link = PRXAccess::PRXHyperResource::Link.new(resource, href: href)
     PRXAccess::PRXHyperResource.new_from(body: body, resource: resource, link: link)

--- a/test/models/podcast_test.rb
+++ b/test/models/podcast_test.rb
@@ -21,6 +21,12 @@ describe Podcast do
     podcast.must_respond_to(:itunes_categories)
   end
 
+  it 'is episodic or serial' do
+    podcast.itunes_type.must_match /episodic/
+    podcast.update_attributes(serial_order: true)
+    podcast.itunes_type.must_match /serial/
+  end
+
   it 'updates last build date after update' do
     Timecop.freeze
     podcast.update_attributes(managing_editor: 'Brian Fernandez')

--- a/test/models/tasks/copy_media_task_test.rb
+++ b/test/models/tasks/copy_media_task_test.rb
@@ -7,7 +7,7 @@ describe Tasks::CopyMediaTask do
 
   let(:story) do
     body = JSON.parse(json_file(:prx_story_small))
-    href = body['_links']['self']['href']
+    href = body.dig(:_links, :self, :href)
     resource = task.api
     link = HyperResource::Link.new(resource, href: href)
     HyperResource.new_from(body: body, resource: resource, link: link)

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -11,9 +11,10 @@ describe Api::EpisodeRepresenter do
     json['summary'].must_match /<a href="\/tina">Tina<\/a>/
   end
 
-  it 'includes season, episode, and ep type info' do
+  it 'includes clean title, season, episode, and ep type info' do
     json['seasonNumber'].must_be_instance_of(Fixnum)
     json['episodeNumber'].must_be_instance_of(Fixnum)
+    json['cleanTitle'].must_match /Clean title/
     json['itunesType'].must_equal 'full'
   end
 

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -11,6 +11,12 @@ describe Api::EpisodeRepresenter do
     json['summary'].must_match /<a href="\/tina">Tina<\/a>/
   end
 
+  it 'includes season, episode, and ep type info' do
+    json['seasonNumber'].must_be_instance_of(Fixnum)
+    json['episodeNumber'].must_be_instance_of(Fixnum)
+    json['itunesType'].must_equal 'full'
+  end
+
   it 'uses summary when not blank' do
     episode.summary = 'summary has <a href="/">a link</a>'
     episode.description = '<b>tags</b> removed, <a href="/">links remain</a>'

--- a/test/representers/api/podcast_representer_test.rb
+++ b/test/representers/api/podcast_representer_test.rb
@@ -37,6 +37,10 @@ describe Api::PodcastRepresenter do
     json['feedImage']['url'].must_equal 'test/fixtures/valid_feed_image.png'
   end
 
+  it 'includes serial v. episodic ordering' do
+    json['serialOrder'].must_equal false
+  end
+
   it 'has links' do
     json['_links']['self']['href'].must_equal "/api/v1/podcasts/#{podcast.id}"
     json['_links']['prx:series']['href'].must_equal "https://cms.prx.org#{podcast.prx_uri}"


### PR DESCRIPTION
#255 

along with this, we'll change CMS to keep track of a story's season as well (https://github.com/PRX/cms.prx.org/issues/319), possibly send the season + episode info to feeder when it creates an EpisodeDistribution for a story (tbd, question in #319), and also update Publish to allow users to set all these fields. (https://github.com/PRX/publish.prx.org/issues/428). This is a blocker for #428. 