### PR TITLE
Upgrade hal_api-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'rack-prx_auth', '~> 0.0.8'
 
 # Controller
 gem 'responders'
-gem 'hal_api-rails', '~> 0.2.9'
+gem 'hal_api-rails', '~> 0.3.3'
 
 # auth
 gem 'rack-cors', require: 'rack/cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,7 +131,7 @@ GEM
     guard-minitest (2.4.6)
       guard-compat (~> 1.2)
       minitest (>= 3.0)
-    hal_api-rails (0.2.9)
+    hal_api-rails (0.3.3)
       actionpack (>= 3.0.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -355,7 +355,7 @@ DEPENDENCIES
   guard
   guard-bundler
   guard-minitest
-  hal_api-rails (~> 0.2.9)
+  hal_api-rails (~> 0.3.3)
   highline
   hyperresource
   jbuilder (~> 2.0)

--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -56,8 +56,8 @@ class Api::EpisodesController < Api::BaseController
     visible
   end
 
-  def included(relation)
-    relation.with_deleted
+  def find_base
+    super.with_deleted
   end
 
   def process_media

--- a/app/controllers/api/podcasts_controller.rb
+++ b/app/controllers/api/podcasts_controller.rb
@@ -35,8 +35,8 @@ class Api::PodcastsController < Api::BaseController
 
   private
 
-  def included(relation)
-    relation.with_deleted
+  def find_base
+    super.with_deleted
   end
 
   def process_media

--- a/app/representers/api/paged_collection_representer.rb
+++ b/app/representers/api/paged_collection_representer.rb
@@ -1,66 +1,6 @@
 # encoding: utf-8
+require 'hal_api/representer/collection_paging'
 
 class Api::PagedCollectionRepresenter < Api::BaseRepresenter
-  property :count
-  property :total
-
-  embeds :items,
-    decorator: lambda { |*| item_decorator },
-    class: lambda { |*| item_class },
-    zoom: :always
-
-  link :prev do
-    href_url_helper(params.merge(page: represented.prev_page)) unless represented.first_page?
-  end
-
-  link :next do
-    href_url_helper(params.merge(page: represented.next_page)) unless represented.last_page?
-  end
-
-  link :first do
-    href_url_helper(params.merge(page: nil)) if represented.total_pages > 1
-  end
-
-  link :last do
-    href_url_helper(params.merge(page: represented.total_pages)) if represented.total_pages > 1
-  end
-
-  def params
-    represented.params
-  end
-
-  def self_url(represented)
-    href_url_helper(represented.params)
-  end
-
-  def profile_url(represented)
-    model_uri(:collection, represented.item_class)
-  end
-
-  # refactor to use single property, :url, that can be a method name, a string, or a lambda
-  # if it is a method name, execute against self - the representer - which has local url helpers methods
-  # if it is a sym/string, but self does not respond to it, then just use that string
-  # if it is a lambda, execute in the context against the represented.parent (if there is one) or represented
-  def href_url_helper(options={})
-    if represented_url.nil?
-      result = url_for(options.merge(only_path: true)) rescue nil
-      if represented.parent
-        result ||= polymorphic_path([:api, represented.parent, represented.item_class], options) rescue nil
-      end
-      result ||= polymorphic_path([:api, represented.item_class], options) rescue nil
-      return result
-    end
-
-    if represented_url.respond_to?(:call)
-      self.instance_exec(options, &represented_url)
-    elsif self.respond_to?(represented_url)
-      self.send(represented_url, options)
-    else
-      represented_url.to_s
-    end
-  end
-
-  def represented_url
-    @represented_url ||= represented.try(:url)
-  end
+  include HalApi::Representer::CollectionPaging
 end

--- a/config/initializers/hal_api.rb
+++ b/config/initializers/hal_api.rb
@@ -1,0 +1,1 @@
+HalApi::PagedCollection.representer_class = Api::PagedCollectionRepresenter

--- a/config/initializers/say_when.rb
+++ b/config/initializers/say_when.rb
@@ -16,14 +16,16 @@ SayWhen.configure do |options|
 end
 
 begin
-  SayWhen.schedule(
-    group: 'application',
-    name: 'release_episodes',
-    trigger_strategy: 'cron',
-    trigger_options: { expression: '0 0/5 * * * ?', time_zone: 'UTC' },
-    job_class: 'Episode',
-    job_method: 'release_episodes!'
-  )
+  unless Rails.env.test?
+    SayWhen.schedule(
+      group: 'application',
+      name: 'release_episodes',
+      trigger_strategy: 'cron',
+      trigger_options: { expression: '0 0/5 * * * ?', time_zone: 'UTC' },
+      job_class: 'Episode',
+      job_method: 'release_episodes!'
+    )
+  end
 rescue ActiveRecord::StatementInvalid => ex
   puts "Failed to init say_when job: #{ex.inspect}"
 end

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -12,7 +12,7 @@ feeder:
     DB_ENV_POSTGRES_PASSWORD: password
     AWS_REGION: us-east-1
 db:
-  image: postgres
+  image: postgres:9.4.15-alpine
   environment:
     POSTGRES_USER: feeder
     POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ worker:
     - db
   command: worker
 db:
-  image: postgres
+  image: postgres:9.4.15-alpine
   env_file:
     - .env
   expose:

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -44,8 +44,12 @@ describe Api::EpisodesController do
 
   it 'should list' do
     episode.id.wont_be_nil
+    episode_deleted.id.wont_be_nil
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
+    guids = JSON.parse(response.body)['_embedded']['prx:items'].map { |p| p['id'] }
+    guids.must_include(episode.guid)
+    guids.wont_include(episode_deleted.guid)
   end
 
   it 'should not list future published' do
@@ -63,9 +67,13 @@ describe Api::EpisodesController do
 
   it 'should list for podcast' do
     episode.id.wont_be_nil
+    episode_deleted.id.wont_be_nil
     podcast.id.wont_be_nil
     get(:index, { api_version: 'v1', format: 'json', podcast_id: podcast.id } )
     assert_response :success
+    guids = JSON.parse(response.body)['_embedded']['prx:items'].map { |p| p['id'] }
+    guids.must_include(episode.guid)
+    guids.wont_include(episode_deleted.guid)
   end
 
   describe 'with a valid token' do

--- a/test/controllers/api/podcasts_controller_test.rb
+++ b/test/controllers/api/podcasts_controller_test.rb
@@ -108,6 +108,12 @@ describe Api::PodcastsController do
     assert_response :success
   end
 
+  it 'should return resource gone for deleted resource' do
+    podcast_deleted.id.wont_be_nil
+    get(:show, { api_version: 'v1', format: 'json', id: podcast_deleted.id } )
+    assert_response 410
+  end
+
   it 'should list' do
     podcast_deleted.id.wont_be_nil
     podcast.id.wont_be_nil


### PR DESCRIPTION
Upgrade hal api gem, to get NewRelic error handling fixes.  Plus other minor-version fixes in the v0.3.x upgrade ... which were a bit more applicable to PRX/cms.prx.org#360 than here.