### PR TITLE
Fix minitest 6 deprecations

### DIFF
--- a/test/controllers/api/auth/episodes_controller_test.rb
+++ b/test/controllers/api/auth/episodes_controller_test.rb
@@ -32,52 +32,52 @@ describe Api::Auth::EpisodesController do
   end
 
   it 'should show the unpublished episode' do
-    episode_unpublished.id.wont_be_nil
-    episode_unpublished.published_at.must_be_nil
+    refute_nil episode_unpublished.id
+    assert_nil episode_unpublished.published_at
     get(:show, { api_version: 'v1', format: 'json', id: episode_unpublished.guid } )
     assert_response :success
   end
 
   it 'should show' do
-    episode.id.wont_be_nil
+    refute_nil episode.id
     get(:show, { api_version: 'v1', format: 'json', id: episode.guid } )
     assert_response :success
   end
 
   it 'should return resource gone for deleted resource' do
-    episode_deleted.id.wont_be_nil
+    refute_nil episode_deleted.id
     get(:show, { api_version: 'v1', format: 'json', id: episode_deleted.guid } )
     assert_response 410
   end
 
   it 'should return not found for unknown resource' do
-    episode_deleted.id.wont_be_nil
+    refute_nil episode_deleted.id
     get(:show, { api_version: 'v1', format: 'json', id: 'thisismadeup' } )
     assert_response 404
   end
 
   it 'should list' do
-    episode.id.wont_be_nil
-    episode_unpublished.id.wont_be_nil
-    episode_unpublished.published_at.must_be_nil
+    refute_nil episode.id
+    refute_nil episode_unpublished.id
+    assert_nil episode_unpublished.published_at
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
     list = JSON.parse(response.body)
     ids = list.dig('_embedded', 'prx:items').map{ |i| i['id'] }
-    ids.must_include(episode.guid)
-    ids.must_include(episode_unpublished.guid)
+    assert_includes ids, episode.guid
+    assert_includes ids, episode_unpublished.guid
   end
 
   it 'should list for podcast' do
-    episode.id.wont_be_nil
-    podcast.id.wont_be_nil
-    episode_different_podcast.id.wont_be_nil
+    refute_nil episode.id
+    refute_nil podcast.id
+    refute_nil episode_different_podcast.id
     get(:index, { api_version: 'v1', format: 'json', podcast_id: podcast.id } )
     assert_response :success
     body = JSON.parse(response.body)
     ids = body['_embedded']['prx:items'].map { |s| s['id'] }
-    ids.count.must_equal 1
-    ids.wont_include episode_different_podcast.guid
+    assert_equal ids.count, 1
+    refute_includes ids, episode_different_podcast.guid
   end
 
   describe 'with a valid token' do
@@ -101,18 +101,18 @@ describe Api::Auth::EpisodesController do
       assert_response :success
       id = JSON.parse(response.body)['id']
       new_episode = Episode.find_by_guid(id)
-      new_episode.released_at.must_equal Time.parse(episode_hash[:releasedAt])
-      new_episode.prx_uri.must_equal '/api/v1/stories/123'
-      new_episode.enclosures.count.must_equal 0
-      new_episode.all_contents.count.must_equal 3
+      assert_equal new_episode.released_at, Time.parse(episode_hash[:releasedAt])
+      assert_equal new_episode.prx_uri, '/api/v1/stories/123'
+      assert_equal new_episode.enclosures.count, 0
+      assert_equal new_episode.all_contents.count, 3
       c = new_episode.all_contents.first
-      c.original_url.must_equal 'https://s3.amazonaws.com/prx-testing/test/audio1.mp3'
+      assert_equal c.original_url, 'https://s3.amazonaws.com/prx-testing/test/audio1.mp3'
     end
 
     it 'can update audio on an episode' do
       update_hash = { media: [{ href: 'https://s3.amazonaws.com/prx-testing/test/change1.mp3' }] }
 
-      episode_update.all_contents.size.must_equal 0
+      assert_equal episode_update.all_contents.size, 0
 
       @controller.stub(:publish, true) do
         @controller.stub(:process_media, true) do
@@ -121,7 +121,7 @@ describe Api::Auth::EpisodesController do
       end
       assert_response :success
 
-      episode_update.reload.all_contents.size.must_equal 1
+      assert_equal episode_update.reload.all_contents.size, 1
 
       # updating with a dupe should insert it, with the same position value of 1
       @controller.stub(:publish, true) do
@@ -131,9 +131,9 @@ describe Api::Auth::EpisodesController do
       end
       assert_response :success
 
-      episode_update.reload.all_contents.size.must_equal 2
-      episode_update.all_contents.first.position.must_equal 1
-      episode_update.all_contents.last.position.must_equal 1
+      assert_equal episode_update.reload.all_contents.size, 2
+      assert_equal episode_update.all_contents.first.position, 1
+      assert_equal episode_update.all_contents.last.position, 1
     end
   end
 
@@ -149,7 +149,7 @@ describe Api::Auth::EpisodesController do
       list = JSON.parse(response.body)
       ids = list.dig('_embedded', 'prx:items').map{ |i| i['id'] }
       guids.each do |guid|
-        ids.must_include guid
+        assert_includes ids, guid
       end
     end
 

--- a/test/controllers/api/auth/podcasts_controller_test.rb
+++ b/test/controllers/api/auth/podcasts_controller_test.rb
@@ -14,8 +14,8 @@ describe Api::Auth::PodcastsController do
   end
 
   it 'should show the unpublished podcast' do
-    podcast.id.wont_be_nil
-    podcast.published_at.must_be_nil
+    refute_nil podcast.id
+    assert_nil podcast.published_at
     get(:show, { api_version: 'v1', format: 'json', id: podcast.id } )
     assert_response :success
   end
@@ -30,9 +30,9 @@ describe Api::Auth::PodcastsController do
     get(:index, api_version: 'v1')
     assert_response :success
     assert_not_nil assigns[:podcasts]
-    assigns[:podcasts].must_include podcast
-    assigns[:podcasts].must_include published_podcast
-    assigns[:podcasts].wont_include other_account_podcast
+    assert_includes assigns[:podcasts], podcast
+    assert_includes assigns[:podcasts], published_podcast
+    refute_includes assigns[:podcasts], other_account_podcast
   end
 
   describe 'with wildcard token' do
@@ -43,9 +43,9 @@ describe Api::Auth::PodcastsController do
       get(:index, api_version: 'v1')
       assert_response :success
       assert_not_nil assigns[:podcasts]
-      assigns[:podcasts].must_include podcast
-      assigns[:podcasts].must_include published_podcast
-      assigns[:podcasts].must_include other_account_podcast
+      assert_includes assigns[:podcasts], podcast
+      assert_includes assigns[:podcasts], published_podcast
+      assert_includes assigns[:podcasts], other_account_podcast
     end
   end
 end

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -9,16 +9,16 @@ describe Api::BaseController do
 
   it "determines show action options for roar" do
     @controller.class.resource_representer = 'rr'
-    @controller.send(:show_options)[:represent_with].must_equal 'rr'
+    assert_equal @controller.send(:show_options)[:represent_with], 'rr'
   end
 
   it "can parse a zoom parameter" do
     @controller.params[:zoom] = "a,test"
-    @controller.send(:zoom_param).must_equal ['a', 'test']
+    assert_equal @controller.send(:zoom_param), ['a', 'test']
   end
 
   it 'has no content for options requests' do
     process :options, 'OPTIONS', api_version: 'v1', any: '1'
-    response.status.must_equal 204
+    assert_equal response.status, 204
   end
 end

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -19,61 +19,61 @@ describe Api::EpisodesController do
   end
 
   it 'should show' do
-    episode.id.wont_be_nil
+    refute_nil episode.id
     get(:show, { api_version: 'v1', format: 'json', id: episode.guid } )
     assert_response :success
   end
 
   it 'should return resource gone for deleted resource' do
-    episode_deleted.id.wont_be_nil
+    refute_nil episode_deleted.id
     get(:show, { api_version: 'v1', format: 'json', id: episode_deleted.guid } )
     assert_response 410
   end
 
   it 'should return resource unknown for unpublished resource' do
-    episode_unpublished.id.wont_be_nil
+    refute_nil episode_unpublished.id
     get(:show, { api_version: 'v1', format: 'json', id: episode_unpublished.guid } )
     assert_response 404
   end
 
   it 'should return not found for unknown resource' do
-    episode_deleted.id.wont_be_nil
+    refute_nil episode_deleted.id
     get(:show, { api_version: 'v1', format: 'json', id: 'thisismadeup' } )
     assert_response 404
   end
 
   it 'should list' do
-    episode.id.wont_be_nil
-    episode_deleted.id.wont_be_nil
+    refute_nil episode.id
+    refute_nil episode_deleted.id
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
     guids = JSON.parse(response.body)['_embedded']['prx:items'].map { |p| p['id'] }
-    guids.must_include(episode.guid)
-    guids.wont_include(episode_deleted.guid)
+    assert_includes guids, episode.guid
+    refute_includes guids, episode_deleted.guid
   end
 
   it 'should not list future published' do
-    episode_unpublished.id.wont_be_nil
-    episode_prepublished.id.wont_be_nil
-    episode.id.wont_be_nil
+    refute_nil episode_unpublished.id
+    refute_nil episode_prepublished.id
+    refute_nil episode.id
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
     list = JSON.parse(response.body)
     ids = list.dig('_embedded', 'prx:items').map{ |i| i['id'] }
-    ids.must_include(episode.guid)
-    ids.wont_include(episode_prepublished.guid)
-    ids.wont_include(episode_unpublished.guid)
+    assert_includes ids, episode.guid
+    refute_includes ids, episode_prepublished.guid
+    refute_includes ids, episode_unpublished.guid
   end
 
   it 'should list for podcast' do
-    episode.id.wont_be_nil
-    episode_deleted.id.wont_be_nil
-    podcast.id.wont_be_nil
+    refute_nil episode.id
+    refute_nil episode_deleted.id
+    refute_nil podcast.id
     get(:index, { api_version: 'v1', format: 'json', podcast_id: podcast.id } )
     assert_response :success
     guids = JSON.parse(response.body)['_embedded']['prx:items'].map { |p| p['id'] }
-    guids.must_include(episode.guid)
-    guids.wont_include(episode_deleted.guid)
+    assert_includes guids, episode.guid
+    refute_includes guids, episode_deleted.guid
   end
 
   describe 'with a valid token' do
@@ -94,7 +94,7 @@ describe Api::EpisodesController do
 
 
     it 'should redirect for authorized request of unpublished resource' do
-      episode_redirect.id.wont_be_nil
+      refute_nil episode_redirect.id
       get(:show, { api_version: 'v1', format: 'json', id: episode_redirect.guid } )
       assert_response :redirect
     end
@@ -104,11 +104,11 @@ describe Api::EpisodesController do
       assert_response :success
       id = JSON.parse(response.body)['id']
       new_episode = Episode.find_by_guid(id)
-      new_episode.prx_uri.must_equal '/api/v1/stories/123'
-      new_episode.enclosures.count.must_equal 0
-      new_episode.all_contents.count.must_equal 3
+      assert_equal new_episode.prx_uri, '/api/v1/stories/123'
+      assert_equal new_episode.enclosures.count, 0
+      assert_equal new_episode.all_contents.count, 3
       c = new_episode.all_contents.first
-      c.original_url.must_equal 'https://s3.amazonaws.com/prx-testing/test/audio1.mp3'
+      assert_equal c.original_url, 'https://s3.amazonaws.com/prx-testing/test/audio1.mp3'
     end
 
     it 'can update on create of a new episode' do
@@ -117,11 +117,11 @@ describe Api::EpisodesController do
       assert_response :success
       id = JSON.parse(response.body)['id']
       new_episode = Episode.find_by_guid(id)
-      ep.id.must_equal new_episode.id
+      assert_equal ep.id, new_episode.id
 
-      new_episode.all_contents.count.must_equal 3
+      assert_equal new_episode.all_contents.count, 3
       c = new_episode.all_contents.first
-      c.original_url.must_equal 'https://s3.amazonaws.com/prx-testing/test/audio1.mp3'
+      assert_equal c.original_url, 'https://s3.amazonaws.com/prx-testing/test/audio1.mp3'
     end
 
     it 'can update audio on an episode' do
@@ -134,16 +134,16 @@ describe Api::EpisodesController do
         }]
       }
 
-      episode_update.all_contents.size.must_equal 0
+      assert_equal episode_update.all_contents.size, 0
 
       put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
 
       contents = episode_update.reload.all_contents
-      contents.size.must_equal 1
-      contents.first.mime_type.must_equal 'audio/mpeg'
-      contents.first.file_size.must_equal 123456
-      contents.first.duration.to_s.must_equal '1234.5678'
+      assert_equal contents.size, 1
+      assert_equal contents.first.mime_type, 'audio/mpeg'
+      assert_equal contents.first.file_size, 123456
+      assert_equal contents.first.duration.to_s, '1234.5678'
       guid1 = contents.first.guid
 
       # updating with a dupe should insert it
@@ -152,31 +152,31 @@ describe Api::EpisodesController do
       assert_response :success
 
       contents = episode_update.reload.all_contents
-      contents.size.must_equal 2
+      assert_equal contents.size, 2
 
-      contents.first.guid.wont_equal guid1
-      contents.first.position.must_equal 1
-      contents.first.mime_type.must_be_nil
-      contents.first.file_size.must_be_nil
-      contents.first.duration.must_be_nil
+      refute_equal contents.first.guid, guid1
+      assert_equal contents.first.position, 1
+      assert_nil contents.first.mime_type
+      assert_nil contents.first.file_size
+      assert_nil contents.first.duration
 
-      contents.last.guid.must_equal guid1
-      contents.last.position.must_equal 1
-      contents.last.mime_type.must_equal 'audio/mpeg'
-      contents.last.file_size.must_equal 123456
-      contents.last.duration.to_s.must_equal '1234.5678'
+      assert_equal contents.last.guid, guid1
+      assert_equal contents.last.position, 1
+      assert_equal contents.last.mime_type, 'audio/mpeg'
+      assert_equal contents.last.file_size, 123456
+      assert_equal contents.last.duration.to_s, '1234.5678'
 
       # updating without media does nothing
       update_hash = { title: 'a new title' }
       put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
-      episode_update.reload.all_contents.size.must_equal 2
+      assert_equal episode_update.reload.all_contents.size, 2
 
       # updating with an empty array deletes
       update_hash = { media: [] }
       put :update, update_hash.to_json, id: episode_update.guid, api_version: 'v1', format: 'json'
       assert_response :success
-      episode_update.reload.all_contents.size.must_equal 0
+      assert_equal episode_update.reload.all_contents.size, 0
     end
   end
 end

--- a/test/controllers/concerns/api_updated_since_test.rb
+++ b/test/controllers/concerns/api_updated_since_test.rb
@@ -13,19 +13,19 @@ describe ApiUpdatedSince do
   let(:controller) { ApiUpdatedSinceTestController.new }
 
   it 'defaults to nothing' do
-    controller.updated_since?.must_equal false
-    controller.updated_since.must_be_nil
+    assert_equal controller.updated_since?, false
+    assert_nil controller.updated_since
   end
 
   it 'parses since params' do
     controller.since_string = '2018-01-10'
-    controller.updated_since?.must_equal true
-    controller.updated_since.must_equal DateTime.parse('2018-01-10T00:00:00 +0000')
+    assert_equal controller.updated_since?, true
+    assert_equal controller.updated_since, DateTime.parse('2018-01-10T00:00:00 +0000')
   end
 
   it 'handles insanity' do
     controller.since_string = 'anything'
-    controller.updated_since?.must_equal false
-    controller.updated_since.must_be_nil
+    assert_equal controller.updated_since?, false
+    assert_nil controller.updated_since
   end
 end

--- a/test/controllers/podcasts_controller_test.rb
+++ b/test/controllers/podcasts_controller_test.rb
@@ -10,37 +10,37 @@ describe PodcastsController do
     @podcast.update_attribute(:locked, true)
     get :show, id: @podcast.id, format: 'rss'
 
-    response.headers['Location'].must_equal 'https://f.prxu.org/jjgo/feed-rss.xml'
-    response.status.to_i.must_equal 302
+    assert_equal response.headers['Location'], 'https://f.prxu.org/jjgo/feed-rss.xml'
+    assert_equal response.status.to_i, 302
   end
 
   it 'does not redirect if the podcast is locked but param unlock' do
     @podcast.update_attribute(:locked, true)
     get :show, id: @podcast.id, format: 'rss', unlock: true
 
