### PR TITLE
API media updates

### DIFF
--- a/test/controllers/api/auth/episodes_controller_test.rb
+++ b/test/controllers/api/auth/episodes_controller_test.rb
@@ -120,19 +120,7 @@ describe Api::Auth::EpisodesController do
 
       episode_update.reload.all_contents.size.must_equal 1
 
-      # updating with a dupe should not insert it
-      @controller.stub(:publish, true) do
-        @controller.stub(:process_media, true) do
-          put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
-        end
-      end
-      assert_response :success
-
-      episode_update.reload.all_contents.size.must_equal 1
-
-      update_hash = { media: [{ href: 'https://s3.amazonaws.com/prx-testing/test/change2.mp3' }] }
-
-      # updating with a different url should insert it, with same position value of 1
+      # updating with a dupe should insert it, with the same position value of 1
       @controller.stub(:publish, true) do
         @controller.stub(:process_media, true) do
           put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'

--- a/test/factories/media_resource_factory.rb
+++ b/test/factories/media_resource_factory.rb
@@ -10,7 +10,7 @@ FactoryGirl.define do
     channels 2
     duration 48
     bit_rate 64
-    original_url 'audio.mp3'
+    original_url 's3://prx-testing/test/audio.mp3'
     status 'created'
 
     after(:create) do |media_resource, evaluator|


### PR DESCRIPTION
For #311.

When setting `{ media: [] }` through an API create/update, always append new Contents instead of looking for existing.  This ensures that any media change coming through the API always reprocesses the files.

This _will_ result in some churn in the resulting mp3 urls, and thus the dovetail arrangement digests/urls.  So definitely don't want anyone automating a bunch of non-change PUTs to the episode media.  But I don't _think_ anyone is doing that right now anyways.  Should only PUT `media:[]` if it's actually changed.