### PR TITLE
Update default feed webMaster value

### DIFF
--- a/config/initializers/config_env.rb
+++ b/config/initializers/config_env.rb
@@ -7,7 +7,7 @@ ENV['META_HOST']   ||= 'meta.prx.org'
 ENV['PRX_HOST']    ||= 'www.prx.org'
 
 # default env vars that may not be set
-ENV['FEEDER_WEB_MASTER'] ||= 'prxhelp@prx.org (PRX)'
+ENV['FEEDER_WEB_MASTER'] ||= 'help@prx.org (PRX)'
 ENV['FEEDER_GENERATOR'] ||= "PRX Feeder v#{Feeder::VERSION}"
 
 env_suffix = Rails.env.production? ? '' : ('-' + Rails.env)

--- a/env-example
+++ b/env-example
@@ -23,7 +23,7 @@ FEEDER_HOST=feeder.prx.docker
 # FEEDER_RELEASE_CHECK_DELAY=
 # defaults to prx-feed in production, otherwise {env}-prx-feed
 # FEEDER_STORAGE_BUCKET=
-# defaults to 'prxhelp@prx.org (PRX)'
+# defaults to 'help@prx.org (PRX)'
 # FEEDER_WEB_MASTER=
 FIXER_CALLBACK_QUEUE=development_feeder_fixer_callback
 ID_HOST=id-staging.prx.tech


### PR DESCRIPTION
Closes #365

This value is not defined in aws-secrets for production, so the default change will apply.