### PR TITLE
Add `explicit_content` attribute

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 4.2.0'
-gem 'rails-html-sanitizer', '~> 1.0.4'
+gem 'rails-html-sanitizer', '~> 1.3.0'
 
 # JWS
 gem 'prx_auth-rails', '~> 0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.3.1)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.10)
@@ -191,7 +191,7 @@ GEM
     multipart-post (2.0.0)
     nenv (0.3.0)
     newrelic_rpm (5.2.0.345)
-    nokogiri (1.10.4)
+    nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -252,8 +252,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -380,7 +380,7 @@ DEPENDENCIES
   rack-cors
   rack-prx_auth (~> 0.1.0)
   rails (~> 4.2.0)
-  rails-html-sanitizer (~> 1.0.4)
+  rails-html-sanitizer (~> 1.3.0)
   rails_12factor
   rake
   responders
@@ -397,4 +397,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -103,6 +103,18 @@ class Episode < BaseModel
     self[:guid]
   end
 
+  def explicit_content
+    e = (explicit.blank? && podcast) ? podcast.explicit : explicit
+    e = e.to_s.downcase.strip
+    if ["clean", "no", "false", "f"].include?(e)
+      false
+    elsif ["explicit", "yes", "true", "t"].include?(e)
+      true
+    else
+      nil
+    end
+  end
+
   def item_guid
     original_guid || "prx_#{podcast_id}_#{guid}"
   end

--- a/app/representers/api/episode_representer.rb
+++ b/app/representers/api/episode_representer.rb
@@ -6,6 +6,9 @@ class Api::EpisodeRepresenter < Api::BaseRepresenter
   property :created_at, writable: false
   property :updated_at, writable: false
 
+  # based on the podcast explicit and the episode explicit values: true, false, and nil
+  property :explicit_content, writeable: false
+
   # the guid that shows up in the rss feed
   # based on id by default, if updated, can be set to anything
   property :item_guid, as: :guid

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -187,6 +187,40 @@ describe Episode do
     episode.find_existing_content(2, 's3://prx-testing/test/audio.mp3').must_be_nil
   end
 
+  it 'returns explicit_content based on the podcast' do
+    podcast = episode.podcast
+    episode.explicit = nil
+
+    ["explicit", "yes", true].each do |val|
+      podcast.explicit = val
+      episode.explicit_content.must_equal true
+    end
+
+    ["clean", "no", false].each do |val|
+      podcast.explicit = val
+      episode.explicit_content.must_equal false
+    end
+
+    podcast.explicit = nil
+    episode.explicit_content.must_be_nil
+  end
+
+  it 'returns explicit_content overriden by the episode' do
+    podcast = episode.podcast
+
+    podcast.explicit = false
+    ["explicit", "yes", true].each do |val|
+      episode.explicit = val
+      episode.explicit_content.must_equal true
+    end
+
+    podcast.explicit = true
+    ["clean", "no", false].each do |val|
+      episode.explicit = val
+      episode.explicit_content.must_equal false
+    end
+  end
+
   describe 'release episodes' do
 
     let(:podcast) { episode.podcast }

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -23,10 +23,16 @@ describe Api::EpisodeRepresenter do
     json['isFeedReady'].must_equal true
   end
 
-  it 'includes an explicit_content value' do
+  it 'includes an explicit_content value from the podcast' do
     episode.explicit.must_be_nil
     episode.podcast.must_be :explicit
     json['explicitContent'].must_equal true
+  end
+
+  it 'nil explicit_content left out of the json' do
+    episode.explicit = nil
+    episode.podcast.explicit = nil
+    json.key?('explicitContent').must_equal false
   end
 
   it 'indicates if the episode media is not ready' do

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -23,6 +23,12 @@ describe Api::EpisodeRepresenter do
     json['isFeedReady'].must_equal true
   end
 
+  it 'includes an explicit_content value' do
+    episode.explicit.must_be_nil
+    episode.podcast.must_be :explicit
+    json['explicitContent'].must_equal true
+  end
+
   it 'indicates if the episode media is not ready' do
     episode.enclosure.update_attributes(status: 'error')
     json['isFeedReady'].must_equal false


### PR DESCRIPTION
Needed for https://github.com/PRX/dovetail.prx.org/issues/344

This PR adds an `explicit_content` read-only attribute to episode which is
`true` if the podcast is explicit and the episode doesn't specify, or the episode is explicit
`false` if the podcast is clean and the episode doesn't specify, or the episode is clean
otherwise `nil`

This can then be used in DT to target clean only, or avoid explicit episodes