### PR TITLE
Prevent N+1 via includes only on index

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -12,7 +12,11 @@ class Api::EpisodesController < Api::BaseController
   after_action :publish, only: [:create, :update, :destroy]
 
   def included(relation)
-    relation.includes(:podcast, :images, :all_contents, :contents, :enclosures)
+    if action_name == 'index'
+      relation.includes(:podcast, :images, :all_contents, :contents, :enclosures)
+    else
+      relation
+    end
   end
 
   def create


### PR DESCRIPTION
I recently added a bunch of `included` to speed up index queries.  But apparently it's slightly slowing down show queries ... which is 99% of the traffic coming from Dovetail.

Revert that, only for show.