-    response.status.to_i.must_equal 200
+    assert_equal response.status.to_i, 200
   end
 
   it 'returns a fresh version of the podcast when it has been updated' do
     @request.headers["HTTP_IF_MODIFIED_SINCE"] = 1.day.ago.strftime('%a, %d %b %Y %H:%M:%S %Z')
     get :show, id: @podcast.id, format: 'rss'
 
-    response.status.to_i.must_equal 200
+    assert_equal response.status.to_i, 200
   end
 
   it 'returns 304 if the resource has not been updated' do
     @request.headers["HTTP_IF_MODIFIED_SINCE"] = Time.now.strftime('%a, %d %b %Y %H:%M:%S %Z')
     get :show, id: @podcast.id, format: 'rss'
 
-    response.status.to_i.must_equal 304
+    assert_equal response.status.to_i, 304
   end
 
   it 'rss includes itunes block yes when podcast itunes_block true' do
     get :show, id: @podcast.id, format: 'rss'
-    response.body.wont_match /itunes:block/
+    refute_match(/itunes:block/, response.body)
 
     @podcast.update_attribute(:itunes_block, true)
     get :show, id: @podcast.id, format: 'rss'
-    response.body.must_match /itunes:block>Yes/
+    assert_match(/itunes:block>Yes/, response.body)
   end
 end

--- a/test/integration/original_audio_request.rb
+++ b/test/integration/original_audio_request.rb
@@ -32,6 +32,6 @@ describe 'Get Original Audio Integration Test' do
     original = story.audio[0].original(expiration: 6000).get_response
     location = original.headers['location']
 
-    location.wont_be_nil
+    refute_nil(location)
   end
 end

--- a/test/integration/podcast_request_test.rb
+++ b/test/integration/podcast_request_test.rb
@@ -19,76 +19,76 @@ describe 'RSS feed Integration Test' do
   end
 
   it 'returns an rss feed with correct podcast information' do
-    response.status.must_equal 200
-    response.content_type.to_s.must_equal 'application/rss+xml'
+    assert_equal response.status, 200
+    assert_equal response.content_type.to_s, 'application/rss+xml'
 
-    @feed.at_css('link').text.must_equal @podcast.link
-    @feed.at_css('title').text.must_equal @podcast.title
-    @feed.css('language').text.must_equal @podcast.language
-    @feed.at_css('description').text.strip.must_equal @podcast.description
-    @feed.css('copyright').text.must_equal @podcast.copyright
-    @feed.css('managingEditor').text.must_equal @podcast.managing_editor
-    @feed.at_css('pubDate').text.must_equal @podcast.pub_date.utc.rfc2822
-    @feed.css('lastBuildDate').text.must_equal @podcast.last_build_date.utc.rfc2822
-    @feed.at_css('atom|link').attributes['href'].value.must_equal 'http://feeds.feedburner.com/thornmorris'
-    @feed.at_css('itunes|author').text.must_equal @podcast.author_name
-    @feed.at_css('itunes|explicit').text.must_equal 'yes'
-    @feed.at_css('itunes|new-feed-url').text.must_equal 'http://feeds.feedburner.com/newthornmorris'
+    assert_equal @feed.at_css('link').text, @podcast.link
+    assert_equal @feed.at_css('title').text, @podcast.title
+    assert_equal @feed.css('language').text, @podcast.language
+    assert_equal @feed.at_css('description').text.strip, @podcast.description
+    assert_equal @feed.css('copyright').text, @podcast.copyright
+    assert_equal @feed.css('managingEditor').text, @podcast.managing_editor
+    assert_equal @feed.at_css('pubDate').text, @podcast.pub_date.utc.rfc2822
+    assert_equal @feed.css('lastBuildDate').text, @podcast.last_build_date.utc.rfc2822
+    assert_equal @feed.at_css('atom|link').attributes['href'].value, 'http://feeds.feedburner.com/thornmorris'
+    assert_equal @feed.at_css('itunes|author').text, @podcast.author_name
+    assert_equal @feed.at_css('itunes|explicit').text, 'yes'
+    assert_equal @feed.at_css('itunes|new-feed-url').text, 'http://feeds.feedburner.com/newthornmorris'
   end
 
   it 'contains correct podcast image information' do
     image_xml = @feed.css('image')
 
-    image_xml.css('url').text.must_equal @channel_image.url
-    image_xml.css('title').text.must_equal @channel_image.title
-    image_xml.css('link').text.must_equal @channel_image.link
-    image_xml.css('width').text.must_equal @channel_image.width.to_s
-    image_xml.css('height').text.must_equal @channel_image.height.to_s
-    image_xml.css('description').text.must_equal @channel_image.description
+    assert_equal image_xml.css('url').text, @channel_image.url
+    assert_equal image_xml.css('title').text, @channel_image.title
+    assert_equal image_xml.css('link').text, @channel_image.link
+    assert_equal image_xml.css('width').text, @channel_image.width.to_s
+    assert_equal image_xml.css('height').text, @channel_image.height.to_s
+    assert_equal image_xml.css('description').text, @channel_image.description
   end
 
   it 'displays iTunes categories correctly' do
     cat_node = @feed.at_css('itunes|category')
     subcats = @category.subcategories
 
-    cat_node.attributes['text'].value.must_equal @category.name
-    cat_node.element_children[0].attributes['text'].value.must_equal subcats[0]
-    cat_node.element_children[1].attributes['text'].value.must_equal subcats[1]
+    assert_equal cat_node.attributes['text'].value, @category.name
+    assert_equal cat_node.element_children[0].attributes['text'].value, subcats[0]
+    assert_equal cat_node.element_children[1].attributes['text'].value, subcats[1]
   end
 
   it 'displays correct episode titles' do
     @feed.css('item').each_with_index do |node, i|
-      node.css('title').text.must_match /Episode \d+/
-      node.at_css('enclosure').attributes['length'].value.must_equal '774059'
-      node.css('itunes|duration').text.must_equal '0:48'
+      assert_match(/Episode \d+/, node.css('title').text)
+      assert_equal node.at_css('enclosure').attributes['length'].value, '774059'
+      assert_equal node.css('itunes|duration').text, '0:48'
     end
   end
 
   it 'displays plaintext and richtext descriptions' do
     node = @feed.css('item')[0]
-    node.css('description').text.strip[0..4].must_equal "<div>"
-    node.css('itunes|summary').text.strip[0..6].must_equal "<a href"
+    assert_equal node.css('description').text.strip[0..4], "<div>"
+    assert_equal node.css('itunes|summary').text.strip[0..6], "<a href"
   end
 
   it 'returns limited number of episodes' do
     @podcast.update_attributes(display_episodes_count: 1)
     get "/podcasts/#{@podcast.id}"
     @feed = Nokogiri::XML(response.body).css('channel')
-    @feed.css('item').count.must_equal 1
+    assert_equal @feed.css('item').count, 1
   end
 
   it 'returns episodes wih minimal tags' do
     @podcast.update_attributes(display_full_episodes_count: 1)
     get "/podcasts/#{@podcast.id}"
     @feed = Nokogiri::XML(response.body).css('channel')
-    @feed.xpath('//item/itunes:author').count.must_equal 1
+    assert_equal @feed.xpath('//item/itunes:author').count, 1
   end
 
   it 'defaults owner to author if owner email not set' do
     @podcast.update_attributes(owner_email: '')
     get "/podcasts/#{@podcast.id}"
-    @feed.at_css('itunes|owner').css('itunes|email').text.must_equal @podcast.author_email
-    @feed.at_css('itunes|owner').css('itunes|name').text.must_equal @podcast.author_name
+    assert_equal @feed.at_css('itunes|owner').css('itunes|email').text, @podcast.author_email
+    assert_equal @feed.at_css('itunes|owner').css('itunes|name').text, @podcast.author_name
   end
 
   it 'supports iTunes tags new in iOS11' do
@@ -102,13 +102,13 @@ describe 'RSS feed Integration Test' do
     get "/podcasts/#{@podcast.id}"
     @feed = Nokogiri::XML(response.body).css('channel')
 
-    @feed.at_css('itunes|type').text.must_equal @podcast.itunes_type
+    assert_equal @feed.at_css('itunes|type').text, @podcast.itunes_type
     @feed.css('item').reverse.each_with_index do |node, ind|
-      node.css('title').text.must_match /Season \d+ Episode \d+/
-      node.css('itunes|title').text.must_equal "Stripped-down title"
-      node.css('itunes|season').text.to_i.must_equal ind + 1
-      node.css('itunes|episode').text.to_i.must_equal ind + 1
-      node.css('itunes|episodeType').text.must_match 'full'
+      assert_match(/Season \d+ Episode \d+/, node.css('title').text)
+      assert_equal node.css('itunes|title').text, "Stripped-down title"
+      assert_equal node.css('itunes|season').text.to_i, ind + 1
+      assert_equal node.css('itunes|episode').text.to_i, ind + 1
+      assert_match('full', node.css('itunes|episodeType').text)
     end
   end
 
@@ -122,9 +122,9 @@ describe 'RSS feed Integration Test' do
       get "/podcasts/#{@podcast.id}"
       @feed = Nokogiri::XML(response.body).css('channel')
 
-      @feed.at_css('itunes|author').text.must_equal @podcast.author_name
-      @feed.at_css('item').css('itunes|author').text.must_equal @ep.author_name
-      @feed.at_css('item').css('author').text.must_equal "#{@ep.author_email} (#{@ep.author_name})"
+      assert_equal @feed.at_css('itunes|author').text, @podcast.author_name
+      assert_equal @feed.at_css('item').css('itunes|author').text, @ep.author_name
+      assert_equal @feed.at_css('item').css('author').text, "#{@ep.author_email} (#{@ep.author_name})"
     end
 
     it 'does not display episode author without email' do
@@ -132,15 +132,15 @@ describe 'RSS feed Integration Test' do
       @podcast.update_attributes(author_email: '')
       get "/podcasts/#{@podcast.id}"
       @feed = Nokogiri::XML(response.body).css('channel')
-      @feed.at_css('item').css('author').count.must_equal 0
+      assert_equal @feed.at_css('item').css('author').count, 0
     end
 
     it 'defaults episode author to podcast author if ep author email not set' do
       @ep = create(:episode, podcast: @podcast, author_name: 'Foo Bar')
       get "/podcasts/#{@podcast.id}"
       @feed = Nokogiri::XML(response.body).css('channel')
-      @feed.at_css('item').css('author').count.must_equal 1
-      @feed.at_css('item').css('author').text.must_equal "#{@podcast.author_email} (#{@podcast.author_name})"
+      assert_equal @feed.at_css('item').css('author').count, 1
+      assert_equal @feed.at_css('item').css('author').text, "#{@podcast.author_email} (#{@podcast.author_name})"
     end
   end
 end

--- a/test/jobs/feed_entry_update_job_test.rb
+++ b/test/jobs/feed_entry_update_job_test.rb
@@ -26,12 +26,12 @@ describe FeedEntryUpdateJob do
     data = json_file(:crier_entry)
     Task.stub :new_porter_sns_client, SnsMock.new do
       create_episode = job.perform(msg)
-      create_episode.wont_be_nil
-      create_episode.source_updated_at.must_equal Time.parse(msg[:sent_at])
+      refute_nil create_episode
+      assert_equal create_episode.source_updated_at, Time.parse(msg[:sent_at])
 
       update_episode = job.perform(msg)
-      update_episode.wont_be :changed?
-      create_episode.must_equal update_episode
+      refute update_episode.changed?
+      assert_equal create_episode, update_episode
     end
   end
 
@@ -39,10 +39,10 @@ describe FeedEntryUpdateJob do
     Task.stub :new_porter_sns_client, SnsMock.new do
       episode = job.perform(msg)
       created_podcast = job.podcast
-      created_podcast.source_updated_at.must_equal Time.parse(msg[:sent_at])
+      assert_equal created_podcast.source_updated_at, Time.parse(msg[:sent_at])
 
       job.create_podcast
-      job.podcast.must_equal created_podcast
+      assert_equal job.podcast, created_podcast
     end
   end
 
@@ -51,7 +51,7 @@ describe FeedEntryUpdateJob do
       episode = job.perform(msg)
       created_episode = job.episode
       job.create_episode
-      job.episode.must_equal created_episode
+      assert_equal job.episode, created_episode
     end
   end
 end

--- a/test/jobs/publish_feed_job_test.rb
+++ b/test/jobs/publish_feed_job_test.rb
@@ -8,38 +8,38 @@ describe PublishFeedJob do
   let(:job) { PublishFeedJob.new }
 
   it 'gets an aws client' do
-    job.client.wont_be_nil
-    job.client.must_be_instance_of Aws::S3::Client
+    refute_nil job.client
+    assert_instance_of Aws::S3::Client, job.client
   end
 
   it 'knows the right bucket to write to' do
-    job.feeder_storage_bucket.must_equal 'test-prx-feed'
+    assert_equal job.feeder_storage_bucket, 'test-prx-feed'
     ENV['FEEDER_STORAGE_BUCKET'] = 'foo'
-    job.feeder_storage_bucket.must_equal 'foo'
+    assert_equal job.feeder_storage_bucket, 'foo'
     ENV['FEEDER_STORAGE_BUCKET'] = 'test-prx-feed'
   end
 
   it 'knows the right key to write to' do
-    job.key(podcast).must_equal 'jjgo/feed-rss.xml'
+    assert_equal job.key(podcast), 'jjgo/feed-rss.xml'
   end
 
   it 'can load the rss template' do
-    job.rss_template.wont_be_nil
-    job.rss_template[0,12].must_equal 'xml.instruct'
+    refute_nil job.rss_template
+    assert_equal job.rss_template[0,12], 'xml.instruct'
   end
 
   it 'can setup the data based on the podcast' do
     job.setup_data(podcast)
-    job.podcast.must_equal podcast
-    job.episodes.count.must_equal 1
+    assert_equal job.podcast, podcast
+    assert_equal job.episodes.count, 1
   end
 
   it 'can setup the data based on the podcast' do
     job.podcast = podcast
     job.episodes = podcast.feed_episodes
     rss = job.generate_rss_xml
-    rss.wont_be_nil
-    rss[0, 38].must_equal '<?xml version="1.0" encoding="UTF-8"?>'
+    refute_nil rss
+    assert_equal rss[0, 38], '<?xml version="1.0" encoding="UTF-8"?>'
   end
 
   describe 'saving the rss file' do
@@ -56,9 +56,9 @@ describe PublishFeedJob do
     it 'can process publishing a podcast' do
       job.stub(:client, stub_client) do
         job.perform(podcast)
-        job.rss.wont_be_nil
-        job.put_object.wont_be_nil
-        job.copy_object.must_be_nil
+        refute_nil job.rss
+        refute_nil job.put_object
+        assert_nil job.copy_object
       end
     end
 
@@ -66,8 +66,8 @@ describe PublishFeedJob do
       podcast.feed_rss_alias = 'some-alias'
       job.stub(:client, stub_client) do
         job.perform(podcast)
-        job.put_object.wont_be_nil
-        job.copy_object.wont_be_nil
+        refute_nil job.put_object
+        refute_nil job.copy_object
       end
     end
   end

--- a/test/jobs/release_episodes_job_test.rb
+++ b/test/jobs/release_episodes_job_test.rb
@@ -14,9 +14,9 @@ describe ReleaseEpisodesJob do
   it 'publishes the podcast if released is passed and after the last build' do
     episode.update_columns(updated_at: 1.day.ago, published_at: 1.hour.ago)
     Episode.stub(:episodes_to_release, [episode]) do
-      episode.updated_at.must_be :<, episode.published_at
+      assert_operator episode.updated_at, :<, episode.published_at
       job.perform
-      podcast.reload.updated_at.must_be :>, episode.published_at
+      assert_operator podcast.reload.updated_at, :>, episode.published_at
     end
   end
 end

--- a/test/jobs/series_update_job_test.rb
+++ b/test/jobs/series_update_job_test.rb
@@ -36,7 +36,7 @@ describe SeriesUpdateJob do
 
   it 'creates a series resource' do
     series = job.api_resource(JSON.parse(body).with_indifferent_access)
-    series.must_be_instance_of PRXAccess::PRXHyperResource
+    assert_instance_of PRXAccess::PRXHyperResource, series
   end
 
   it 'can update an podcast' do
@@ -45,19 +45,19 @@ describe SeriesUpdateJob do
         lbd = podcast.last_build_date
         uat = podcast.updated_at
         job.perform(msg)
