### PR TITLE
Episode feed-ready indicator

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -222,7 +222,7 @@ class Episode < BaseModel
   def media_ready?
     # if this episode has enclosores, media is ready if there is a complete one
     if !enclosures.blank?
-      enclosure
+      !!enclosure
     # if this episode has contents, ready when each position is ready
     elsif !all_contents.blank?
       max_pos = all_contents.map { |c| c.position }.max

--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -33,6 +33,7 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   property :block
   property :is_closed_captioned
   property :is_perma_link
+  property :include_in_feed?, as: :is_feed_ready
   property :duration
   property :keywords
   property :categories

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -19,6 +19,15 @@ describe Api::EpisodeRepresenter do
     json['itunesBlock'].must_equal false
   end
 
+  it 'indicates if the episode media is not ready' do
+    json['isFeedReady'].must_equal true
+  end
+
+  it 'indicates if the episode media is not ready' do
+    episode.enclosure.update_attributes(status: 'error')
+    json['isFeedReady'].must_equal false
+  end
+
   it 'uses summary when not blank' do
     episode.summary = 'summary has <a href="/">a link</a>'
     episode.description = '<b>tags</b> removed, <a href="/">links remain</a>'


### PR DESCRIPTION
Make it easier for publish to check if an episode is "complete".  Include a `is_feed_ready` boolean attribute, using Feeder's own logic of when an episode is ready to go in the feed.