### PR TITLE
Use correct syntax for around_perform

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,15 +1,14 @@
 require 'newrelic_rpm'
 
 class ApplicationJob < ActiveJob::Base
-  around_perform :use_db_pool
 
   rescue_from(StandardError) do |e|
     NewRelic::Agent.notice_error(e)
   end
 
-  def use_db_pool(job)
+  around_perform do |job, block|
     ActiveRecord::Base.connection_pool.with_connection do
-      yield
+      block.call
     end
   end
 end


### PR DESCRIPTION
Had some issues after #281 merged -- 
`StoryUpdateJob/executeArgumentError | wrong number of arguments (given 0, expected 1)`
think this should solve? 