-        job.podcast.last_build_date.must_be :>, lbd
-        job.podcast.updated_at.must_be :>, uat
+        assert_operator job.podcast.last_build_date, :>, lbd
+        assert_operator job.podcast.updated_at, :>, uat
       end
     end
   end
 
   it 'will not update a deleted podcast' do
     podcast = create(:podcast, prx_uri: '/api/v1/series/32832', deleted_at: Time.now)
-    podcast.must_be :deleted?
+    assert podcast.deleted?
     podcast.stub(:copy_media, true) do
       Podcast.stub(:by_prx_series, podcast) do
         job.perform(msg)
-        job.podcast.must_be :deleted?
+        assert job.podcast.deleted?
       end
     end
   end
@@ -66,7 +66,7 @@ describe SeriesUpdateJob do
     podcast = create(:podcast, prx_uri: '/api/v1/series/32832')
     Podcast.stub(:by_prx_series, podcast) do
       job.perform(msg.tap { |m| m[:action] = 'delete'} )
-      job.podcast.deleted_at.wont_be_nil
+      refute_nil job.podcast.deleted_at
     end
   end
 end

--- a/test/lib/prx_access_test.rb
+++ b/test/lib/prx_access_test.rb
@@ -10,29 +10,29 @@ describe PRXAccess do
   let(:resource) { PRXAccess::PRXHyperResource.new }
 
   it 'returns an api' do
-    prx_access.api.wont_be_nil
+    refute_nil prx_access.api
   end
 
   it 'returns root uri' do
-    prx_access.id_root.wont_be_nil
-    prx_access.cms_root.wont_be_nil
-    prx_access.crier_root.wont_be_nil
-    prx_access.feeder_root.wont_be_nil
+    refute_nil prx_access.id_root
+    refute_nil prx_access.cms_root
+    refute_nil prx_access.crier_root
+    refute_nil prx_access.feeder_root
   end
 
   it 'create a resource from json' do
     res = prx_access.api_resource(crier_entry, prx_access.crier_root)
-    res.wont_be_nil
+    refute_nil res
     res.attributes['url'] = 'http://traffic.libsyn.com/test/test.mp3'
   end
 
   it 'underscores incoming hash keys' do
     input = { 'camelCase' => 1 }
-    resource.incoming_body_filter(input)['camel_case'].must_equal 1
+    assert_equal resource.incoming_body_filter(input)['camel_case'], 1
   end
 
   it 'underscores outgoing hash keys' do
     input = { 'under_score' => 1 }
-    resource.outgoing_body_filter(input)['underScore'].must_equal 1
+    assert_equal resource.outgoing_body_filter(input)['underScore'], 1
   end
 end

--- a/test/lib/time_formats_test.rb
+++ b/test/lib/time_formats_test.rb
@@ -6,23 +6,23 @@ class Bignum; include TimeFormats; end
 
 describe TimeFormats do
   it 'formats 0-23 as a string' do
-    0.to_hour_of_day.must_equal '12:00:00 midnight'
-    (1..11).each{|h| h.to_hour_of_day.must_equal "#{h}:00:00 AM"}
-    12.to_hour_of_day.must_equal '12:00:00 noon'
-    (13..23).each{|h| h.to_hour_of_day.must_equal "#{h - 12}:00:00 PM"}
+    assert_equal 0.to_hour_of_day, '12:00:00 midnight'
+    (1..11).each { |h| assert_equal(h.to_hour_of_day, "#{h}:00:00 AM") }
+    assert_equal 12.to_hour_of_day, '12:00:00 noon'
+    (13..23).each { |h| assert_equal(h.to_hour_of_day, "#{h - 12}:00:00 PM") }
   end
 
   it 'formats integers to HH:MM:SS' do
-    1.to_time_summary.must_equal '0:01'
-    100.to_time_summary.must_equal '01:40'
-    10000.to_time_summary.must_equal '02:46:40'
-    1000000.to_time_summary.must_equal '277:46:40'
+    assert_equal 1.to_time_summary, '0:01'
+    assert_equal 100.to_time_summary, '01:40'
+    assert_equal 10000.to_time_summary, '02:46:40'
+    assert_equal 1000000.to_time_summary, '277:46:40'
   end
 
   it 'formats integers to time duration sentence' do
-    1.to_time_in_words.must_equal '1 second'
-    100.to_time_in_words.must_equal '1 minute and 40 seconds'
-    10000.to_time_in_words.must_equal '2 hours, 46 minutes, and 40 seconds'
-    1000000.to_time_in_words.must_equal '277 hours, 46 minutes, and 40 seconds'
+    assert_equal 1.to_time_in_words, '1 second'
+    assert_equal 100.to_time_in_words, '1 minute and 40 seconds'
+    assert_equal 10000.to_time_in_words, '2 hours, 46 minutes, and 40 seconds'
+    assert_equal 1000000.to_time_in_words, '277 hours, 46 minutes, and 40 seconds'
   end
 end

--- a/test/models/api_test.rb
+++ b/test/models/api_test.rb
@@ -4,28 +4,28 @@ describe Api do
   let(:api) { Api.version('1.0') }
 
   it 'create an api with a version' do
-    api.version.must_equal '1.0'
+    assert_equal api.version, '1.0'
   end
 
   it 'implements to_model' do
-    api.to_model.must_equal api
+    assert_equal api.to_model, api
   end
 
   it 'is not persisted' do
-    api.wont_be :persisted?
+    refute api.persisted?
   end
 
   it 'has a cache key' do
-    api.cache_key.wont_be_nil
-    api.cache_key.must_match /^api\/1.0-/
+    refute_nil api.cache_key
+    assert_match(/^api\/1.0-/, api.cache_key)
   end
 
   it 'has an updated_at date' do
-    api.updated_at.wont_be_nil
-    api.updated_at.must_be_instance_of Time
+    refute_nil api.updated_at
+    assert_instance_of Time, api.updated_at
   end
 
   it 'always a root resource' do
-    api.must_be :is_root_resource
+    assert api.is_root_resource
   end
 end

--- a/test/models/authorization_test.rb
+++ b/test/models/authorization_test.rb
@@ -12,32 +12,32 @@ describe Authorization do
   let(:episode3) { create(:episode, podcast: podcast3) }
 
   it 'has a user_id' do
-    authorization.user_id.must_equal 456
+    assert_equal authorization.user_id, 456
   end
 
   it 'has a token' do
-    authorization.token.wont_be_nil
+    refute_nil authorization.token
   end
 
   it 'has a cache_key' do
-    authorization.cache_key.wont_be_nil
-    authorization.cache_key.must_match /PRX::Authorization/
+    refute_nil authorization.cache_key
+    assert_match(/PRX::Authorization/, authorization.cache_key)
   end
 
   it 'has token accounts' do
-    authorization.token_auth_account_ids.must_equal ['123']
-    authorization.token_auth_account_uris.must_equal ['/api/v1/accounts/123']
+    assert_equal authorization.token_auth_account_ids, ['123']
+    assert_equal authorization.token_auth_account_uris, ['/api/v1/accounts/123']
   end
 
   it 'gets podcasts for token accounts' do
     podcast1 && podcast2 && podcast3
-    authorization.token_auth_podcasts.count.must_equal 1
-    authorization.token_auth_podcasts.first.must_equal podcast1
+    assert_equal authorization.token_auth_podcasts.count, 1
+    assert_equal authorization.token_auth_podcasts.first, podcast1
   end
 
   it 'gets episodes for token accounts' do
     episode1 && episode2 && episode3
-    authorization.token_auth_episodes.count.must_equal 1
-    authorization.token_auth_episodes.first.must_equal episode1
+    assert_equal authorization.token_auth_episodes.count, 1
+    assert_equal authorization.token_auth_episodes.first, episode1
   end
 end

--- a/test/models/concerns/porter_encoder_test.rb
+++ b/test/models/concerns/porter_encoder_test.rb
@@ -28,13 +28,13 @@ describe PorterEncoder do
     model.porter_start!(opts)
     ENV['AWS_ACCOUNT_ID'] = account_bk
 
