### PR TITLE
Re-raise job errors

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,7 +3,11 @@ require 'newrelic_rpm'
 class ApplicationJob < ActiveJob::Base
 
   rescue_from(StandardError) do |e|
-    NewRelic::Agent.notice_error(e)
+    begin
+      NewRelic::Agent.notice_error(e)
+    ensure
+      raise e
+    end
   end
 
   around_perform do |job, block|


### PR DESCRIPTION
We were sending job exceptions to New Relic, but not re-raising them.

Also did a bit of reading on [ActiveJob Retries](https://github.com/ruby-shoryuken/shoryuken/issues/553).  I _think_ what happens now is:

- A job raises an exception
- This handler catches it, logs to new relic, and re-raises
- The SQS message is _not_ deleted, but ends up hidden for 1 hour (our visibility timeout)
- After 10 receives/retries (10 hours?), the SQS message goes into the DLQ