### PR TITLE
Fix episode update endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -108,6 +108,7 @@ end
 group :test do
   # Add rspec behaviour to minitest
   gem 'minitest-spec-rails'
+  gem 'minitest-around'
 
   # factory_girl provides a DSL for defining and using factories
   gem 'factory_girl_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,8 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
+    minitest-around (0.5.0)
+      minitest (~> 5.0)
     minitest-spec-rails (5.4.0)
       minitest (~> 5.0)
       rails (>= 4.1)
@@ -358,6 +360,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   json-jwt
   kaminari
+  minitest-around
   minitest-spec-rails
   newrelic_rpm
   nokogiri

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -264,6 +264,7 @@ class Episode < BaseModel
 
   def update_contents(files)
     ignore = [:id, :type, :episode_id, :guid, :position, :status, :created_at, :updated_at]
+    ignore_nil = [:mime_type, :file_size, :duration]
     files.each_with_index do |f, index|
       file = f.attributes.with_indifferent_access.except(*ignore)
       file[:position] = index + 1
@@ -271,6 +272,7 @@ class Episode < BaseModel
 
       # If there is an existing file with the same url, update
       if existing_content
+        ignore_nil.each { |k| file[k] = existing_content[k] if file[k].nil? }
         existing_content.update_attributes(file)
       # Otherwise, make a new content to be or replace content for that position
       # If there is no file, or the file has a different url

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -139,11 +139,12 @@ describe Api::EpisodesController do
       put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
-      episode_update.reload.all_contents.size.must_equal 1
-      episode_update.all_contents.first.mime_type.must_equal 'audio/mpeg'
-      episode_update.all_contents.first.file_size.must_equal 123456
-      episode_update.all_contents.first.duration.to_s.must_equal '1234.5678'
-      guid1 = episode_update.all_contents.first.guid
+      contents = episode_update.reload.all_contents
+      contents.size.must_equal 1
+      contents.first.mime_type.must_equal 'audio/mpeg'
+      contents.first.file_size.must_equal 123456
+      contents.first.duration.to_s.must_equal '1234.5678'
+      guid1 = contents.first.guid
 
 
       # updating with a dupe should not insert it
@@ -151,31 +152,44 @@ describe Api::EpisodesController do
       put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
-      episode_update.reload.all_contents.size.must_equal 1
-      episode_update.all_contents.first.mime_type.must_equal 'audio/mpeg'
-      episode_update.all_contents.first.file_size.must_equal 123456
-      episode_update.all_contents.first.duration.to_s.must_equal '1234.5678'
-      episode_update.all_contents.first.guid.must_equal guid1
+      contents = episode_update.reload.all_contents
+      contents.size.must_equal 1
+      contents.first.mime_type.must_equal 'audio/mpeg'
+      contents.first.file_size.must_equal 123456
+      contents.first.duration.to_s.must_equal '1234.5678'
+      contents.first.guid.must_equal guid1
 
       # updating with a different url but with matching path and filename won't insert
       update_hash = { media: [{ href: 'https://s3.amazonaws.com/prx-testing/this.is.different/test/change1.mp3' }] }
       put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
-      episode_update.reload.all_contents.size.must_equal 1
-      episode_update.all_contents.first.mime_type.must_equal 'audio/mpeg'
-      episode_update.all_contents.first.file_size.must_equal 123456
-      episode_update.all_contents.first.duration.to_s.must_equal '1234.5678'
-      episode_update.all_contents.first.guid.must_equal guid1
+      contents = episode_update.reload.all_contents
+      contents.size.must_equal 1
+      contents.first.mime_type.must_equal 'audio/mpeg'
+      contents.first.file_size.must_equal 123456
+      contents.first.duration.to_s.must_equal '1234.5678'
+      contents.first.guid.must_equal guid1
 
       # updating with a different path should insert it, with same position value of 1
       update_hash = { media: [{ href: 'https://s3.amazonaws.com/prx-testing/testing/change1.mp3' }] }
       put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
