### PR TITLE
Scope-based policies

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -27,7 +27,7 @@ class Authorization
   end
 
   def token_auth_account_ids
-    token.resources
+    token.resources(:read_private)
   end
 
   def token_auth_account_uris

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -80,6 +80,18 @@ class Episode < BaseModel
     !published_at.nil? && published_at <= Time.now
   end
 
+  def draft?
+    published_at.nil?
+  end
+
+  def was_draft?
+    if published_at_changed?
+      published_at_was.nil?
+    else
+      draft?
+    end
+  end
+
   def author=(a)
     author = a || {}
     self.author_name = author['name']

--- a/app/policies/episode_policy.rb
+++ b/app/policies/episode_policy.rb
@@ -1,10 +1,11 @@
 class EpisodePolicy < ApplicationPolicy
   def create?
-    token && token.authorized?(account_id)
+    update?
   end
 
   def update?
-    token && token.authorized?(account_id)
+    token&.authorized?(account_id, :episode) ||
+      ( token&.authorized?(account_id, :episode_draft) && resource.draft? && resource.was_draft? )
   end
 
   def destroy?

--- a/app/policies/podcast_policy.rb
+++ b/app/policies/podcast_policy.rb
@@ -1,14 +1,14 @@
 class PodcastPolicy < ApplicationPolicy
   def create?
-    token && token.authorized?(account_id)
+    token&.authorized?(account_id, :podcast_create)
   end
 
   def update?
-    token && token.authorized?(account_id)
+    token&.authorized?(account_id, :podcast_edit)
   end
 
   def destroy?
-    token && token.authorized?(account_id, :admin)
+    token&.authorized?(account_id, :podcast_delete)
   end
 
   def account_id

--- a/config/initializers/prx_auth.rb
+++ b/config/initializers/prx_auth.rb
@@ -2,4 +2,5 @@ require 'prx_auth/rails'
 
 PrxAuth::Rails.configure do |config|
   config.install_middleware = ENV['ID_HOST'].blank?
+  config.namespace = :feeder
 end

--- a/test/controllers/api/auth/episodes_controller_test.rb
+++ b/test/controllers/api/auth/episodes_controller_test.rb
@@ -3,7 +3,9 @@ require 'test_helper'
 describe Api::Auth::EpisodesController do
   let(:account_id) { 123 }
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }
-  let(:token) { StubToken.new(account_id, ['member']) }
+  let(:member_token) { StubToken.new(account_id, ['member feeder:read-private feeder:podcast-edit feeder:podcast-create feeder:episode feeder:episode-draft']) }
+  let(:limited_token) { StubToken.new(account_id, ['member feeder:read-private']) }
+  let(:admin_token) { StubToken.new(account_id, ['admin feeder:read-private feeder:podcast-edit feeder:podcast-create feeder:episode feeder:episode-draft']) }
   let(:episode) { create(:episode, podcast: podcast) }
 
   let(:different_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", path: 'diff') }
@@ -25,7 +27,7 @@ describe Api::Auth::EpisodesController do
 
   before do
     class << @controller; attr_accessor :prx_auth_token; end
-    @controller.prx_auth_token = token
+    @controller.prx_auth_token = member_token
     @request.env['CONTENT_TYPE'] = 'application/json'
   end
 
@@ -83,11 +85,10 @@ describe Api::Auth::EpisodesController do
     let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }
     let(:episode_redirect) { create(:episode, podcast: podcast, published_at: nil) }
     let(:episode_update) { create(:episode, podcast: podcast, published_at: nil) }
-    let(:token) { StubToken.new(account_id, ['member']) }
 
     before do
       class << @controller; attr_accessor :prx_auth_token; end
-      @controller.prx_auth_token = token
+      @controller.prx_auth_token = member_token
       @request.env['CONTENT_TYPE'] = 'application/json'
     end
 
@@ -137,7 +138,7 @@ describe Api::Auth::EpisodesController do
   end
 
   describe 'with wildcard token' do
-    let (:token) { StubToken.new('*', ['read-private']) }
+    let (:member_token) { StubToken.new('*', ['feeder:read-private']) }
     let (:other_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id + 1}", path: 'foo') }
     let (:other_unpublished_episode) { create(:episode, podcast: other_podcast, published_at: nil) }
 