-    sns.message[:Job][:Id].length.must_equal 36
-    sns.message[:Job][:Source].must_equal({
+    assert_equal sns.message[:Job][:Id].length, 36
+    assert_equal(sns.message[:Job][:Source], {
       'Mode' => 'AWS/S3',
       'BucketName' => 'src',
       'ObjectKey' => 'path/key.mp3'
     })
-    sns.message[:Job][:Tasks].must_equal([{
+    assert_equal(sns.message[:Job][:Tasks], [{
       'Type' => 'Copy',
       'Mode' => 'AWS/S3',
       'BucketName' => 'dest',
@@ -45,8 +45,8 @@ describe PorterEncoder do
         'ContentDisposition' => 'attachment; filename="key.mp3"'
       }
     }])
-    sns.message[:Job][:Inspect].must_be_nil
-    sns.message[:Job][:Callbacks].must_equal([{
+    assert_nil sns.message[:Job][:Inspect]
+    assert_equal(sns.message[:Job][:Callbacks], [{
       'Type' => 'AWS/SQS',
       'Queue' => 'https://sqs.us-whatev.amazonaws.com/12345678/queue-name'
     }])
@@ -57,11 +57,11 @@ describe PorterEncoder do
     opts[:destination] = 's3://dest/path/file%252B.mp3'
     model.porter_start!(opts)
 
-    sns.message[:Job][:Source].must_equal({
+    assert_equal(sns.message[:Job][:Source], {
       'Mode' => 'HTTP',
       'URL' => 'https://some.where/the/file%252B.mp3'
     })
-    sns.message[:Job][:Tasks].must_equal([{
+    assert_equal(sns.message[:Job][:Tasks], [{
       'Type' => 'Copy',
       'Mode' => 'AWS/S3',
       'BucketName' => 'dest',
@@ -79,12 +79,12 @@ describe PorterEncoder do
     opts[:destination] = 's3://dest/path/file%252B.mp3'
     model.porter_start!(opts)
 
-    sns.message[:Job][:Source].must_equal({
+    assert_equal(sns.message[:Job][:Source], {
       'Mode' => 'AWS/S3',
       'BucketName' => 'src',
       'ObjectKey' => 'the/file%252B.mp3'
     })
-    sns.message[:Job][:Tasks].must_equal([{
+    assert_equal(sns.message[:Job][:Tasks], [{
       'Type' => 'Copy',
       'Mode' => 'AWS/S3',
       'BucketName' => 'dest',
@@ -101,7 +101,7 @@ describe PorterEncoder do
     opts[:source] = 'https://some.where/the/file.mp3'
     model.porter_start!(opts)
 
-    sns.message[:Job][:Source].must_equal({
+    assert_equal(sns.message[:Job][:Source], {
       'Mode' => 'HTTP',
       'URL' => 'https://some.where/the/file.mp3'
     })
@@ -111,6 +111,6 @@ describe PorterEncoder do
     opts[:job_type] = 'audio'
     model.porter_start!(opts)
 
-    sns.message[:Job][:Tasks].must_include({'Type' => 'Inspect'})
+    assert_includes sns.message[:Job][:Tasks], ({'Type' => 'Inspect'})
   end
 end

--- a/test/models/concerns/porter_parser_test.rb
+++ b/test/models/concerns/porter_parser_test.rb
@@ -7,65 +7,65 @@ end
 
 describe PorterParser do
   it 'handles non-porter messages' do
-    TestParser.porter_callback_job_id({}).must_be_nil
-    TestParser.porter_callback_status({}).must_be_nil
-    TestParser.porter_callback_time({}).must_be_nil
-    TestParser.porter_callback_copy({}).must_be_nil
-    TestParser.porter_callback_inspect({}).must_be_nil
+    assert_nil TestParser.porter_callback_job_id({})
+    assert_nil TestParser.porter_callback_status({})
+    assert_nil TestParser.porter_callback_time({})
+    assert_nil TestParser.porter_callback_copy({})
+    assert_nil TestParser.porter_callback_inspect({})
   end
 
   it 'parses porter job received callback messages' do
     porter_received_callback = build(:porter_job_received)
-    TestParser.porter_callback_job_id(porter_received_callback).must_equal 'the-job-id'
-    TestParser.porter_callback_status(porter_received_callback).must_equal 'processing'
-    TestParser.porter_callback_time(porter_received_callback).must_equal Time.parse('2012-12-21T12:34:56Z')
-    TestParser.porter_callback_copy(porter_received_callback).must_be_nil
-    TestParser.porter_callback_inspect(porter_received_callback).must_be_nil
+    assert_equal TestParser.porter_callback_job_id(porter_received_callback), 'the-job-id'
+    assert_equal TestParser.porter_callback_status(porter_received_callback), 'processing'
+    assert_equal TestParser.porter_callback_time(porter_received_callback), Time.parse('2012-12-21T12:34:56Z')
+    assert_nil TestParser.porter_callback_copy(porter_received_callback)
+    assert_nil TestParser.porter_callback_inspect(porter_received_callback)
   end
 
   it 'ignores porter task result callback messages' do
     task_result_callback = build(:porter_task_result)
-    TestParser.porter_callback_job_id(task_result_callback).must_equal 'the-job-id'
-    TestParser.porter_callback_status(task_result_callback).must_be_nil
+    assert_equal TestParser.porter_callback_job_id(task_result_callback), 'the-job-id'
+    assert_nil TestParser.porter_callback_status(task_result_callback)
   end
 
   it 'ignores porter task error callback messages' do
     task_error_callback = build(:porter_task_error)
-    TestParser.porter_callback_job_id(task_error_callback).must_equal 'the-job-id'
-    TestParser.porter_callback_status(task_error_callback).must_be_nil
+    assert_equal TestParser.porter_callback_job_id(task_error_callback), 'the-job-id'
+    assert_nil TestParser.porter_callback_status(task_error_callback)
   end
 
   it 'parses porter ingest failed callback messages' do
     porter_404_callback = build(:porter_job_ingest_failed)
-    TestParser.porter_callback_job_id(porter_404_callback).must_equal 'the-job-id'
-    TestParser.porter_callback_status(porter_404_callback).must_equal 'error'
-    TestParser.porter_callback_time(porter_404_callback).must_equal Time.parse('2012-12-21T12:34:56Z')
-    TestParser.porter_callback_copy(porter_404_callback).must_be_nil
-    TestParser.porter_callback_inspect(porter_404_callback).must_be_nil
+    assert_equal TestParser.porter_callback_job_id(porter_404_callback), 'the-job-id'
+    assert_equal TestParser.porter_callback_status(porter_404_callback), 'error'
+    assert_equal TestParser.porter_callback_time(porter_404_callback), Time.parse('2012-12-21T12:34:56Z')
+    assert_nil TestParser.porter_callback_copy(porter_404_callback)
+    assert_nil TestParser.porter_callback_inspect(porter_404_callback)
   end
 
   it 'parses porter job failed callback messages' do
     porter_error_callback = build(:porter_job_failed)
-    TestParser.porter_callback_job_id(porter_error_callback).must_equal 'the-job-id'
-    TestParser.porter_callback_status(porter_error_callback).must_equal 'error'
-    TestParser.porter_callback_time(porter_error_callback).must_equal Time.parse('2012-12-21T12:34:56Z')
-    TestParser.porter_callback_copy(porter_error_callback).must_be_nil
-    TestParser.porter_callback_inspect(porter_error_callback).must_be_nil
+    assert_equal TestParser.porter_callback_job_id(porter_error_callback), 'the-job-id'
+    assert_equal TestParser.porter_callback_status(porter_error_callback), 'error'
+    assert_equal TestParser.porter_callback_time(porter_error_callback), Time.parse('2012-12-21T12:34:56Z')
+    assert_nil TestParser.porter_callback_copy(porter_error_callback)
+    assert_nil TestParser.porter_callback_inspect(porter_error_callback)
   end
 
   it 'parses porter successful callback messages' do
     porter_success_callback = build(:porter_job_results)
-    TestParser.porter_callback_job_id(porter_success_callback).must_equal 'the-job-id'
-    TestParser.porter_callback_status(porter_success_callback).must_equal 'complete'
-    TestParser.porter_callback_time(porter_success_callback).must_equal Time.parse('2012-12-21T12:34:56Z')
-    TestParser.porter_callback_copy(porter_success_callback).must_equal(build(:porter_copy_result))
-    TestParser.porter_callback_inspect(porter_success_callback).must_equal(build(:porter_inspect_audio_result))
+    assert_equal TestParser.porter_callback_job_id(porter_success_callback), 'the-job-id'
+    assert_equal TestParser.porter_callback_status(porter_success_callback), 'complete'
+    assert_equal TestParser.porter_callback_time(porter_success_callback), Time.parse('2012-12-21T12:34:56Z')
+    assert_equal TestParser.porter_callback_copy(porter_success_callback), build(:porter_copy_result)
+    assert_equal TestParser.porter_callback_inspect(porter_success_callback), build(:porter_inspect_audio_result)
   end
 
   it 'parses porter audio metadata' do
     model = TestParser.new
     model.result = build(:porter_job_results)
-    model.porter_callback_media_meta.must_equal({
+    assert_equal(model.porter_callback_media_meta, {
       mime_type: 'audio/mpeg',
       medium: 'audio',
       file_size: 32980032,
@@ -83,7 +83,7 @@ describe PorterParser do
 
     model = TestParser.new
     model.result = porter_success_callback
-    model.porter_callback_media_meta.must_equal({
+    assert_equal(model.porter_callback_media_meta, {
       mime_type: 'video/mp4',
       medium: 'video',
       file_size: 16996018,
@@ -103,7 +103,7 @@ describe PorterParser do
     end
     model = TestParser.new
     model.result = porter_success_callback
-    model.porter_callback_media_meta[:mime_type].must_equal('image/png')
-    model.porter_callback_media_meta[:medium].must_equal('image')
+    assert_equal model.porter_callback_media_meta[:mime_type], 'image/png'
+    assert_equal model.porter_callback_media_meta[:medium], 'image'
   end
 end

--- a/test/models/concerns/text_sanitizer_test.rb
+++ b/test/models/concerns/text_sanitizer_test.rb
@@ -12,26 +12,26 @@ describe TextSanitizer do
   end
 
   it 'scrubs all tags' do
-    model.sanitize_text_only(text).must_equal 'my dog & cat ate my '
+    assert_equal model.sanitize_text_only(text), 'my dog & cat ate my '
   end
 
   it 'leaves ampersands alone' do
-    model.sanitize_text_only('Us & Them').must_equal 'Us & Them'
+    assert_equal model.sanitize_text_only('Us & Them'), 'Us & Them'
   end
 
   it 'scrubs all but links' do
     r = 'my dog &amp; cat <a href="/">ate</a> my '
-    model.sanitize_links_only(text).must_equal r
+    assert_equal model.sanitize_links_only(text), r
   end
 
   it 'scrubs all but white listed' do
     r = '<p>my</p> <b>dog &amp; cat</b> <a href="/">ate</a> <span><div>my</div></span> '
-    model.sanitize_white_list(text).must_equal r
+    assert_equal model.sanitize_white_list(text), r
   end
 
   it 'white lists tables' do
     text = "<table>\n<thead></thead>\n<tbody>\n<tr>\n<th></th>\n<td></td>\n</tr>\n" +
            "<caption></caption>\n</tbody>\n<tfoot></tfoot>\n</table>"
-    model.sanitize_white_list(text).must_equal text
+    assert_equal model.sanitize_white_list(text), text
   end
 end

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -21,23 +21,23 @@ describe Content do
 
   it 'can be constructed from feed content' do
     c = Content.build_from_content(episode, crier_content)
-    c.is_default.wont_equal true
-    c.bit_rate.must_equal 64
-    c.channels.must_equal 1
-    c.duration.must_equal 3252.19
-    c.expression.must_equal "sample"
-    c.file_size.must_equal 26017749
-    c.lang.must_equal "en"
-    c.medium.must_equal "audio"
-    c.sample_rate.must_equal 44100
-    c.mime_type.must_equal "audio/mpeg"
-    c.original_url.must_equal "https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio.mp3"
+    refute c.is_default
+    assert_equal c.bit_rate, 64
+    assert_equal c.channels, 1
+    assert_equal c.duration, 3252.19
+    assert_equal c.expression, "sample"
+    assert_equal c.file_size, 26017749
+    assert_equal c.lang, "en"
+    assert_equal c.medium, "audio"
+    assert_equal c.sample_rate, 44100
+    assert_equal c.mime_type, "audio/mpeg"
+    assert_equal c.original_url, "https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio.mp3"
   end
 
   it 'can be updated' do
     content.update_with_content!(crier_content)
-    content.original_url.must_equal "https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio.mp3"
-    content.file_size.must_equal 26017749
-    content.mime_type.must_equal 'audio/mpeg'
+    assert_equal content.original_url, "https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio.mp3"
+    assert_equal content.file_size, 26017749
+    assert_equal content.mime_type, 'audio/mpeg'
   end
 end

--- a/test/models/enclosure_test.rb
+++ b/test/models/enclosure_test.rb
@@ -14,15 +14,15 @@ describe Enclosure do
 
   it 'can be constructed from feed enclosure' do
     e = Enclosure.build_from_enclosure(episode, crier_enclosure)
-    e.original_url.must_equal 'http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3'
-    e.file_size.must_equal 27485957
-    e.mime_type.must_equal 'audio/mpeg'
+    assert_equal e.original_url, 'http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3'
+    assert_equal e.file_size, 27485957
+    assert_equal e.mime_type, 'audio/mpeg'
   end
 
   it 'can be updated' do
     enclosure.update_with_enclosure!(crier_enclosure)
-    enclosure.original_url.must_equal 'http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3'
-    enclosure.file_size.must_equal 27485957
-    enclosure.mime_type.must_equal 'audio/mpeg'
+    assert_equal enclosure.original_url, 'http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3'
+    assert_equal enclosure.file_size, 27485957
+    assert_equal enclosure.mime_type, 'audio/mpeg'
   end
 end

--- a/test/models/episode_entry_handler_test.rb
+++ b/test/models/episode_entry_handler_test.rb
@@ -16,19 +16,19 @@ describe EpisodeEntryHandler do
 
   it 'can update from entry' do
     EpisodeEntryHandler.update_from_entry!(episode, entry)
-    episode.title.must_equal 'Episode 12: What We Know'
+    assert_equal episode.title, 'Episode 12: What We Know'
   end
 
   it 'can create from entry' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry)
-    episode.podcast_id.must_equal podcast.id
-    episode.guid.wont_be_nil
-    episode.original_guid.wont_be_nil
-    episode.published_at.wont_be_nil
-    episode.guid.wont_equal episode.overrides[:guid]
-    episode.title.must_equal 'Episode 12: What We Know'
-    episode.url.must_equal 'http://serialpodcast.org'
+    assert_equal episode.podcast_id, podcast.id
+    refute_nil episode.guid
+    refute_nil episode.original_guid
+    refute_nil episode.published_at
+    refute_equal episode.guid, episode.overrides[:guid]
+    assert_equal episode.title, 'Episode 12: What We Know'
+    assert_equal episode.url, 'http://serialpodcast.org'
   end
 
   it 'fixes libsyn links' do
@@ -37,50 +37,50 @@ describe EpisodeEntryHandler do
 
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry)
-    episode.url.must_be_nil
+    assert_nil episode.url
   end
 
   it 'sets all attributes' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_all)
-    episode.id.wont_be_nil
-    episode.created_at.wont_be_nil
-    episode.updated_at.wont_be_nil
-    episode.podcast_id.must_equal podcast.id
-    episode.guid.wont_be_nil
-    episode.prx_uri.must_be_nil
-    episode.deleted_at.must_be_nil
-    episode.original_guid.must_equal 'http://99percentinvisible.prx.org/?p=1253'
-    episode.published_at.must_equal episode.published_at
-    episode.url.must_equal 'http://99percentinvisible.prx.org/2016/10/18/232-mcmansion-hell/'
-    episode.author_name.must_equal 'Roman Mars'
-    episode.author_email.must_equal 'roman@99pi.org'
-    episode.title.must_equal '232- McMansion Hell'
-    episode.subtitle.must_equal 'Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact...'
-    episode.content.must_equal "<p>Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact with their environment. Kate Wagner, architecture critic and creator of <a href=\"http://www.mcmansionhell.com/\">McMansion Hell</a>, is on a mission to illustrate just why these buildings are so terrible.</p>\n<p><a href=\"http://99percentinvisible.org/?p=15841&amp;post_type=episode\">McMansion Hell: The Devil is in the Details</a></p>\n<p><a href=\"https://www.commitchange.com/ma/cambridge/prx-inc/campaigns/radiotopia-fall-campaign-2016\">Support 99pi and Radiotopia today</a>! Be part of the 5000 backer FreshBooks challenge: FreshBooks will donate $40,000 to Radiotopia if we get 5000 total new donations during this drive. <a href=\"https://www.freshbooks.com\">FreshBooks</a> makes intuitive and beautiful cloud accounting software for small businesses.</p>\n"
-    episode.summary.must_equal 'Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact with their environment. Kate Wagner, architecture critic and creator of McMansion Hell, is on a mission to illustrate just why these buildings are so terrible. McMansion Hell: The Devil is in the Details Support 99pi and Radiotopia today! Be part of the 5000 backer FreshBooks challenge: FreshBooks will donate $40,000 to Radiotopia if we get 5000 total new donations during this drive. FreshBooks makes intuitive and beautiful cloud accounting software for small businesses.'
-    episode.explicit.must_equal 'clean'
-    episode.keywords.must_equal ["roman mars", "kate wagner"]
-    episode.description.must_equal 'Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact with their environment. Kate Wagner, architecture critic and creator of McMansion Hell, is on a mission to illustrate just why these buildings are so terrible. McMansion Hell: The Devil is in the Details Support 99pi and Radiotopia today! Be part of the 5000 backer FreshBooks challenge: FreshBooks will donate $40,000 to Radiotopia if we get 5000 total new donations during this drive. FreshBooks makes intuitive and beautiful cloud accounting software for small businesses.'
-    episode.categories.must_equal ["99 Percent Invisible", "architecture", "criticism", "design", "excess", "housing crisis", "Kate Wagner", "mcmansion"]
-    episode.block.must_equal false
-    episode.is_closed_captioned.must_equal false
-    episode.position.must_be_nil
-    episode.feedburner_orig_link.must_be_nil
-    episode.feedburner_orig_enclosure_link.must_be_nil
-    episode.wont_be :is_perma_link
+    refute_nil episode.id
+    refute_nil episode.created_at
+    refute_nil episode.updated_at
+    assert_equal episode.podcast_id, podcast.id
+    refute_nil episode.guid
+    assert_nil episode.prx_uri
+    assert_nil episode.deleted_at
+    assert_equal episode.original_guid, 'http://99percentinvisible.prx.org/?p=1253'
+    assert_equal episode.published_at, episode.published_at
+    assert_equal episode.url, 'http://99percentinvisible.prx.org/2016/10/18/232-mcmansion-hell/'
+    assert_equal episode.author_name, 'Roman Mars'
+    assert_equal episode.author_email, 'roman@99pi.org'
+    assert_equal episode.title, '232- McMansion Hell'
+    assert_equal episode.subtitle, 'Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact...'
+    assert_equal episode.content, "<p>Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact with their environment. Kate Wagner, architecture critic and creator of <a href=\"http://www.mcmansionhell.com/\">McMansion Hell</a>, is on a mission to illustrate just why these buildings are so terrible.</p>\n<p><a href=\"http://99percentinvisible.org/?p=15841&amp;post_type=episode\">McMansion Hell: The Devil is in the Details</a></p>\n<p><a href=\"https://www.commitchange.com/ma/cambridge/prx-inc/campaigns/radiotopia-fall-campaign-2016\">Support 99pi and Radiotopia today</a>! Be part of the 5000 backer FreshBooks challenge: FreshBooks will donate $40,000 to Radiotopia if we get 5000 total new donations during this drive. <a href=\"https://www.freshbooks.com\">FreshBooks</a> makes intuitive and beautiful cloud accounting software for small businesses.</p>\n"
+    assert_equal episode.summary, 'Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact with their environment. Kate Wagner, architecture critic and creator of McMansion Hell, is on a mission to illustrate just why these buildings are so terrible. McMansion Hell: The Devil is in the Details Support 99pi and Radiotopia today! Be part of the 5000 backer FreshBooks challenge: FreshBooks will donate $40,000 to Radiotopia if we get 5000 total new donations during this drive. FreshBooks makes intuitive and beautiful cloud accounting software for small businesses.'
+    assert_equal episode.explicit, 'clean'
+    assert_equal episode.keywords, ["roman mars", "kate wagner"]
+    assert_equal episode.description, 'Few forms of contemporary architecture draw as much criticism as the McMansion, a particular type of oversized house that people love to hate. McMansions usually feature 3,000 or more square feet of space and fail to embody a cohesive style or interact with their environment. Kate Wagner, architecture critic and creator of McMansion Hell, is on a mission to illustrate just why these buildings are so terrible. McMansion Hell: The Devil is in the Details Support 99pi and Radiotopia today! Be part of the 5000 backer FreshBooks challenge: FreshBooks will donate $40,000 to Radiotopia if we get 5000 total new donations during this drive. FreshBooks makes intuitive and beautiful cloud accounting software for small businesses.'
+    assert_equal episode.categories, ["99 Percent Invisible", "architecture", "criticism", "design", "excess", "housing crisis", "Kate Wagner", "mcmansion"]
+    assert_equal episode.block, false
+    assert_equal episode.is_closed_captioned, false
+    assert_nil episode.position
+    assert_nil episode.feedburner_orig_link
+    assert_nil episode.feedburner_orig_enclosure_link
+    refute episode.is_perma_link
   end
 
   it 'creates image for entry' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_all)
-    episode.images.first.original_url.must_equal 'http://cdn.99percentinvisible.org/wp-content/uploads/powerpress/99-1400.png?entry=1'
+    assert_equal episode.images.first.original_url, 'http://cdn.99percentinvisible.org/wp-content/uploads/powerpress/99-1400.png?entry=1'
   end
 
   it 'creates enclosure from entry' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry)
-    episode.enclosures.size.must_equal 1
+    assert_equal episode.enclosures.size, 1
   end
 
   it 'updates enclosure from entry' do
@@ -90,23 +90,23 @@ describe EpisodeEntryHandler do
     first_enclosure = episode.enclosure
 
     EpisodeEntryHandler.update_from_entry!(episode, entry)
-    episode.enclosure.must_equal first_enclosure
-    episode.enclosures.size.must_equal 1
+    assert_equal episode.enclosure, first_enclosure
+    assert_equal episode.enclosures.size, 1
 
     episode.enclosure.update_attribute(:original_url, "https://test.com")
     first_enclosure = episode.enclosure
     EpisodeEntryHandler.update_from_entry!(episode, entry)
-    episode.enclosures.size.must_equal 2
+    assert_equal episode.enclosures.size, 2
     replacement_enclosure = episode.enclosures.first
 
-    episode.enclosure.must_equal first_enclosure
-    first_enclosure.original_url.must_equal "https://test.com"
-    replacement_enclosure.original_url.must_equal "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
+    assert_equal episode.enclosure, first_enclosure
+    assert_equal first_enclosure.original_url, "https://test.com"
+    assert_equal replacement_enclosure.original_url, "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
 
     replacement_enclosure.complete!
     replacement_enclosure.replace_resources!
-    episode.enclosures(true).size.must_equal 1
-    episode.enclosure.must_equal replacement_enclosure
+    assert_equal episode.enclosures(true).size, 1
+    assert_equal episode.enclosure, replacement_enclosure
   end
 
   it 'will not changes enclosure when file name same' do
@@ -115,11 +115,11 @@ describe EpisodeEntryHandler do
     episode.enclosures.first.complete!
     first_enclosure = episode.enclosure
 
-    first_enclosure.original_url.must_equal "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
+    assert_equal first_enclosure.original_url, "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
     first_enclosure.update_attribute(:original_url, "http://www.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3")
     EpisodeEntryHandler.update_from_entry!(episode, entry)
-    episode.enclosures(true).size.must_equal 1
-    episode.enclosures.first.original_url.must_equal "http://www.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
+    assert_equal episode.enclosures(true).size, 1
+    assert_equal episode.enclosures.first.original_url, "http://www.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
   end
 
   it 'updates enclosure when only file name changes' do
@@ -128,18 +128,18 @@ describe EpisodeEntryHandler do
     episode.enclosures.first.complete!
     first_enclosure = episode.enclosure
 
-    first_enclosure.original_url.must_equal "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
+    assert_equal first_enclosure.original_url, "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
     first_enclosure.update_attribute(:original_url, "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12_original.mp3")
     EpisodeEntryHandler.update_from_entry!(episode, entry)
-    episode.enclosures(true).size.must_equal 2
-    episode.enclosures.first.original_url.must_equal "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
-    episode.enclosures.last.original_url.must_equal "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12_original.mp3"
+    assert_equal episode.enclosures(true).size, 2
+    assert_equal episode.enclosures.first.original_url, "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12.mp3"
+    assert_equal episode.enclosures.last.original_url, "http://dts.podtrac.com/redirect.mp3/files.serialpodcast.org/sites/default/files/podcast/1445350094/serial-s01-e12_original.mp3"
   end
 
   it 'creates contents from entry' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry)
-    episode.all_contents.size.must_equal 2
+    assert_equal episode.all_contents.size, 2
   end
 
   it 'updates contents from entry' do
@@ -154,25 +154,25 @@ describe EpisodeEntryHandler do
 
     EpisodeEntryHandler.update_from_entry!(episode, entry)
     episode.reload
-    episode.all_contents.first.must_equal first_content
-    episode.all_contents.last.must_equal last_content
+    assert_equal episode.all_contents.first, first_content
+    assert_equal episode.all_contents.last, last_content
 
     first_content = episode.contents.first
-    first_content.original_url.must_equal 'https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio.mp3'
+    assert_equal first_content.original_url, 'https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio.mp3'
     first_content.update_attributes(original_url: 'https://prx-dovetail.amazonaws.com/testserial/serial_audio.mp3')
     EpisodeEntryHandler.update_from_entry!(episode, entry)
-    episode.all_contents(true).size.must_equal 2
+    assert_equal episode.all_contents(true).size, 2
 
     first_content.update_attributes(original_url: 'https://s3.amazonaws.com/prx-dovetail/testserial/serial_audio_original.mp3')
     EpisodeEntryHandler.update_from_entry!(episode, entry)
-    episode.all_contents(true).size.must_equal 3
-    episode.all_contents.group_by(&:position)[first_content.position].size.must_equal 2
+    assert_equal episode.all_contents(true).size, 3
+    assert_equal episode.all_contents.group_by(&:position)[first_content.position].size, 2
   end
 
   it 'creates contents with no enclosure' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_no_enclosure)
-    episode.all_contents.size.must_equal 2
+    assert_equal episode.all_contents.size, 2
   end
 
   it 'uses first content url when there is no enclosure' do
@@ -180,22 +180,22 @@ describe EpisodeEntryHandler do
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_no_enclosure)
     episode.all_contents.first.complete!
     episode.reload
-    episode.media_url.must_match /#{episode.contents.first.guid}.mp3$/
+    assert_match(/#{episode.contents.first.guid}.mp3$/, episode.media_url)
   end
 
   it 'returns nil for media_url when there is no audio' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_no_enclosure)
     episode.all_contents.clear
-    episode.media_url.must_be_nil
+    assert_nil episode.media_url
   end
 
   it 'return include in feed and has_media false when no audio' do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_no_enclosure)
     episode.all_contents.clear
-    episode.wont_be :media?
-    episode.wont_be :media_ready?
-    episode.must_be :include_in_feed?
+    refute episode.media?
+    refute episode.media_ready?
+    assert episode.include_in_feed?
   end
 end

--- a/test/models/episode_image_test.rb
+++ b/test/models/episode_image_test.rb
@@ -6,7 +6,7 @@ describe EpisodeImage do
       episode = create(:episode)
       image = episode.image
 
-      image.episode.must_equal episode
+      assert_equal image.episode, episode
     end
   end
 
@@ -15,15 +15,15 @@ describe EpisodeImage do
     let (:episode) { image.episode }
 
     it 'has a path' do
-      image.destination_path.must_equal "jjgo/#{image.episode.guid}/images/#{image.guid}/image.png"
+      assert_equal image.destination_path, "jjgo/#{image.episode.guid}/images/#{image.guid}/image.png"
     end
 
     it 'has a published url' do
-      image.published_url.must_equal "https://f.prxu.org/jjgo/#{image.episode.guid}/images/#{image.guid}/image.png"
+      assert_equal image.published_url, "https://f.prxu.org/jjgo/#{image.episode.guid}/images/#{image.guid}/image.png"
     end
 
     it 'has a path for episode images' do
-      image.image_path.must_equal "images/#{image.guid}/image.png"
+      assert_equal image.image_path, "images/#{image.guid}/image.png"
     end
   end
 
@@ -33,56 +33,56 @@ describe EpisodeImage do
     end
 
     it 'is valid with correct size and type' do
-      @image.must_be :valid?
+      assert @image.valid?
     end
 
     it 'is valid with no size or type' do
       @image = EpisodeImage.new(original_url: 'test/fixtures/valid_series_image.png')
-      @image.must_be :valid?
+      assert @image.valid?
     end
 
     it 'is invalid without an original url' do
       @image.original_url = nil
-      @image.wont_be :valid?
+      refute @image.valid?
     end
 
     it 'must be a jpg or png' do
       @image.original_url = 'test/fixtures/valid_series_image.png'
-      @image.must_be :valid?
+      assert @image.valid?
 
       @image.original_url = 'test/fixtures/wrong_type_image.gif'
-      @image.wont_be :valid?
+      refute @image.valid?
     end
 
     it 'must be under 3000x3000' do
       @image.original_url = 'test/fixtures/too_big_image.jpg'
-      @image.wont_be :valid?
+      refute @image.valid?
     end
 
     it 'must be greater than 1400x1400' do
       @image.original_url = 'test/fixtures/too_small_image.jpg'
-      @image.wont_be :valid?
+      refute @image.valid?
     end
 
     it 'must be a square' do
       @image.original_url = 'test/fixtures/wrong_proportions_image.jpg'
-      @image.wont_be :valid?
+      refute @image.valid?
     end
 
     it 'can be a large file' do
       @image.original_url = 'test/fixtures/offshore-logo-3000.jpg'
-      @image.must_be :valid?
-      @image.width.must_equal 3000
+      assert @image.valid?
+      assert_equal @image.width, 3000
     end
 
     it 'handle fastimage error' do
       stub_request(:get, "http://www.prx.org/fakeimageurl.jpg").
         to_return(status: 500, body: '', headers: {})
 
-      lambda do
+      assert_raises(FastImage::ImageFetchFailure) do
         @image.original_url = 'http://www.prx.org/fakeimageurl.jpg'
         @image.valid?
-      end.must_raise(FastImage::ImageFetchFailure)
+      end
     end
   end
 end

--- a/test/models/episode_story_handler_test.rb
+++ b/test/models/episode_story_handler_test.rb
@@ -23,23 +23,23 @@ describe EpisodeStoryHandler do
   it 'can be created from a story' do
     podcast = create(:podcast, prx_uri: '/api/v1/series/36501')
     episode = EpisodeStoryHandler.create_from_story!(story)
-    episode.explicit.must_equal 'clean'
-    episode.wont_be_nil
-    episode.published_at.wont_be_nil
-    episode.published_at.must_equal Time.parse(story.attributes[:published_at])
-    episode.released_at.wont_be_nil
-    episode.released_at.must_equal Time.parse(story.attributes[:released_at])
+    assert_equal episode.explicit, 'clean'
+    refute_nil episode
+    refute_nil episode.published_at
+    assert_equal episode.published_at, Time.parse(story.attributes[:published_at])
+    refute_nil episode.released_at
+    assert_equal episode.released_at, Time.parse(story.attributes[:released_at])
     first_audio = episode.all_contents.first.original_url
     last_audio = episode.all_contents.last.original_url
-    first_audio.must_equal 's3://mediajoint.production.prx.org/public/audio_files/1200648/lcs_spring16_act1.mp3'
-    last_audio.must_equal 's3://mediajoint.production.prx.org/public/audio_files/1200657/broadcast/t01.mp3'
-    episode.description.must_equal 'this is a description'
-    episode.season_number.must_equal 2
-    episode.episode_number.must_equal 4
-    episode.clean_title.must_equal 'Stripped-down title'
-    episode.prx_audio_version_uri.must_equal '/api/v1/audio_versions/35397'
-    episode.audio_version.must_equal 'Audio Version'
-    episode.segment_count.must_equal 4
+    assert_equal first_audio, 's3://mediajoint.production.prx.org/public/audio_files/1200648/lcs_spring16_act1.mp3'
+    assert_equal last_audio, 's3://mediajoint.production.prx.org/public/audio_files/1200657/broadcast/t01.mp3'
+    assert_equal episode.description, 'this is a description'
+    assert_equal episode.season_number, 2
+    assert_equal episode.episode_number, 4
+    assert_equal episode.clean_title, 'Stripped-down title'
+    assert_equal episode.prx_audio_version_uri, '/api/v1/audio_versions/35397'
+    assert_equal episode.audio_version, 'Audio Version'
+    assert_equal episode.segment_count, 4
   end
 
   describe 'with episode identifiers' do
@@ -65,32 +65,32 @@ describe EpisodeStoryHandler do
     it 'sets episode and season numbers from identifiers' do
       podcast = create(:podcast, prx_uri: '/api/v1/series/36501')
       episode = EpisodeStoryHandler.create_from_story!(story)
-      episode.season_number.must_equal 2
-      episode.episode_number.must_equal 4
+      assert_equal episode.season_number, 2
+      assert_equal episode.episode_number, 4
     end
 
     it 'wont use string identifiers' do
       podcast = create(:podcast, prx_uri: '/api/v1/series/32165')
       episode = EpisodeStoryHandler.create_from_story!(invalid_identifiers_story)
-      episode.season_number.must_be_nil
-      episode.episode_number.must_be_nil
+      assert_nil episode.season_number
+      assert_nil episode.episode_number
     end
 
    it 'does not allow identifiers to be zero' do
      podcast = create(:podcast, prx_uri: '/api/v1/series/32164')
      episode = EpisodeStoryHandler.create_from_story!(zero_identifiers_story)
-     episode.season_number.must_be_nil
-     episode.episode_number.must_be_nil
+     assert_nil episode.season_number
+     assert_nil episode.episode_number
    end
 
    it 'blanks out identifiers on update' do
      podcast = create(:podcast, prx_uri: '/api/v1/series/36501')
      episode = EpisodeStoryHandler.create_from_story!(story)
-     episode.season_number.must_be :>, 0
-     episode.episode_number.must_be :>, 0
+     assert_operator episode.season_number, :>, 0
+     assert_operator episode.episode_number, :>, 0
      EpisodeStoryHandler.new(episode).update_from_story(zero_identifiers_story)
-     episode.season_number.must_be_nil
-     episode.episode_number.must_be_nil
+     assert_nil episode.season_number
+     assert_nil episode.episode_number
    end
   end
 end

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -8,106 +8,106 @@ describe Episode do
 
   it 'initializes guid and overrides' do
     e = Episode.new
-    e.guid.wont_be_nil
-    e.overrides.wont_be_nil
+    refute_nil e.guid
+    refute_nil e.overrides
   end
 
   it 'leaves title ampersands alone' do
     episode.title = "Hear & Now"
     episode.save!
-    episode.title.must_equal "Hear & Now"
+    assert_equal episode.title, "Hear & Now"
   end
 
   it 'must belong to a podcast' do
     episode = build_stubbed(:episode)
-    episode.must_be(:valid?)
-    episode.must_respond_to(:podcast)
+    assert episode.valid?
+    assert_respond_to episode, :podcast
 
     episode = build_stubbed(:episode, podcast: nil)
-    episode.wont_be(:valid?)
+    refute episode.valid?
   end
 
   it 'lazily sets the guid' do
     episode = build(:episode, guid: nil)
-    episode.guid.wont_be_nil
+    refute_nil episode.guid
   end
 
   it 'returns a guid to use in the channel item' do
     episode.guid = 'guid'
-    episode.item_guid.must_equal "prx_#{episode.podcast_id}_guid"
+    assert_equal episode.item_guid, "prx_#{episode.podcast_id}_guid"
   end
 
   it 'is ready to add to a feed' do
-    episode.must_be :include_in_feed?
+    assert episode.include_in_feed?
   end
 
   it 'knows if audio is ready' do
     episode.enclosures = [create(:enclosure, episode: episode)]
-    episode.enclosures.first.status.must_equal 'created'
-    episode.enclosures.first.wont_be :complete?
-    episode.must_be :media?
-    episode.wont_be :media_ready?
-    episode.media_status.must_equal 'processing'
+    assert_equal episode.enclosures.first.status, 'created'
+    refute episode.enclosures.first.complete?
+    assert episode.media?
+    refute episode.media_ready?
+    assert_equal episode.media_status, 'processing'
     episode.enclosures.first.complete!
-    episode.enclosure.must_be :complete?
-    episode.must_be :media?
-    episode.must_be :media_ready?
-    episode.media_status.must_equal 'complete'
+    assert episode.enclosure.complete?
+    assert episode.media?
+    assert episode.media_ready?
+    assert_equal episode.media_status, 'complete'
   end
 
   it 'returns an audio content_type by default' do
-    Episode.new.content_type.must_equal 'audio/mpeg'
+    assert_equal Episode.new.content_type, 'audio/mpeg'
   end
 
   it 'returns the first media content_type' do
-    episode.content_type.must_equal 'audio/mpeg'
+    assert_equal episode.content_type, 'audio/mpeg'
   end
 
   it 'proxies podcast_slug to #podcast' do
     podcast = build_stubbed(:podcast)
     episode = build_stubbed(:episode, podcast: podcast)
     podcast.stub(:path, 'podcast path!') do
-      episode.podcast_slug.must_equal('podcast path!')
+      assert_equal episode.podcast_slug, 'podcast path!'
     end
   end
 
   it 'has no audio file until processed' do
     episode = build_stubbed(:episode)
-    episode.media_files.length.must_equal 0
+    assert_equal episode.media_files.length, 0
   end
 
   it 'has one audio file once processed' do
     episode = create(:episode)
-    episode.media_files.length.must_equal 1
+    assert_equal episode.media_files.length, 1
   end
 
   it 'has a 0 duration when unprocessed' do
     episode = build_stubbed(:episode)
-    episode.duration.must_equal 0
+    assert_equal episode.duration, 0
   end
 
   it 'has duration once processed' do
     episode = create(:episode)
     episode.enclosures = [create(:enclosure, episode: episode, status: 'complete', duration: 10)]
-    episode.duration.must_equal 10
+    assert_equal episode.duration, 10
   end
 
   it 'has duration with podcast duration padding' do
     episode = create(:episode)
     episode.enclosures = [create(:enclosure, episode: episode, status: 'complete', duration: 10)]
     episode.podcast.duration_padding = 10
-    episode.duration.must_equal 20
+    assert_equal episode.duration, 20
   end
 
   it 'updates the podcast published date' do
     now = 1.minute.ago
     podcast = episode.podcast
     orig = episode.podcast.published_at
-    now.wont_equal orig
+    refute_equal now, orig
     episode.run_callbacks :save do
       episode.update_attribute(:published_at, now)
     end
-    podcast.reload.published_at.to_i.must_equal now.to_i
+    assert_equal podcast.reload.published_at.to_i, now.to_i
   end
 
   it 'sets one unique identifying episode keyword for tracking purposes' do
@@ -116,8 +116,8 @@ describe Episode do
     episode.run_callbacks :save do
       episode.save
     end
-    episode.reload.keyword_xid.wont_be_nil
-    episode.reload.keyword_xid.must_equal orig_keyword
+    refute_nil episode.reload.keyword_xid
+    assert_equal episode.reload.keyword_xid, orig_keyword
   end
 
   it 'strips non-alphanumeric characters from identifying keyword' do
@@ -125,8 +125,8 @@ describe Episode do
     episode.run_callbacks :save do
       episode.save
     end
-    episode.reload.keyword_xid.wont_be_nil
-    episode.keyword_xid.must_include '241 its a title yay'
+    refute_nil episode.reload.keyword_xid
+    assert_includes episode.keyword_xid, '241 its a title yay'
   end
 
   it 'strips non-alphanumeric characters from all keywords' do
@@ -134,57 +134,57 @@ describe Episode do
     episode.run_callbacks :save do
       episode.save
     end
-    episode.reload.keywords.wont_be_nil
-    episode.keywords.each { |k| k.wont_match(/['?!,']/) }
+    refute_nil episode.reload.keywords
+    episode.keywords.each { |k| refute_match(/['?!,']/, k) }
   end
 
   it 'has a valid itunes episode type' do
-    episode.itunes_type.must_equal('full')
+    assert_equal episode.itunes_type, 'full'
     episode.itunes_type = 'foo'
-    episode.wont_be(:valid?)
+    refute episode.valid?
   end
 
   it 'sets the itunes block to false by default' do
-    episode.wont_be :itunes_block
+    refute episode.itunes_block
     episode.update_attribute(:itunes_block, true)
-    episode.must_be :itunes_block
+    assert episode.itunes_block
   end
 
   it 'sets media files by adding new ones' do
-    episode.all_contents.count.must_equal 0
+    assert_equal episode.all_contents.count, 0
 
     episode.media_files = [build(:content, episode: episode)]
-    episode.all_contents.count.must_equal 1
+    assert_equal episode.all_contents.count, 1
 
     episode.media_files = [build(:content, episode: episode), build(:content, episode: episode)]
-    episode.all_contents.count.must_equal 3
+    assert_equal episode.all_contents.count, 3
   end
 
   it 'deletes media files' do
-    episode.all_contents.count.must_equal 0
+    assert_equal episode.all_contents.count, 0
 
     episode.media_files = [build(:content, episode: episode), build(:content, episode: episode)]
-    episode.all_contents.count.must_equal 2
+    assert_equal episode.all_contents.count, 2
 
     episode.media_files = [build(:content, episode: episode)]
-    episode.all_contents.count.must_equal 2
+    assert_equal episode.all_contents.count, 2
 
     episode.media_files = []
-    episode.all_contents.count.must_equal 0
+    assert_equal episode.all_contents.count, 0
   end
 
   it 'finds existing content based on the last 2 segments of the url' do
     episode.all_contents << build(:content, episode: episode, position: 1)
-    episode.all_contents.first.href.must_equal 's3://prx-testing/test/audio.mp3'
+    assert_equal episode.all_contents.first.href, 's3://prx-testing/test/audio.mp3'
 
-    episode.find_existing_content(1, 's3://prx-testing/test/audio.mp3').wont_be_nil
-    episode.find_existing_content(1, 's3://change-this/test/audio.mp3').wont_be_nil
-    episode.find_existing_content(1, 'http://prx-testing/any/thing/here/test/audio.mp3').wont_be_nil
+    refute_nil episode.find_existing_content(1, 's3://prx-testing/test/audio.mp3')
+    refute_nil episode.find_existing_content(1, 's3://change-this/test/audio.mp3')
+    refute_nil episode.find_existing_content(1, 'http://prx-testing/any/thing/here/test/audio.mp3')
 
-    episode.find_existing_content(1, nil).must_be_nil
-    episode.find_existing_content(1, 's3://prx-testing/changed/audio.mp3').must_be_nil
-    episode.find_existing_content(1, 's3://prx-testing/test/changed.mp3').must_be_nil
-    episode.find_existing_content(2, 's3://prx-testing/test/audio.mp3').must_be_nil
+    assert_nil episode.find_existing_content(1, nil)
+    assert_nil episode.find_existing_content(1, 's3://prx-testing/changed/audio.mp3')
+    assert_nil episode.find_existing_content(1, 's3://prx-testing/test/changed.mp3')
+    assert_nil episode.find_existing_content(2, 's3://prx-testing/test/audio.mp3')
   end
 
   it 'returns explicit_content based on the podcast' do
@@ -193,16 +193,16 @@ describe Episode do
 
     ["explicit", "yes", true].each do |val|
       podcast.explicit = val
-      episode.explicit_content.must_equal true
+      assert_equal episode.explicit_content, true
     end
 
     ["clean", "no", false].each do |val|
       podcast.explicit = val
-      episode.explicit_content.must_equal false
+      assert_equal episode.explicit_content, false
     end
 
     podcast.explicit = nil
-    episode.explicit_content.must_be_nil
+    assert_nil episode.explicit_content
   end
 
   it 'returns explicit_content overriden by the episode' do
@@ -211,13 +211,13 @@ describe Episode do
     podcast.explicit = false
     ["explicit", "yes", true].each do |val|
       episode.explicit = val
-      episode.explicit_content.must_equal true
+      assert_equal episode.explicit_content, true
     end
 
     podcast.explicit = true
     ["clean", "no", false].each do |val|
       episode.explicit = val
-      episode.explicit_content.must_equal false
+      assert_equal episode.explicit_content, false
     end
   end
 
@@ -232,19 +232,19 @@ describe Episode do
     end
 
     it 'lists episodes to release' do
-      podcast.last_build_date.must_be :<, episode.published_at
+      assert_operator podcast.last_build_date, :<, episode.published_at
       episodes = Episode.episodes_to_release
-      episodes.size.must_equal 1
-      episodes.first.must_equal episode
+      assert_equal episodes.size, 1
+      assert_equal episodes.first, episode
     end
 
     it 'updates feed published date after release' do
-      podcast.published_at.must_be :<, episode.published_at
+      assert_operator podcast.published_at, :<, episode.published_at
       episodes = Episode.episodes_to_release
-      episodes.first.must_equal episode
+      assert_equal episodes.first, episode
       Episode.release_episodes!
       podcast.reload
-      podcast.published_at.to_i.must_equal episode.published_at.to_i
+      assert_equal podcast.published_at.to_i, episode.published_at.to_i
     end
   end
 
@@ -262,7 +262,7 @@ describe Episode do
       episode.podcast.enclosure_template = template
       episode.podcast.enclosure_prefix = nil
       new_url = episode.enclosure_url(base_url, original_url)
-      new_url.must_equal("https://#{ENV['DOVETAIL_HOST']}/foo/guid/filename.mp3")
+      assert_equal new_url, "https://#{ENV['DOVETAIL_HOST']}/foo/guid/filename.mp3"
     end
 
     it 'applies prefix to enclosure url' do
@@ -273,7 +273,7 @@ describe Episode do
       episode.podcast.enclosure_template = nil
       episode.podcast.enclosure_prefix = pre
       new_url = episode.enclosure_url(base_url, original_url)
-      new_url.must_equal "#{pre}/test-f.prxu.org/podcast/episode/filename.mp3"
+      assert_equal new_url, "#{pre}/test-f.prxu.org/podcast/episode/filename.mp3"
     end
 
     it 'applies prefix and template' do
@@ -285,7 +285,7 @@ describe Episode do
       episode.podcast.enclosure_template = template
       episode.podcast.enclosure_prefix = pre
       new_url = episode.enclosure_url(base_url, original_url)
-      new_url.must_equal "#{pre}/#{ENV['DOVETAIL_HOST']}/foo/guid/filename.mp3"
+      assert_equal new_url, "#{pre}/#{ENV['DOVETAIL_HOST']}/foo/guid/filename.mp3"
     end
 
     it 'applies template to audio file link' do
@@ -293,39 +293,39 @@ describe Episode do
 
       url = 'http://test-f.prxu.org/podcast/episode/filename.mp3'
       new_url = episode.enclosure_template_url(url)
-      new_url.must_equal('http://foo.com/r.mp3/b/n/test-f.prxu.org/podcast/episode/filename.mp3')
+      assert_equal new_url, 'http://foo.com/r.mp3/b/n/test-f.prxu.org/podcast/episode/filename.mp3'
     end
 
     it 'can include the slug from the podcast' do
       episode.podcast.enclosure_template = "{slug}"
-      episode.enclosure_template_url("http://example.com/foo.mp3").must_equal("foo")
+      assert_equal episode.enclosure_template_url("http://example.com/foo.mp3"), "foo"
     end
 
     it 'can include the guid' do
       episode.podcast.enclosure_template = "{guid}"
-      episode.enclosure_template_url("http://example.com/foo.mp3").must_equal("guid")
+      assert_equal episode.enclosure_template_url("http://example.com/foo.mp3"), "guid"
     end
 
     it 'can include all properties' do
       episode.podcast.enclosure_template = "http://fake.host/{slug}/{guid}{extension}{?host}"
       url = episode.enclosure_template_url("http://example.com/path/filename.extension")
-      url.must_equal("http://fake.host/foo/guid.extension?host=example.com")
+      assert_equal url, "http://fake.host/foo/guid.extension?host=example.com"
     end
 
     it 'gets expansions for original and base urls' do
       base_url = "http://example.com/path/filename.extension"
       original_url = "http://original.com/folder/original.mp3"
       expansions = episode.enclosure_template_expansions(base_url, original_url)
-      expansions[:filename].must_equal "filename.extension"
-      expansions[:host].must_equal "example.com"
-      expansions[:original_filename].must_equal "original.mp3"
-      expansions[:original_host].must_equal "original.com"
+      assert_equal expansions[:filename], "filename.extension"
+      assert_equal expansions[:host], "example.com"
+      assert_equal expansions[:original_filename], "original.mp3"
+      assert_equal expansions[:original_host], "original.com"
     end
 
     it 'can use original properties' do
       episode.podcast.enclosure_template = "http://fake.host/{original_host}/{original_filename}"
       url = episode.enclosure_template_url("http://blah", "http://original.host/path/filename.mp3")
-      url.must_equal("http://fake.host/original.host/filename.mp3")
+      assert_equal url, "http://fake.host/original.host/filename.mp3"
     end
   end
 
@@ -342,7 +342,7 @@ describe Episode do
     it 'can be found by story' do
       create(:episode, prx_uri: '/api/v1/stories/80548')
       episode = Episode.by_prx_story(story)
-      episode.wont_be_nil
+      refute_nil episode
     end
   end
 end

--- a/test/models/feed_image_test.rb
+++ b/test/models/feed_image_test.rb
@@ -4,31 +4,31 @@ describe FeedImage do
   let(:image) { build_stubbed(:feed_image) }
 
   it 'is valid when all attributes are present' do
-    image.must_be(:valid?)
+    assert image.valid?
   end
 
   it 'must have an original url' do
     image.original_url = nil
 
-    image.wont_be(:valid?)
-    image.errors[:original_url].must_include "can't be blank"
+    refute image.valid?
+    assert_includes image.errors[:original_url], "can't be blank"
   end
 
   it 'can have height and width' do
     image.height, image.width = [nil, nil]
 
-    image.must_be(:valid?)
+    assert image.valid?
   end
 
   it 'can have a description' do
     image.description = nil
-    image.must_be(:valid?)
+    assert image.valid?
   end
 
   it 'must be a jpg, png, or gif' do
     image.detect_image_attributes
     image.format = 'bmp'
     image.valid?
-    image.errors[:format].must_include "is not included in the list"
+    assert_includes image.errors[:format], "is not included in the list"
   end
 end

--- a/test/models/itunes_category_test.rb
+++ b/test/models/itunes_category_test.rb
@@ -4,22 +4,22 @@ describe ITunesCategory do
   let(:cat) { build_stubbed(:itunes_category) }
 
   it 'is valid when all attributes are valid' do
-    cat.must_be(:valid?)
+    assert cat.valid?
   end
 
   it 'must have a name on the list' do
     cat.name = 'Space'
-    cat.wont_be(:valid?)
+    refute cat.valid?
   end
 
   it 'must have subcategories on list' do
     cat.subcategories = ['Aviation', 'Space']
-    cat.wont_be(:valid?)
+    refute cat.valid?
   end
 
   it 'must have subcategories that correspond to category' do
     cat.subcategories = ['Aviation', 'Literature']
-    cat.wont_be(:valid?)
-    cat.errors[:subcategories].must_include "Literature is not a valid subcategory"
+    refute cat.valid?
+    assert_includes cat.errors[:subcategories], 'Literature is not a valid subcategory'
   end
 end

--- a/test/models/itunes_image_test.rb
+++ b/test/models/itunes_image_test.rb
@@ -6,7 +6,7 @@ describe ITunesImage do
       podcast = create(:podcast)
       image = podcast.itunes_image
 
-      image.podcast.must_equal podcast
+      assert_equal image.podcast, podcast
     end
   end
 
@@ -16,43 +16,43 @@ describe ITunesImage do
     end
 
     it 'is valid with correct size and type' do
-      @image.must_be(:valid?)
+      assert @image.valid?
     end
 
     it 'is valid with no size or type' do
       @image = ITunesImage.new(original_url: 'test/fixtures/valid_series_image.png')
-      @image.must_be(:valid?)
+      assert @image.valid?
     end
 
     it 'is invalid without a url' do
       @image.original_url = nil
 
-      @image.wont_be(:valid?)
+      refute @image.valid?
     end
 
     it 'must be a jpg or png' do
       @image.original_url = 'test/fixtures/valid_series_image.png'
-      @image.must_be(:valid?)
+      assert @image.valid?
 
       @image.original_url = 'test/fixtures/wrong_type_image.gif'
-      @image.wont_be(:valid?)
+      refute @image.valid?
     end
 
     it 'must be under 2048x2048' do
       @image.original_url = 'test/fixtures/too_big_image.jpg'
-      @image.wont_be(:valid?)
+      refute @image.valid?
     end
 
     it 'must be greater than 1400x1400' do
       @image.original_url = "test/fixtures/too_small_image.jpg"
 
-      @image.wont_be(:valid?)
+      refute @image.valid?
     end
 
     it 'must be a square' do
       @image.original_url = "test/fixtures/wrong_proportions_image.jpg"
 
-      @image.wont_be(:valid?)
+      refute @image.valid?
     end
   end
 end

--- a/test/models/media_resource_test.rb
+++ b/test/models/media_resource_test.rb
@@ -7,23 +7,23 @@ describe MediaResource do
   it 'initializes attributes' do
     mr = MediaResource.new(episode: episode)
     mr.validate
-    mr.guid.wont_be_nil
-    mr.url.wont_be_nil
-    mr.status.must_equal 'created'
+    refute_nil mr.guid
+    refute_nil mr.url
+    assert_equal mr.status, 'created'
   end
 
   it 'answers if it is processed' do
-    media_resource.wont_be :complete?
+    refute media_resource.complete?
     media_resource.complete!
-    media_resource.must_be :complete?
+    assert media_resource.complete?
   end
 
   it 'sets url based on href' do
     mr = MediaResource.new(episode: episode)
-    mr.href.must_be_nil
+    assert_nil mr.href
     mr.href = 'http://test.prxu.org/somefile.mp3'
-    mr.href.must_equal 'http://test.prxu.org/somefile.mp3'
-    mr.original_url.must_equal 'http://test.prxu.org/somefile.mp3'
+    assert_equal mr.href, 'http://test.prxu.org/somefile.mp3'
+    assert_equal mr.original_url, 'http://test.prxu.org/somefile.mp3'
   end
 
   it 'resets processing when href changes' do
@@ -35,13 +35,13 @@ describe MediaResource do
     mr.task = Task.new
 
     mr.href = 'http://test.prxu.org/somefile.mp3'
-    mr.href.must_equal 'http://test.prxu.org/somefile.mp3'
-    mr.original_url.must_equal 'http://test.prxu.org/somefile.mp3'
-    mr.wont_be :complete?
-    mr.task.must_be_nil
+    assert_equal mr.href, 'http://test.prxu.org/somefile.mp3'
+    assert_equal mr.original_url, 'http://test.prxu.org/somefile.mp3'
+    refute mr.complete?
+    assert_nil mr.task
   end
 
   it 'provides audio url based on guid' do
-    media_resource.media_url.must_match /https:\/\/f.prxu.org\/jjgo\/ba047dce-9df5-4132-a04b-31d24c7c55a(\d+)\/ca047dce-9df5-4132-a04b-31d24c7c55a(\d+).mp3/
+    assert_match(/https:\/\/f.prxu.org\/jjgo\/ba047dce-9df5-4132-a04b-31d24c7c55a(\d+)\/ca047dce-9df5-4132-a04b-31d24c7c55a(\d+).mp3/, media_resource.media_url)
   end
 end

--- a/test/models/podcast_feed_handler_test.rb
+++ b/test/models/podcast_feed_handler_test.rb
@@ -15,35 +15,35 @@ describe PodcastFeedHandler do
   it 'create_from_feed' do
     podcast = PodcastFeedHandler.create_from_feed!(feed)
 
-    podcast.id.wont_be_nil
-    podcast.created_at.wont_be_nil
-    podcast.updated_at.wont_be_nil
-    podcast.prx_uri.must_be_nil
-    podcast.deleted_at.must_be_nil
-    podcast.title.must_equal 'Serial'
-    podcast.source_url.must_equal 'https://s3.amazonaws.com/prx-dovetail/testserial/serialpodcast.xml'
-    podcast.link.must_equal 'http://serialpodcast.org'
-    podcast.author_name.must_equal 'This American Life'
-    podcast.owner_name.must_be_nil
-    podcast.owner_email.must_equal 'rich@strangebirdlabs.com'
-    podcast.managing_editor_name.must_equal 'This American Life'
-    podcast.managing_editor_email.must_equal 'chad@thislife.org'
-    podcast.new_feed_url.must_equal 'https://s3.amazonaws.com/prx-dovetail/testserial/newserialpodcast.xml'
+    refute_nil podcast.id
+    refute_nil podcast.created_at
+    refute_nil podcast.updated_at
+    assert_nil podcast.prx_uri
+    assert_nil podcast.deleted_at
+    assert_equal podcast.title, 'Serial'
+    assert_equal podcast.source_url, 'https://s3.amazonaws.com/prx-dovetail/testserial/serialpodcast.xml'
+    assert_equal podcast.link, 'http://serialpodcast.org'
+    assert_equal podcast.author_name, 'This American Life'
+    assert_nil podcast.owner_name
+    assert_equal podcast.owner_email, 'rich@strangebirdlabs.com'
+    assert_equal podcast.managing_editor_name, 'This American Life'
+    assert_equal podcast.managing_editor_email, 'chad@thislife.org'
+    assert_equal podcast.new_feed_url, 'https://s3.amazonaws.com/prx-dovetail/testserial/newserialpodcast.xml'
   end
 
   it 'update_from_feed' do
     podcast = Podcast.new
     PodcastFeedHandler.update_from_feed!(podcast, feed)
 
-    podcast.title.must_equal 'Serial'
-    podcast.source_url.must_equal 'https://s3.amazonaws.com/prx-dovetail/testserial/serialpodcast.xml'
-    podcast.link.must_equal 'http://serialpodcast.org'
-    podcast.author_name.must_equal 'This American Life'
-    podcast.owner_name.must_be_nil
-    podcast.owner_email.must_equal 'rich@strangebirdlabs.com'
-    podcast.managing_editor_name.must_equal 'This American Life'
-    podcast.managing_editor_email.must_equal 'chad@thislife.org'
-    podcast.new_feed_url.must_equal 'https://s3.amazonaws.com/prx-dovetail/testserial/newserialpodcast.xml'
+    assert_equal podcast.title, 'Serial'
+    assert_equal podcast.source_url, 'https://s3.amazonaws.com/prx-dovetail/testserial/serialpodcast.xml'
+    assert_equal podcast.link, 'http://serialpodcast.org'
+    assert_equal podcast.author_name, 'This American Life'
+    assert_nil podcast.owner_name
+    assert_equal podcast.owner_email, 'rich@strangebirdlabs.com'
+    assert_equal podcast.managing_editor_name, 'This American Life'
+    assert_equal podcast.managing_editor_email, 'chad@thislife.org'
+    assert_equal podcast.new_feed_url, 'https://s3.amazonaws.com/prx-dovetail/testserial/newserialpodcast.xml'
   end
 
   it 'update_images' do
@@ -59,8 +59,8 @@ describe PodcastFeedHandler do
 
     handler.update_images
 
-    handler.podcast.feed_images.first.original_url.must_equal 'http://prx.org/thumb.png'
-    handler.podcast.itunes_images.first.original_url.must_equal 'http://prx.org/image.png'
+    assert_equal handler.podcast.feed_images.first.original_url, 'http://prx.org/thumb.png'
+    assert_equal handler.podcast.itunes_images.first.original_url, 'http://prx.org/image.png'
   end
 
   it 'update_categories' do
@@ -73,8 +73,8 @@ describe PodcastFeedHandler do
 
     handler.update_categories
 
-    podcast.itunes_categories.size.must_equal 1
-    podcast.itunes_categories.first.name.must_equal "Science"
-    podcast.categories.first.must_equal "Fictional"
+    assert_equal podcast.itunes_categories.size, 1
+    assert_equal podcast.itunes_categories.first.name, "Science"
+    assert_equal podcast.categories.first, "Fictional"
   end
 end

--- a/test/models/podcast_series_handler_test.rb
+++ b/test/models/podcast_series_handler_test.rb
@@ -24,13 +24,13 @@ describe PodcastSeriesHandler do
 
   it 'can be created from a series' do
     podcast = PodcastSeriesHandler.create_from_series!(series)
-    podcast.wont_be_nil
-    podcast.title.must_equal 'The Moth Radio Hour'
-    podcast.description.must_match /^Brought to you by PRX/
-    podcast.summary.must_be_nil
-    podcast.subtitle.must_match /^The Moth Radio Hour is a weekly series/
+    refute_nil podcast
+    assert_equal podcast.title, 'The Moth Radio Hour'
+    assert_match(/^Brought to you by PRX/, podcast.description)
+    assert_nil podcast.summary
+    assert_match(/^The Moth Radio Hour is a weekly series/, podcast.subtitle)
 
-    podcast.itunes_images.first.original_url.must_equal profile
-    podcast.feed_image.must_be_nil
+    assert_equal podcast.itunes_images.first.original_url, profile
+    assert_nil podcast.feed_image
   end
 end

--- a/test/models/podcast_test.rb
+++ b/test/models/podcast_test.rb
@@ -8,30 +8,30 @@ describe Podcast do
   let(:podcast) { create(:podcast) }
 
   it 'has episodes' do
-    podcast.must_respond_to(:episodes)
+    assert_respond_to podcast, :episodes
   end
 
   it 'has a default enclosure template' do
     podcast = Podcast.new.tap {|p| p.valid? }
-    podcast.enclosure_template_default.must_match /^http/
-    podcast.enclosure_template.must_equal podcast.enclosure_template_default
+    assert_match(/^http/, podcast.enclosure_template_default)
+    assert_equal podcast.enclosure_template, podcast.enclosure_template_default
   end
 
   it 'has iTunes categories' do
-    podcast.must_respond_to(:itunes_categories)
+    assert_respond_to podcast, :itunes_categories
   end
 
   it 'is episodic or serial' do
-    podcast.itunes_type.must_match /episodic/
+    assert_match(/episodic/, podcast.itunes_type)
     podcast.update_attributes(serial_order: true)
-    podcast.itunes_type.must_match /serial/
+    assert_match(/serial/, podcast.itunes_type)
   end
 
   it 'updates last build date after update' do
     Timecop.freeze
     podcast.update_attributes(managing_editor: 'Brian Fernandez')
 
-    podcast.last_build_date.must_equal Time.now
+    assert_equal podcast.last_build_date, Time.now
 
     Timecop.return
   end
@@ -39,36 +39,36 @@ describe Podcast do
   it 'wont nil out podcast published_at' do
     ep = podcast.episodes.create(published_at: 1.week.ago)
     pub_at = podcast.reload.published_at
-    podcast.published_at.wont_be_nil
+    refute_nil podcast.published_at
 
     ep.update_attributes(published_at: 1.week.from_now)
     podcast.reload
-    podcast.published_at.wont_be_nil
-    podcast.published_at.wont_equal ep.published_at
-    podcast.published_at.wont_equal pub_at
+    refute_nil podcast.published_at
+    refute_equal podcast.published_at, ep.published_at
+    refute_equal podcast.published_at, pub_at
 
     ep.destroy
-    podcast.reload.published_at.wont_be_nil
+    refute_nil podcast.reload.published_at
   end
 
   it 'sets the itunes block to false by default' do
-    podcast.wont_be :itunes_block
+    refute podcast.itunes_block
     podcast.update_attribute(:itunes_block, true)
-    podcast.must_be :itunes_block
+    assert podcast.itunes_block
   end
 
   describe 'publishing' do
 
     it 'creates a publish job on publish' do
       podcast.stub(:create_publish_job, "published!") do
-        podcast.publish!.must_equal 'published!'
+        assert_equal podcast.publish!, 'published!'
       end
     end
 
     it 'wont create a publish job when podcast is locked' do
       podcast.stub(:create_publish_job, 'published!') do
         podcast.locked = true
-        podcast.publish!.wont_equal 'published!'
+        refute_equal podcast.publish!, 'published!'
       end
     end
   end
@@ -77,10 +77,10 @@ describe Podcast do
     let(:episodes) { create_list(:episode, 10, podcast: podcast).reverse }
 
     it 'returns only limited number of episodes' do
-      episodes.count.must_equal podcast.episodes.count
-      podcast.feed_episodes.count.must_equal 10
+      assert_equal episodes.count, podcast.episodes.count
+      assert_equal podcast.feed_episodes.count, 10
       podcast.display_episodes_count = 5
-      podcast.feed_episodes.count.must_equal 5
+      assert_equal podcast.feed_episodes.count, 5
     end
   end
 end

--- a/test/models/task_test.rb
+++ b/test/models/task_test.rb
@@ -7,31 +7,31 @@ describe Task do
   let(:task) { Task.create }
 
   it 'knows what bucket to drop the file in' do
-    task.feeder_storage_bucket.must_equal 'test-prx-feed'
+    assert_equal task.feeder_storage_bucket, 'test-prx-feed'
   end
 
   it 'uses an sqs queue for callbacks' do
     r, ENV['AWS_REGION'], ENV['FIXER_CALLBACK_QUEUE'], q = ENV['AWS_REGION'], 'us-east-1', nil, ENV['FIXER_CALLBACK_QUEUE']
-    task.callback_queue.must_equal 'sqs://us-east-1/test_feeder_fixer_callback'
+    assert_equal task.callback_queue, 'sqs://us-east-1/test_feeder_fixer_callback'
     ENV['AWS_REGION'], ENV['FIXER_CALLBACK_QUEUE'] = r, q
   end
 
   it 'handles porter callbacks' do
     task.update_attribute(:job_id, porter_task['JobResult']['Job']['Id'])
-    task.must_be :started?
+    assert task.started?
     Task.callback(porter_task)
-    task.reload.must_be :complete?
-    task.logged_at.must_equal Time.parse('2012-12-21T12:34:56Z')
+    assert task.reload.complete?
+    assert_equal task.logged_at, Time.parse('2012-12-21T12:34:56Z')
   end
 
   it 'ignores porter task results' do
     task.update_attribute(:job_id, porter_task['JobResult']['Job']['Id'])
-    task.must_be :started?
-    task.logged_at.must_be_nil
+    assert task.started?
+    assert_nil task.logged_at
 
     porter_task['TaskResult'] = porter_task.delete('JobResult')
     Task.callback(porter_task)
-    task.reload.must_be :started?
-    task.logged_at.must_be_nil
+    assert task.reload.started?
+    assert_nil task.logged_at
   end
 end

--- a/test/models/tasks/copy_image_task_test.rb
+++ b/test/models/tasks/copy_image_task_test.rb
@@ -6,21 +6,21 @@ describe Tasks::CopyImageTask do
 
   it 'has task options' do
     opts = task.task_options
-    opts[:job_type].must_equal 'file'
-    opts[:source].must_equal image.original_url
-    opts[:destination].must_match /s3:\/\/test-prx-feed\/jjgo\/ba047dce-9df5-4132-a04b-31d24c7c55a(\d+)\/images\/4e745a8c-77ee-481c-a72b-fd868dfd1c9(\d+)\/image\.png/
+    assert_equal opts[:job_type], 'file'
+    assert_equal opts[:source], image.original_url
+    assert_match(/s3:\/\/test-prx-feed\/jjgo\/ba047dce-9df5-4132-a04b-31d24c7c55a(\d+)\/images\/4e745a8c-77ee-481c-a72b-fd868dfd1c9(\d+)\/image\.png/, opts[:destination])
   end
 
   it 'gets the image path' do
-    task.image_path(image).must_equal "/jjgo/#{image.episode.guid}/images/#{image.guid}/image.png"
+    assert_equal task.image_path(image), "/jjgo/#{image.episode.guid}/images/#{image.guid}/image.png"
   end
 
   it 'updates status before save' do
-    task.status.must_equal 'complete'
-    task.image_resource.status.must_equal 'complete'
+    assert_equal task.status, 'complete'
+    assert_equal task.image_resource.status, 'complete'
     task.update_attributes(status: 'processing')
-    task.status.must_equal 'processing'
-    task.image_resource.status.must_equal 'processing'
+    assert_equal task.status, 'processing'
+    assert_equal task.image_resource.status, 'processing'
   end
 
   it 'replaces resources and publishes on complete' do
@@ -46,14 +46,14 @@ describe Tasks::CopyImageTask do
     task.image_resource.update_attributes(url: 'what/ever')
 
     task.update_attributes(status: 'created')
-    task.image_resource[:url].must_equal 'what/ever'
-    task.image_resource.url.wont_equal 'what/ever'
-    task.image_resource.url.must_equal task.image_resource.original_url
+    assert_equal task.image_resource[:url], 'what/ever'
+    refute_equal task.image_resource.url, 'what/ever'
+    assert_equal task.image_resource.url, task.image_resource.original_url
 
     task.update_attributes(status: 'complete')
-    task.image_resource[:url].wont_equal 'what/ever'
-    task.image_resource[:url].must_equal task.image_resource.published_url
-    task.image_resource.url.wont_equal 'what/ever'
-    task.image_resource.url.must_equal task.image_resource.published_url
+    refute_equal task.image_resource[:url], 'what/ever'
+    assert_equal task.image_resource[:url], task.image_resource.published_url
+    refute_equal task.image_resource.url, 'what/ever'
+    assert_equal task.image_resource.url, task.image_resource.published_url
   end
 end

--- a/test/policies/application_policy_test.rb
+++ b/test/policies/application_policy_test.rb
@@ -5,14 +5,14 @@ describe ApplicationPolicy do
   let(:resource) { 'resource' }
 
   it 'prevents create' do
-    ApplicationPolicy.new(token, resource).wont_allow :create?
+    refute ApplicationPolicy.new(token, resource).create?
   end
 
   it 'prevents update' do
-    ApplicationPolicy.new(token, resource).wont_allow :update?
+    refute ApplicationPolicy.new(token, resource).update?
   end
 
   it 'prevents destroy' do
-    ApplicationPolicy.new(token, resource).wont_allow :destroy?
+    refute ApplicationPolicy.new(token, resource).destroy?
   end
 end

--- a/test/policies/episode_policy_test.rb
+++ b/test/policies/episode_policy_test.rb
@@ -11,27 +11,27 @@ describe EpisodePolicy do
 
   describe '#update?, #create?, and #delete?' do
     it 'returns false if token is not present' do
-      EpisodePolicy.new(nil, episode).wont_allow :update?
-      EpisodePolicy.new(nil, episode).wont_allow :create?
-      EpisodePolicy.new(nil, episode).wont_allow :destroy?
+      refute EpisodePolicy.new(nil, episode).update?
+      refute EpisodePolicy.new(nil, episode).create?
+      refute EpisodePolicy.new(nil, episode).destroy?
     end
 
     it 'returns false if token is not a member of the account' do
-      EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).wont_allow :update?
-      EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).wont_allow :create?
-      EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).wont_allow :destroy?
+      refute EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).update?
+      refute EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).create?
+      refute EpisodePolicy.new(token('feeder:episode', account_id + 1), episode).destroy?
     end
 
     it 'returns true if token is a member of the account' do
-      EpisodePolicy.new(token('feeder:episode'), episode).must_allow :update?
-      EpisodePolicy.new(token('feeder:episode'), episode).must_allow :create?
-      EpisodePolicy.new(token('feeder:episode'), episode).must_allow :destroy?
+      assert EpisodePolicy.new(token('feeder:episode'), episode).update?
+      assert EpisodePolicy.new(token('feeder:episode'), episode).create?
+      assert EpisodePolicy.new(token('feeder:episode'), episode).destroy?
     end
 
     it 'returns false if the token lacks the episode scope' do
-      EpisodePolicy.new(token('feeder:read-private'), episode).wont_allow :update?
-      EpisodePolicy.new(token('feeder:read-private'), episode).wont_allow :create?
-      EpisodePolicy.new(token('feeder:read-private'), episode).wont_allow :destroy?
+      refute EpisodePolicy.new(token('feeder:read-private'), episode).update?
+      refute EpisodePolicy.new(token('feeder:read-private'), episode).create?
+      refute EpisodePolicy.new(token('feeder:read-private'), episode).destroy?
     end
 
     it 'returns false if changing podcast from one the token has no access to' do

--- a/test/policies/podcast_policy_test.rb
+++ b/test/policies/podcast_policy_test.rb
@@ -10,19 +10,19 @@ describe PodcastPolicy do
 
   describe '#update?' do
     it 'returns false if token is not present' do
-      PodcastPolicy.new(nil, podcast).wont_allow :update?
+      refute PodcastPolicy.new(nil, podcast).update?
     end
 
     it 'returns false if token is not a member of the account' do
-      PodcastPolicy.new(token('feeder:podcast-edit', account_id + 1), podcast).wont_allow :update?
+      refute PodcastPolicy.new(token('feeder:podcast-edit', account_id + 1), podcast).update?
     end
 
     it 'returns true if token is a member of the account and has edit scope' do
-      PodcastPolicy.new(token('feeder:podcast-edit'), podcast).must_allow :update?
+      assert PodcastPolicy.new(token('feeder:podcast-edit'), podcast).update?
     end
 
     it 'returns false if token lacks edit scope' do
-      PodcastPolicy.new(token('feeder:podcast-create feeder:podcast-delete'), podcast).wont_allow :update?
+      refute PodcastPolicy.new(token('feeder:podcast-create feeder:podcast-delete'), podcast).update?
     end
 
     it 'disallows changing the account id of a podcast which the token did not previously have access to' do
@@ -35,37 +35,37 @@ describe PodcastPolicy do
 
   describe '#create?' do
     it 'returns false if token is not present' do
-      PodcastPolicy.new(nil, podcast).wont_allow :create?
+      refute PodcastPolicy.new(nil, podcast).create?
     end
 
     it 'returns false if token is not a member of the account' do
-      PodcastPolicy.new(token('feeder:podcast-create', account_id + 1), podcast).wont_allow :create?
+      refute PodcastPolicy.new(token('feeder:podcast-create', account_id + 1), podcast).create?
     end
 
     it 'returns true if token is a member of the account and has create scope' do
-      PodcastPolicy.new(token('feeder:podcast-create'), podcast).must_allow :create?
+      assert PodcastPolicy.new(token('feeder:podcast-create'), podcast).create?
     end
 
     it 'returns false if token lacks create scope' do
-      PodcastPolicy.new(token('feeder:podcast-edit feeder:podcast-delete'), podcast).wont_allow :create?
+      refute PodcastPolicy.new(token('feeder:podcast-edit feeder:podcast-delete'), podcast).create?
     end
   end
 
   describe '#destroy?' do
     it 'returns false if token is not present' do
-      PodcastPolicy.new(nil, podcast).wont_allow :destroy?
+      refute PodcastPolicy.new(nil, podcast).destroy?
     end
 
     it 'returns false if token is not a member of the account' do
-      PodcastPolicy.new(token('feeder:podcast-delete', account_id + 1), podcast).wont_allow :destroy?
+      refute PodcastPolicy.new(token('feeder:podcast-delete', account_id + 1), podcast).destroy?
     end
 
     it 'returns true if token is a member of the account and has create scope' do
-      PodcastPolicy.new(token('feeder:podcast-delete'), podcast).must_allow :destroy?
+      assert PodcastPolicy.new(token('feeder:podcast-delete'), podcast).destroy?
     end
 
     it 'returns false if token lacks destroy scope' do
-      PodcastPolicy.new(token('feeder:podcast-create feeder:podcast-edit'), podcast).wont_allow :destroy?
+      refute PodcastPolicy.new(token('feeder:podcast-create feeder:podcast-edit'), podcast).destroy?
     end
   end
 end

--- a/test/representers/api/api_representer_test.rb
+++ b/test/representers/api/api_representer_test.rb
@@ -10,20 +10,20 @@ describe Api::ApiRepresenter do
   let(:json)        { JSON.parse(representer.to_json) }
 
   it 'create api representer' do
-    representer.wont_be_nil
+    refute_nil representer
   end
 
   it 'use api representer to create json' do
-    json['version'].must_equal '1.0'
-    json.keys.sort.must_equal ['_links', 'version']
+    assert_equal json['version'], '1.0'
+    assert_equal json.keys.sort, ['_links', 'version']
   end
 
   it 'return root doc with links for an api version' do
-    json['_links']['self']['href'].must_equal '/api/1.0'
-    json['_links']['prx:episode'].size.must_equal 1
-    json['_links']['prx:episodes'].size.must_equal 1
-    json['_links']['prx:podcast'].size.must_equal 1
-    json['_links']['prx:podcasts'].size.must_equal 1
-    json['_links']['prx:authorization'].must_be_instance_of Hash
+    assert_equal json['_links']['self']['href'], '/api/1.0'
+    assert_equal json['_links']['prx:episode'].size, 1
+    assert_equal json['_links']['prx:episodes'].size, 1
+    assert_equal json['_links']['prx:podcast'].size, 1
+    assert_equal json['_links']['prx:podcasts'].size, 1
+    assert_instance_of Hash, json['_links']['prx:authorization']
   end
 end

--- a/test/representers/api/auth/episode_representer_test.rb
+++ b/test/representers/api/auth/episode_representer_test.rb
@@ -7,6 +7,6 @@ describe Api::Auth::EpisodeRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   it 'has authorized links' do
-    json['_links']['self']['href'].must_equal "/api/v1/authorization/episodes/#{episode.guid}"
+    assert_equal json['_links']['self']['href'], "/api/v1/authorization/episodes/#{episode.guid}"
   end
 end

--- a/test/representers/api/auth/podcast_representer_test.rb
+++ b/test/representers/api/auth/podcast_representer_test.rb
@@ -7,7 +7,7 @@ describe Api::Auth::PodcastRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   it 'has authorized links' do
-    json['_links']['self']['href'].must_equal "/api/v1/authorization/podcasts/#{podcast.id}"
-    json['_links']['prx:episodes']['href'].must_match "/api/v1/authorization/podcasts/#{podcast.id}/episodes"
+    assert_equal json['_links']['self']['href'], "/api/v1/authorization/podcasts/#{podcast.id}"
+    assert_match("/api/v1/authorization/podcasts/#{podcast.id}/episodes", json['_links']['prx:episodes']['href'])
   end
 end

--- a/test/representers/api/authorization_representer_test.rb
+++ b/test/representers/api/authorization_representer_test.rb
@@ -11,22 +11,22 @@ describe Api::AuthorizationRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   it 'has link to episodes' do
-    episode.id.wont_be_nil
-    json['_links']['prx:episodes'].wont_be_nil
-    json['_links']['prx:episodes']['count'].must_equal 1
+    refute_nil episode.id
+    refute_nil json['_links']['prx:episodes']
+    assert_equal json['_links']['prx:episodes']['count'], 1
   end
 
   it 'has link to episode' do
-    json['_links']['prx:episode'].wont_be_nil
+    refute_nil json['_links']['prx:episode']
   end
 
   it 'has link to podcasts' do
-    podcast.id.wont_be_nil
-    json['_links']['prx:podcasts'].wont_be_nil
-    json['_links']['prx:podcasts']['count'].must_equal 1
+    refute_nil podcast.id
+    refute_nil json['_links']['prx:podcasts']
+    assert_equal json['_links']['prx:podcasts']['count'], 1
   end
 
   it 'has link to podcast' do
-    json['_links']['prx:podcast'].wont_be_nil
+    refute_nil json['_links']['prx:podcast']
   end
 end

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -7,87 +7,87 @@ describe Api::EpisodeRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   it 'includes basic properties' do
-    json['prxUri'].must_match /\/api\/v1\/stories\//
-    json['summary'].must_match /<a href="\/tina">Tina<\/a>/
+    assert_match(/\/api\/v1\/stories\//, json['prxUri'])
+    assert_match(/<a href="\/tina">Tina<\/a>/, json['summary'])
   end
 
   it 'includes clean title, season, episode, and ep type info' do
-    json['seasonNumber'].must_be_instance_of(Fixnum)
-    json['episodeNumber'].must_be_instance_of(Fixnum)
-    json['cleanTitle'].must_match /Clean title/
-    json['itunesType'].must_equal 'full'
-    json['itunesBlock'].must_equal false
+    assert_instance_of Fixnum, json['seasonNumber']
+    assert_instance_of Fixnum, json['episodeNumber']
+    assert_match(/Clean title/, json['cleanTitle'])
+    assert_equal json['itunesType'], 'full'
+    assert_equal json['itunesBlock'], false
   end
 
   it 'indicates if the episode media is not ready' do
-    json['isFeedReady'].must_equal true
+    assert_equal json['isFeedReady'], true
   end
 
   it 'includes an explicit_content value from the podcast' do
-    episode.explicit.must_be_nil
-    episode.podcast.must_be :explicit
-    json['explicitContent'].must_equal true
+    assert_nil episode.explicit
+    assert episode.podcast.explicit
+    assert_equal json['explicitContent'], true
   end
 
   it 'nil explicit_content left out of the json' do
     episode.explicit = nil
     episode.podcast.explicit = nil
-    json.key?('explicitContent').must_equal false
+    assert_equal json.key?('explicitContent'), false
   end
 
   it 'indicates if the episode media is not ready' do
     episode.enclosure.update_attributes(status: 'error')
-    json['isFeedReady'].must_equal false
+    assert_equal json['isFeedReady'], false
   end
 
   it 'uses summary when not blank' do
     episode.summary = 'summary has <a href="/">a link</a>'
     episode.description = '<b>tags</b> removed, <a href="/">links remain</a>'
-    json['summary'].must_equal episode.summary
-    json['summaryPreview'].must_be_nil
-    json['description'].must_equal episode.description
+    assert_equal json['summary'], episode.summary
+    assert_nil json['summaryPreview']
+    assert_equal json['description'], episode.description
   end
 
   it 'uses sanitized description for nil summary' do
     episode.summary = nil
     episode.description = '<b>tags</b> removed, <a href="/">links remain</a>'
-    json['summary'].must_be_nil
-    json['summaryPreview'].must_equal 'tags removed, <a href="/">links remain</a>'
-    json['description'].must_equal episode.description
+    assert_nil json['summary']
+    assert_equal json['summaryPreview'], 'tags removed, <a href="/">links remain</a>'
+    assert_equal json['description'], episode.description
   end
 
   it 'has links' do
-    json['_links']['self']['href'].must_equal "/api/v1/episodes/#{episode.guid}"
-    json['_links']['prx:podcast']['href'].must_equal "/api/v1/podcasts/#{episode.podcast.id}"
-    json['_links']['prx:story']['href'].must_equal "https://cms.prx.org#{episode.prx_uri}"
-    json['_links']['prx:audio-version']['href'].must_equal "https://cms.prx.org#{episode.prx_audio_version_uri}"
+    assert_equal json['_links']['self']['href'], "/api/v1/episodes/#{episode.guid}"
+    assert_equal json['_links']['prx:podcast']['href'], "/api/v1/podcasts/#{episode.podcast.id}"
+    assert_equal json['_links']['prx:story']['href'], "https://cms.prx.org#{episode.prx_uri}"
+    assert_equal json['_links']['prx:audio-version']['href'], "https://cms.prx.org#{episode.prx_audio_version_uri}"
   end
 
   it 'has media' do
-    json['media'].size.must_equal 1
-    json['media'].first['href'].must_equal episode.enclosure.url
-    json['media'].first['original_url'].must_equal episode.enclosure.original_url
+    assert_equal json['media'].size, 1
+    assert_equal json['media'].first['href'], episode.enclosure.url
+    assert_equal json['media'].first['original_url'], episode.enclosure.original_url
   end
 
   it 'has an audio version' do
-    json['audioVersion'].must_equal 'One segment audio'
-    json['segmentCount'].must_equal 1
+    assert_equal json['audioVersion'], 'One segment audio'
+    assert_equal json['segmentCount'], 1
   end
 
   it 'has image' do
-    json['images'].size.must_equal 1
-    json['images'].first['url'].must_equal episode.image.url
-    json['images'].first['original_url'].must_equal episode.image.original_url
+    assert_equal json['images'].size, 1
+    assert_equal json['images'].first['url'], episode.image.url
+    assert_equal json['images'].first['original_url'], episode.image.original_url
   end
 
   it 'has enclosure' do
-    json['_links']['enclosure']['href'].must_equal episode.media_url
+    assert_equal json['_links']['enclosure']['href'], episode.media_url
   end
 
   it 'can represent a sad, podcast-less episode' do
     episode.podcast_id = nil
-    json['guid'].must_equal "prx__#{episode.guid}"
-    json['_links']['enclosure']['href'].must_match "//#{episode.guid}/"
-    json['_links']['prx:podcast'].must_be_nil
+    assert_equal json['guid'], "prx__#{episode.guid}"
+    assert_match("//#{episode.guid}/", json['_links']['enclosure']['href'])
+    assert_nil json['_links']['prx:podcast']
   end
 end

--- a/test/representers/api/media_resource_representer_test.rb
+++ b/test/representers/api/media_resource_representer_test.rb
@@ -6,25 +6,25 @@ describe Api::MediaResourceRepresenter do
 
   it 'includes the href' do
     media_resource.stub(:href, 'url') do
-      representer.as_json['href'].must_equal 'url'
+      assert_equal representer.as_json['href'], 'url'
     end
   end
 
   it 'includes the type' do
     media_resource.stub(:mime_type, 'audio/taco') do
-      representer.as_json['type'].must_equal 'audio/taco'
+      assert_equal representer.as_json['type'], 'audio/taco'
     end
   end
 
   it 'includes the size' do
     media_resource.stub(:file_size, 123456) do
-      representer.as_json['size'].must_equal 123456
+      assert_equal representer.as_json['size'], 123456
     end
   end
 
   it 'includes the duration' do
     media_resource.stub(:duration, 1234) do
-      representer.as_json['duration'].must_equal 1234
+      assert_equal representer.as_json['duration'], 1234
     end
   end
 end

--- a/test/representers/api/podcast_representer_test.rb
+++ b/test/representers/api/podcast_representer_test.rb
@@ -7,47 +7,47 @@ describe Api::PodcastRepresenter do
   let(:json) { JSON.parse(representer.to_json) }
 
   it 'includes basic properties' do
-    json['path'].must_equal 'jjgo'
-    json['prxUri'].must_match /\/api\/v1\/series\//
+    assert_equal json['path'], 'jjgo'
+    assert_match(/\/api\/v1\/series\//, json['prxUri'])
   end
 
   it 'includes itunes categories' do
-    json['itunesCategories'].wont_be_nil
-    json['itunesCategories'].first['name'].must_equal 'Leisure'
+    refute_nil json['itunesCategories']
+    assert_equal json['itunesCategories'].first['name'], 'Leisure'
   end
 
   it 'includes owner' do
-    json['owner']['name'].must_equal 'Jesse Thorn'
-    json['owner']['email'].must_equal 'jesse@maximumfun.org'
+    assert_equal json['owner']['name'], 'Jesse Thorn'
+    assert_equal json['owner']['email'], 'jesse@maximumfun.org'
   end
 
   it 'includes keywords' do
-    json['keywords'].must_include 'laffs'
+    assert_includes json['keywords'], 'laffs'
   end
 
   it 'includes categories' do
-    json['categories'].must_include 'Humor'
+    assert_includes json['categories'], 'Humor'
   end
 
   it 'includes itunes image' do
-    json['itunesImage']['url'].must_equal 'test/fixtures/valid_series_image.jpg'
+    assert_equal json['itunesImage']['url'], 'test/fixtures/valid_series_image.jpg'
   end
 
   it 'includes feed image' do
-    json['feedImage']['url'].must_equal 'test/fixtures/valid_feed_image.png'
+    assert_equal json['feedImage']['url'], 'test/fixtures/valid_feed_image.png'
   end
 
   it 'includes serial v. episodic ordering' do
-    json['serialOrder'].must_equal false
+    assert_equal json['serialOrder'], false
   end
 
   it 'includes itunes block' do
-    json['itunesBlock'].must_equal false
+    assert_equal json['itunesBlock'], false
   end
 
   it 'has links' do
-    json['_links']['self']['href'].must_equal "/api/v1/podcasts/#{podcast.id}"
-    json['_links']['prx:series']['href'].must_equal "https://cms.prx.org#{podcast.prx_uri}"
-    json['_links']['prx:account']['href'].must_equal "https://cms.prx.org#{podcast.prx_account_uri}"
+    assert_equal json['_links']['self']['href'], "/api/v1/podcasts/#{podcast.id}"
+    assert_equal json['_links']['prx:series']['href'], "https://cms.prx.org#{podcast.prx_uri}"
+    assert_equal json['_links']['prx:account']['href'], "https://cms.prx.org#{podcast.prx_account_uri}"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,9 +79,6 @@ class SnsMock
   end
 end
 
-Minitest::Expectations.infect_an_assertion :assert_operator, :must_allow, :reverse
-Minitest::Expectations.infect_an_assertion :refute_operator, :wont_allow, :reverse
-
 class StubToken < PrxAuth::Rails::Token
   @@fake_user_id = 0
 


### PR DESCRIPTION
Pretty much all our tests were using the deprecated `obj.must_equal` syntax.  The main choices are to wrap everything in an underscore `_(obj).must_equal` or convert to a `assert_equal obj, "str"` syntax.  I opted for the latter, as we've gone down that route in other repos.  (And I'm just not a fan of the underscore syntax in ruby).

Didn't make any attempt to rubocop/lint things.  Just finding/replacing.