-      episode_update.reload.all_contents.size.must_equal 2
-      episode_update.all_contents.first.position.must_equal 1
-      episode_update.all_contents.last.position.must_equal 1
+      contents = episode_update.reload.all_contents
+      contents.size.must_equal 2
+
+      contents.first.guid.wont_equal guid1
+      contents.first.position.must_equal 1
+      contents.first.mime_type.must_be_nil
+      contents.first.file_size.must_be_nil
+      contents.first.duration.must_be_nil
+
+      contents.last.guid.must_equal guid1
+      contents.last.position.must_equal 1
+      contents.last.mime_type.must_equal 'audio/mpeg'
+      contents.last.file_size.must_equal 123456
+      contents.last.duration.to_s.must_equal '1234.5678'
     end
   end
 end

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -83,11 +83,15 @@ describe Api::EpisodesController do
     let(:episode_update) { create(:episode, podcast: podcast, published_at: nil) }
     let(:token) { StubToken.new(account_id, ['member']) }
 
-    before do
+    around do |test|
       class << @controller; attr_accessor :prx_auth_token; end
       @controller.prx_auth_token = token
       @request.env['CONTENT_TYPE'] = 'application/json'
+      @controller.stub(:publish, true) do
+        @controller.stub(:process_media, true) { test.call }
+      end
     end
+
 
     it 'should redirect for authorized request of unpublished resource' do
       episode_redirect.id.wont_be_nil
@@ -96,11 +100,7 @@ describe Api::EpisodesController do
     end
 
     it 'can create a new episode' do
-      @controller.stub(:publish, true) do
-        @controller.stub(:process_media, true) do
-          post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
-        end
-      end
+      post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
       assert_response :success
       id = JSON.parse(response.body)['id']
       new_episode = Episode.find_by_guid(id)
@@ -113,11 +113,7 @@ describe Api::EpisodesController do
 
     it 'can update on create of a new episode' do
       ep = create(:episode, published_at: (Time.now + 1.week), podcast: podcast, prx_uri: '/api/v1/stories/123')
-      @controller.stub(:publish, true) do
-        @controller.stub(:process_media, true) do
-          post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
-        end
-      end
+      post :create, episode_hash.to_json, api_version: 'v1', format: 'json', podcast_id: podcast.id
       assert_response :success
       id = JSON.parse(response.body)['id']
       new_episode = Episode.find_by_guid(id)
@@ -133,43 +129,27 @@ describe Api::EpisodesController do
 
       episode_update.all_contents.size.must_equal 0
 
-      @controller.stub(:publish, true) do
-        @controller.stub(:process_media, true) do
-          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
-        end
-      end
+      put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
       episode_update.reload.all_contents.size.must_equal 1
 
       # updating with a dupe should not insert it
-      @controller.stub(:publish, true) do
-        @controller.stub(:process_media, true) do
-          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
-        end
-      end
+      put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
       episode_update.reload.all_contents.size.must_equal 1
 
       # updating with a different url but with matching path and filename won't insert
       update_hash = { media: [{ href: 'https://s3.amazonaws.com/prx-testing/this.is.different/test/change1.mp3' }] }
-      @controller.stub(:publish, true) do
-        @controller.stub(:process_media, true) do
-          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
-        end
-      end
+      put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
       episode_update.reload.all_contents.size.must_equal 1
 
       # updating with a different path should insert it, with same position value of 1
       update_hash = { media: [{ href: 'https://s3.amazonaws.com/prx-testing/testing/change1.mp3' }] }
-      @controller.stub(:publish, true) do
-        @controller.stub(:process_media, true) do
-          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
-        end
-      end
+      put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
       episode_update.reload.all_contents.size.must_equal 2


### PR DESCRIPTION
If you PUT an episode with _the same_ media hrefs, the update will be ignored.  But it did attempt to update the other `Content` fields - which would result in a bunch of fields being nulled out.  And no `CopyMediaTask` is created to get them re-updated, since the underlying file didn't change.

The result would be nulled-out `:mime_type / :file_size / :duration` on the Content, which made Dovetail angry.

This PR ignores null-updates to the `type / size / duration` fields.  Even if you explicitly PUT a `media: [{href: "href1", type: null}]`, it will refuse to null them out.

I was very explicit in targeting those 3 fields, as they're in the `MediaResourceRepresenter`.  So even though the `Episode.update_contents` allows all sorts of other fields through, the representer will not.