### PR TITLE
log anywhere that published_url is called on something that could be nil

### DIFF
--- a/app/models/tasks/copy_image_task.rb
+++ b/app/models/tasks/copy_image_task.rb
@@ -36,7 +36,7 @@ class Tasks::CopyImageTask < ::Task
 
   def image_path(image_resource)
     if !image_resource
-      logger.info("in CopyImageTask#image_path and image_resource is nil. self is #{self}")
+      logger.info("in CopyImageTask#image_path and image_resource is nil. self is #{self.inspect}")
     end
     URI.parse(image_resource.published_url).path
   end

--- a/app/models/tasks/copy_image_task.rb
+++ b/app/models/tasks/copy_image_task.rb
@@ -35,6 +35,9 @@ class Tasks::CopyImageTask < ::Task
   end
 
   def image_path(image_resource)
+    if !image_resource
+      logger.info("in CopyImageTask#image_path and image_resource is nil. self is #{self}")
+    end
     URI.parse(image_resource.published_url).path
   end
 

--- a/app/models/tasks/publish_feed_task.rb
+++ b/app/models/tasks/publish_feed_task.rb
@@ -34,6 +34,9 @@ class Tasks::PublishFeedTask < ::Task
 
   def task_status_changed(fixer_task, new_status)
     # purge the cdn cache
+    if !podcast
+      logger.info("in PublishFeedTask#task_status_changed and podcast is nil. self is #{self}")
+    end
     HighwindsAPI::Content.purge_url(podcast.published_url, false)
 
     # send out a feed updated event?
@@ -43,6 +46,9 @@ class Tasks::PublishFeedTask < ::Task
   end
 
   def feed_path(podcast = owner)
+    if !podcast
+      logger.info("in PublishFeedTask#feed_path and podcast is nil. self is #{self}")
+    end
     URI.parse(podcast.published_url).path
   end
 

--- a/app/models/tasks/publish_feed_task.rb
+++ b/app/models/tasks/publish_feed_task.rb
@@ -35,7 +35,7 @@ class Tasks::PublishFeedTask < ::Task
   def task_status_changed(fixer_task, new_status)
     # purge the cdn cache
     if !podcast
-      logger.info("in PublishFeedTask#task_status_changed and podcast is nil. self is #{self}")
+      logger.info("in PublishFeedTask#task_status_changed and podcast is nil. self is #{self.inspect}")
     end
     HighwindsAPI::Content.purge_url(podcast.published_url, false)
 
@@ -47,7 +47,7 @@ class Tasks::PublishFeedTask < ::Task
 
   def feed_path(podcast = owner)
     if !podcast
-      logger.info("in PublishFeedTask#feed_path and podcast is nil. self is #{self}")
+      logger.info("in PublishFeedTask#feed_path and podcast is nil. self is #{self.inspect}")
     end
     URI.parse(podcast.published_url).path
   end


### PR DESCRIPTION
Lots of `NoMethodError: undefined method `published_url' for nil:NilClass` in CloudWatch for feeder-staging after last attempted podcast import (of very large feed). Not sure where it could be coming from, so let's add lots of logging around everywhere temporarily and then rerun the same import in staging again. 