### PR TITLE
Filter authorized podcasts

### DIFF
--- a/app/controllers/api/auth/podcasts_controller.rb
+++ b/app/controllers/api/auth/podcasts_controller.rb
@@ -17,4 +17,8 @@ class Api::Auth::PodcastsController < Api::PodcastsController
     end
     visible
   end
+
+  def resources_base
+    @podcasts ||= authorization.token_auth_podcasts
+  end
 end

--- a/app/controllers/api/authorizations_controller.rb
+++ b/app/controllers/api/authorizations_controller.rb
@@ -8,6 +8,6 @@ class Api::AuthorizationsController < Api::BaseController
   private
 
   def resource
-    Authorization.new(prx_auth_token)
+    authorization
   end
 end

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -26,6 +26,10 @@ class Api::BaseController < ApplicationController
     prx_auth_token
   end
 
+  def authorization
+    Authorization.new(prx_auth_token) if prx_auth_token
+  end
+
   protect_from_forgery with: :null_session
 
   allow_params :show, [:api_version, :format, :zoom]

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -25,4 +25,16 @@ class Authorization
     token_key = OpenSSL::Digest::MD5.hexdigest(token.attributes.flatten.join)
     ActiveSupport::Cache.expand_cache_key(['PRX::Authorization', token_key])
   end
+
+  def token_auth_account_ids
+    token.authorized_resources.try(:keys) || []
+  end
+
+  def token_auth_account_uris
+    token_auth_account_ids.map { |id| "/api/v1/accounts/#{id}" }
+  end
+
+  def token_auth_podcasts
+    Podcast.where(prx_account_uri: token_auth_account_uris)
+  end
 end

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -10,6 +10,13 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
     }
   end
 
+  link :podcasts do
+    {
+      href: api_authorization_podcasts_path,
+      count: represented.token_auth_podcasts.count
+    }
+  end
+
   link :podcast do
     {
       href: api_authorization_podcast_path_template(id: '{id}'),

--- a/test/controllers/api/auth/podcasts_controller_test.rb
+++ b/test/controllers/api/auth/podcasts_controller_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 describe Api::Auth::PodcastsController do
   let(:account_id) { 123 }
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", published_at: nil) }
+  let(:published_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", path: 'pod2') }
+  let(:other_account_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/9876", path: 'pod3') }
   let(:token) { StubToken.new(account_id, ['member']) }
 
   before do
@@ -16,5 +18,20 @@ describe Api::Auth::PodcastsController do
     podcast.published_at.must_be_nil
     get(:show, { api_version: 'v1', format: 'json', id: podcast.id } )
     assert_response :success
+  end
+
+  it 'should not show unowned podcast' do
+    get(:show, { api_version: 'v1', format: 'json', id: other_account_podcast.id } )
+    assert_response :not_found
+  end
+
+  it 'should only index account podcasts' do
+    podcast && published_podcast && other_account_podcast
+    get(:index, api_version: 'v1')
+    assert_response :success
+    assert_not_nil assigns[:podcasts]
+    assigns[:podcasts].must_include podcast
+    assigns[:podcasts].must_include published_podcast
+    assigns[:podcasts].wont_include other_account_podcast
   end
 end

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -4,6 +4,9 @@ describe Authorization do
   let(:account_id) { '123' }
   let(:token) { StubToken.new(account_id, ['member'], 456) }
   let(:authorization) { Authorization.new(token) }
+  let(:podcast1) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", path: 'pod1') }
+  let(:podcast2) { create(:podcast, prx_account_uri: "/api/v1/accounts/987", path: 'pod2') }
+  let(:podcast3) { create(:podcast, prx_account_uri: "/api/v1/accounts/654", path: 'pod3') }
 
   it 'has a user_id' do
     authorization.user_id.must_equal 456
@@ -17,5 +20,16 @@ describe Authorization do
   it 'has a cache_key' do
     authorization.cache_key.wont_be_nil
     authorization.cache_key.must_match /PRX::Authorization/
+  end
+
+  it 'has token accounts' do
+    authorization.token_auth_account_ids.must_equal ['123']
+    authorization.token_auth_account_uris.must_equal ['/api/v1/accounts/123']
+  end
+
+  it 'gets podcasts for token accounts' do
+    podcast1 && podcast2 && podcast3
+    authorization.token_auth_podcasts.count.must_equal 1
+    authorization.token_auth_podcasts.first.must_equal podcast1
   end
 end

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -6,9 +6,16 @@ describe Api::AuthorizationRepresenter do
   let(:token) { StubToken.new(account_id, ['member'], 456) }
   let(:authorization) { Authorization.new(token) }
   let(:representer) { Api::AuthorizationRepresenter.new(authorization) }
+  let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }
   let(:json) { JSON.parse(representer.to_json) }
 
   it 'has link to episode' do
     json['_links']['prx:episode'].wont_be_nil
+  end
+
+  it 'has link to podcasts' do
+    podcast.id.wont_be_nil
+    json['_links']['prx:podcasts'].wont_be_nil
+    json['_links']['prx:podcasts']['count'].must_equal 1
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -103,6 +103,10 @@ class StubToken
     { sub: @@fake_user_id, aur: { resource => scopes }, scope: 'read write purchase sell delete' }
   end
 
+  def authorized_resources
+    attributes[:aur]
+  end
+
   def authorized?(r, s = nil)
     resource == r.to_s && (s.nil? || scopes.include?(s.to_s))
   end


### PR DESCRIPTION
See #262.

Assumes a known structure to the `podcasts.prx_account_uri`.  But I think that's okay for now.