### PR TITLE
Fill in and fix some authorized links

### DIFF
--- a/app/controllers/api/auth/episodes_controller.rb
+++ b/app/controllers/api/auth/episodes_controller.rb
@@ -5,7 +5,7 @@ class Api::Auth::EpisodesController < Api::EpisodesController
   include ApiUpdatedSince
 
   api_versions :v1
-  represent_with Api::EpisodeRepresenter
+  represent_with Api::Auth::EpisodeRepresenter
   filter_resources_by :podcast_id
   find_method :find_by_guid
 

--- a/app/controllers/api/auth/podcasts_controller.rb
+++ b/app/controllers/api/auth/podcasts_controller.rb
@@ -5,7 +5,7 @@ class Api::Auth::PodcastsController < Api::PodcastsController
   include ApiUpdatedSince
 
   api_versions :v1
-  represent_with Api::PodcastRepresenter
+  represent_with Api::Auth::PodcastRepresenter
   filter_resources_by :prx_account_uri
 
   def visible?

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -50,4 +50,13 @@ class Api::ApiRepresenter < Api::BaseRepresenter
       }
     ]
   end
+
+  link :authorization do
+    {
+      title: 'Get information about the active authorization for this request',
+      profile: 'http://meta.prx.org/model/user',
+      href: api_authorization_path,
+      templated: false
+    }
+  end
 end

--- a/app/representers/api/auth/episode_representer.rb
+++ b/app/representers/api/auth/episode_representer.rb
@@ -1,0 +1,5 @@
+class Api::Auth::EpisodeRepresenter < Api::EpisodeRepresenter
+  def self_url(episode)
+    api_authorization_episode_path(id: episode.guid)
+  end
+end

--- a/app/representers/api/auth/podcast_representer.rb
+++ b/app/representers/api/auth/podcast_representer.rb
@@ -1,0 +1,14 @@
+class Api::Auth::PodcastRepresenter < Api::PodcastRepresenter
+  def self_url(podcast)
+    api_authorization_podcast_path(podcast)
+  end
+
+  # point to authorized episodes (including unpublished)
+  link :episodes do
+    {
+      href: api_authorization_podcast_episodes_path(represented) + '{?page,per,zoom,since}',
+      count: represented.episodes.count,
+      templated: true
+    } if represented.id
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
       resource :authorization, only: [:show] do
         resources :podcasts, except: [:new, :edit], module: :auth do
-          resources :episodes, except: [:new, :edit], module: :auth
+          resources :episodes, except: [:new, :edit]
         end
 
         resources :episodes, except: [:new, :edit], module: :auth

--- a/test/representers/api/api_representer_test.rb
+++ b/test/representers/api/api_representer_test.rb
@@ -24,5 +24,6 @@ describe Api::ApiRepresenter do
     json['_links']['prx:episodes'].size.must_equal 1
     json['_links']['prx:podcast'].size.must_equal 1
     json['_links']['prx:podcasts'].size.must_equal 1
+    json['_links']['prx:authorization'].must_be_instance_of Hash
   end
 end

--- a/test/representers/api/auth/episode_representer_test.rb
+++ b/test/representers/api/auth/episode_representer_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+describe Api::Auth::EpisodeRepresenter do
+
+  let(:episode) { create(:episode) }
+  let(:representer) { Api::Auth::EpisodeRepresenter.new(episode) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'has authorized links' do
+    json['_links']['self']['href'].must_equal "/api/v1/authorization/episodes/#{episode.guid}"
+  end
+end

--- a/test/representers/api/auth/podcast_representer_test.rb
+++ b/test/representers/api/auth/podcast_representer_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+describe Api::Auth::PodcastRepresenter do
+
+  let(:podcast) { create(:podcast) }
+  let(:representer) { Api::Auth::PodcastRepresenter.new(podcast) }
+  let(:json) { JSON.parse(representer.to_json) }
+
+  it 'has authorized links' do
+    json['_links']['self']['href'].must_equal "/api/v1/authorization/podcasts/#{podcast.id}"
+    json['_links']['prx:episodes']['href'].must_match "/api/v1/authorization/podcasts/#{podcast.id}/episodes"
+  end
+end


### PR DESCRIPTION
Missing some links:

- [x] Adds `prx:authorization` link to the API root.
- [x] Fix the authorization podcast/episode self urls to stay under `/api/v1/authorization`
- [x] Keep the authorization podcast `prx:episodes` link under `/api/v1/authorization`
- [x] The `/api/v1/authorization/podcasts/1234/episodes` routes were broken