### PR TITLE
Fix worker env vars

### DIFF
--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -44,11 +44,11 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
 
   collection :media_files,
     as: :media,
-    decorator: MediaResourceRepresenter,
+    decorator: Api::MediaResourceRepresenter,
     class: MediaResource
 
   collection :images,
-    decorator: ImageRepresenter,
+    decorator: Api::ImageRepresenter,
     class: EpisodeImage
 
   def self_url(episode)

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -5,11 +5,6 @@ env:
     PRX_ECR_REPOSITORY: "feeder.prx.org"
     PRX_ECR_CONFIG_PARAMETERS: "FeederEcrImageTag"
 phases:
-  install:
-    commands:
-      - 'echo "Installing docker-compose..."'
-      - 'COMPOSE="https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" && curl -sL $COMPOSE -o /usr/local/bin/docker-compose'
-      - "chmod +x /usr/local/bin/docker-compose"
   build:
     commands:
       - "cd $(ls -d */|head -n 1)"

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -17,14 +17,14 @@ Shoryuken.default_worker_options =  {
   'body_parser'             => :json
 }
 
-Shoryuken.configure_server do |config|
+Shoryuken.configure_server do |_config|
   Rails.logger = Shoryuken::Logging.logger
   ActiveJob::Base.logger = Shoryuken::Logging.logger
   ActiveRecord::Base.logger = Shoryuken::Logging.logger
 end
 
 begin
-  Shoryuken.configure_client do |config|
+  Shoryuken.configure_client do |_config|
     unless Rails.env.test?
       config_file = File.join(Rails.root, 'config', 'shoryuken.yml')
       Shoryuken::EnvironmentLoader.load(config_file: config_file)

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -5,8 +5,10 @@ aws:
   secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   region:            <%= ENV['AWS_REGION'] %>
   account_id:        <%= ENV['AWS_ACCOUNT_ID'] %>
-concurrency:         25 # The number of allocated threads to process messages. Default 25
-delay:               30 # The delay in seconds to pause a queue when it's empty. Default 0
+# The number of allocated threads to process messages. Default 25
+concurrency:         <%= ENV['WORKER_COUNT'] || 25 %>
+# The delay in seconds to pause a queue when it's empty. Default 0
+delay:               <%= ENV['WORKER_PAUSE'] || 30 %>
 queues:
   - [<%= env %>_feeder_default, 2]
   - [<%= env %>_feeder_fixer_callback, 1]


### PR DESCRIPTION
- [x] Use env vars for the worker config #265 
- [x] Take `compose` out of CI config
- [x] Fix representer to use module name
- [x] Use leading `_` for unused args