### PR TITLE
Check for existing episode for a story id before inserting

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -9,6 +9,21 @@ class Api::EpisodesController < Api::BaseController
   after_action :process_media, only: [:create, :update]
   after_action :publish, only: [:create, :update, :destroy]
 
+  def create
+    res = create_resource
+    consume! res, create_options
+
+    if !res.prx_uri.blank? && existing_res = Episode.find_by(prx_uri: res.prx_uri)
+      res = existing_res
+      consume! res, create_options
+    end
+
+    hal_authorize res
+    res.save!
+    respond_with root_resource(res), create_options
+    res
+  end
+
   def decorate_query(res)
     list_scoped(super(res))
   end


### PR DESCRIPTION
When a cms story episode distribution request inserts an episode, but the response it not correctly returned or processed, a retry of the distribution will fail with a dupe key on the prx id (story id).

With this change, the episode controller will lookup an existing story, and update it.