--- a/test/controllers/api/auth/podcasts_controller_test.rb
+++ b/test/controllers/api/auth/podcasts_controller_test.rb
@@ -5,7 +5,7 @@ describe Api::Auth::PodcastsController do
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", published_at: nil) }
   let(:published_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", path: 'pod2') }
   let(:other_account_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/9876", path: 'pod3') }
-  let(:token) { StubToken.new(account_id, ['member']) }
+  let(:token) { StubToken.new(account_id, ['feeder:read-private']) }
 
   before do
     class << @controller; attr_accessor :prx_auth_token; end

--- a/test/controllers/api/authorizations_controller_test.rb
+++ b/test/controllers/api/authorizations_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::AuthorizationsController do
 
   let(:account_id) { '123' }
-  let(:token) { StubToken.new(account_id, ['member']) }
+  let(:token) { StubToken.new(account_id, ['feeder:read-private']) }
 
   it 'shows the user with a valid token' do
     @controller.stub(:prx_auth_token, token) do

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -81,7 +81,7 @@ describe Api::EpisodesController do
     let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }
     let(:episode_redirect) { create(:episode, podcast: podcast, published_at: nil) }
     let(:episode_update) { create(:episode, podcast: podcast, published_at: nil) }
-    let(:token) { StubToken.new(account_id, ['member']) }
+    let(:token) { StubToken.new(account_id, ['member feeder:read-private feeder:podcast-edit feeder:podcast-create feeder:episode feeder:episode-draft']) }
 
     around do |test|
       class << @controller; attr_accessor :prx_auth_token; end

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Authorization do
   let(:account_id) { '123' }
-  let(:token) { StubToken.new(account_id, ['member'], 456) }
+  let(:token) { StubToken.new(account_id, ['feeder:read-private'], 456) }
   let(:authorization) { Authorization.new(token) }
   let(:podcast1) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", path: 'pod1') }
   let(:podcast2) { create(:podcast, prx_account_uri: "/api/v1/accounts/987", path: 'pod2') }
@@ -14,7 +14,6 @@ describe Authorization do
   it 'has a user_id' do
     authorization.user_id.must_equal 456
   end
-
 
   it 'has a token' do
     authorization.token.wont_be_nil

--- a/test/policies/episode_policy_test.rb
+++ b/test/policies/episode_policy_test.rb
@@ -2,10 +2,12 @@ require 'test_helper'
 
 describe EpisodePolicy do
   let(:account_id) { 123 }
-  let(:non_member_token) { StubToken.new(account_id + 1, ['no']) }
-  let(:member_token) { StubToken.new(account_id, ['member']) }
   let(:podcast) { build_stubbed(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}")}
   let(:episode) { build_stubbed(:episode, podcast: podcast)}
+
+  def token(scopes, set_account_id=account_id)
+    StubToken.new(set_account_id, scopes)
+  end
 
   describe '#update?' do
     it 'returns false if token is not present' do
@@ -13,11 +15,11 @@ describe EpisodePolicy do
     end
 
     it 'returns false if token is not a member of the account' do
-      EpisodePolicy.new(non_member_token, episode).wont_allow :update?
+      EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).wont_allow :update?
     end
 
     it 'returns true if token is a member of the account' do
-      EpisodePolicy.new(member_token, episode).must_allow :update?
+      EpisodePolicy.new(token('feeder:episode'), episode).must_allow :update?
     end
   end
 end

--- a/test/policies/episode_policy_test.rb
+++ b/test/policies/episode_policy_test.rb
@@ -9,17 +9,53 @@ describe EpisodePolicy do
     StubToken.new(set_account_id, scopes)
   end
 
-  describe '#update?' do
+  describe '#update? and #create?' do
     it 'returns false if token is not present' do
       EpisodePolicy.new(nil, episode).wont_allow :update?
     end
 
     it 'returns false if token is not a member of the account' do
       EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).wont_allow :update?
+      EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).wont_allow :create?
     end
 
     it 'returns true if token is a member of the account' do
       EpisodePolicy.new(token('feeder:episode'), episode).must_allow :update?
+      EpisodePolicy.new(token('feeder:episode'), episode).must_allow :create?
+    end
+
+    it 'returns false if the token lacks the episode scope' do
+      EpisodePolicy.new(token('feeder:read-private'), episode).wont_allow :update?
+      EpisodePolicy.new(token('feeder:read-private'), episode).wont_allow :create?
+    end
+  end
+
+  describe 'with a draft only token' do
+    let (:draft_token) { token('feeder:episode-draft') }
+
+    it 'allows creating a new draft epsiode' do
+      episode = build(:episode, published_at: nil, podcast: build(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}"))
+      assert EpisodePolicy.new(draft_token, episode).create?
+    end
+
+    it 'allows editing an existing draft episode' do
+      episode = create(:episode, published_at: nil, podcast: podcast)
+
+      episode.title = 'changed!'
+      assert EpisodePolicy.new(draft_token, episode).update?
+    end
+
+    it 'does not allow creating a non-draft episode' do
+      episode.published_at = 2.days.ago
+
+      refute EpisodePolicy.new(draft_token, episode).create?
+    end
+
+    it 'does not allow editing a published episode (even to make it a draft)' do
+      episode = create(:episode, published_at: 5.days.from_now, podcast: create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}"))
+
+      episode.published_at = nil
+      refute EpisodePolicy.new(draft_token, episode).update?
     end
   end
 end

--- a/test/policies/podcast_policy_test.rb
+++ b/test/policies/podcast_policy_test.rb
@@ -2,9 +2,11 @@ require 'test_helper'
 
 describe PodcastPolicy do
   let(:account_id) { 123 }
-  let(:non_member_token) { StubToken.new(account_id + 1, ['no']) }
-  let(:member_token) { StubToken.new(account_id, ['member']) }
   let(:podcast) { build_stubbed(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}")}
+
+  def token(scopes, set_account_id=account_id)
+    StubToken.new(set_account_id, scopes)
+  end
 
   describe '#update?' do
     it 'returns false if token is not present' do
@@ -12,11 +14,51 @@ describe PodcastPolicy do
     end
 
     it 'returns false if token is not a member of the account' do
-      PodcastPolicy.new(non_member_token, podcast).wont_allow :update?
+      PodcastPolicy.new(token('feeder:podcast-edit', account_id + 1), podcast).wont_allow :update?
     end
 
-    it 'returns true if token is a member of the account' do
-      PodcastPolicy.new(member_token, podcast).must_allow :update?
+    it 'returns true if token is a member of the account and has edit scope' do
+      PodcastPolicy.new(token('feeder:podcast-edit'), podcast).must_allow :update?
+    end
+
+    it 'returns false if token lacks edit scope' do
+      PodcastPolicy.new(token('feeder:podcast-create feeder:podcast-delete'), podcast).wont_allow :update?
+    end
+  end
+
+  describe '#create?' do
+    it 'returns false if token is not present' do
+      PodcastPolicy.new(nil, podcast).wont_allow :create?
+    end
+
+    it 'returns false if token is not a member of the account' do
+      PodcastPolicy.new(token('feeder:podcast-create', account_id + 1), podcast).wont_allow :create?
+    end
+
+    it 'returns true if token is a member of the account and has create scope' do
+      PodcastPolicy.new(token('feeder:podcast-create'), podcast).must_allow :create?
+    end
+
+    it 'returns false if token lacks create scope' do
+      PodcastPolicy.new(token('feeder:podcast-edit feeder:podcast-delete'), podcast).wont_allow :create?
+    end
+  end
+
+  describe '#destroy?' do
+    it 'returns false if token is not present' do
+      PodcastPolicy.new(nil, podcast).wont_allow :destroy?
+    end
+
+    it 'returns false if token is not a member of the account' do
+      PodcastPolicy.new(token('feeder:podcast-delete', account_id + 1), podcast).wont_allow :destroy?
+    end
+
+    it 'returns true if token is a member of the account and has create scope' do
+      PodcastPolicy.new(token('feeder:podcast-delete'), podcast).must_allow :destroy?
+    end
+
+    it 'returns false if token lacks destroy scope' do
+      PodcastPolicy.new(token('feeder:podcast-create feeder:podcast-edit'), podcast).wont_allow :destroy?
     end
   end
 end

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Api::AuthorizationRepresenter do
 
   let(:account_id) { '123' }
-  let(:token) { StubToken.new(account_id, ['member'], 456) }
+  let(:token) { StubToken.new(account_id, ['feeder:read-private'], 456) }
   let(:authorization) { Authorization.new(token) }
   let(:representer) { Api::AuthorizationRepresenter.new(authorization) }
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }


### PR DESCRIPTION
This is the first PR that is ready for review to start using the new scope-based tokens for checking permissions.

There are a couple of potential issues I want to flag: first, I have left things requiring the `admin` meta-scope to allow deleting episodes. That's because the existing behavior only allowed admins to delete episodes, but we didn't have a real scope that seemed to fit that case. I think this is at best a stopgap and we should plan to retire that scope and determine what we want to do going forward (personally, I think you can do as much damage editing an episode as deleting it but maybe I don't know everything going on here...)

Second, this is the introduction of draft semantics and they may not work as you initially assume, so probably good to really make sure you're following how it works.

I guess last, I assume that the Authorization model is really only used for reads (that's how it looks to me, and I dug pretty deep) but if there's somewhere that it's being used to further constrain writes (e.g. building models based on the scopes here) then obviously we might run into problems when someone has write access without read access. That feels pretty contrived.