### PR TITLE
Include deleted for wildcard token

### DIFF
--- a/app/controllers/api/auth/episodes_controller.rb
+++ b/app/controllers/api/auth/episodes_controller.rb
@@ -26,6 +26,6 @@ class Api::Auth::EpisodesController < Api::EpisodesController
   end
 
   def resources_base
-    @episodes ||= authorization.token_auth_episodes.merge(super)
+    @episodes ||= super.merge(authorization.token_auth_episodes)
   end
 end

--- a/app/controllers/api/auth/podcasts_controller.rb
+++ b/app/controllers/api/auth/podcasts_controller.rb
@@ -21,6 +21,6 @@ class Api::Auth::PodcastsController < Api::PodcastsController
   end
 
   def resources_base
-    @podcasts ||= authorization.token_auth_podcasts.merge(super)
+    @podcasts ||= super.merge(authorization.token_auth_podcasts)
   end
 end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -36,7 +36,7 @@ class Authorization
 
   def token_auth_podcasts
     if token.globally_authorized?('read-private')
-      Podcast.all
+      Podcast.with_deleted.all
     else
       Podcast.where(prx_account_uri: token_auth_account_uris)
     end
@@ -45,7 +45,7 @@ class Authorization
   # avoid joining podcasts here, as it breaks a bunch of other queries
   def token_auth_episodes
     if token.globally_authorized?('read-private')
-      Episode.all
+      Episode.with_deleted.all
     else
       Episode.where(podcast_id: token_auth_podcasts.pluck(:id))
     end

--- a/app/representers/api/auth/episode_representer.rb
+++ b/app/representers/api/auth/episode_representer.rb
@@ -1,4 +1,6 @@
 class Api::Auth::EpisodeRepresenter < Api::EpisodeRepresenter
+  property :deleted_at, writeable: false
+
   def self_url(episode)
     api_authorization_episode_path(id: episode.guid)
   end

--- a/app/representers/api/auth/podcast_representer.rb
+++ b/app/representers/api/auth/podcast_representer.rb
@@ -1,4 +1,6 @@
 class Api::Auth::PodcastRepresenter < Api::PodcastRepresenter
+  property :deleted_at, writeable: false
+
   def self_url(podcast)
     api_authorization_podcast_path(podcast)
   end

--- a/test/controllers/api/auth/episodes_controller_test.rb
+++ b/test/controllers/api/auth/episodes_controller_test.rb
@@ -60,12 +60,14 @@ describe Api::Auth::EpisodesController do
     refute_nil episode.id
     refute_nil episode_unpublished.id
     assert_nil episode_unpublished.published_at
+    refute_nil episode_deleted.id
     get(:index, { api_version: 'v1', format: 'json' } )
     assert_response :success
     list = JSON.parse(response.body)
     ids = list.dig('_embedded', 'prx:items').map{ |i| i['id'] }
     assert_includes ids, episode.guid
     assert_includes ids, episode_unpublished.guid
+    refute_includes ids, episode_deleted.guid
   end
 
   it 'should list for podcast' do
@@ -142,8 +144,8 @@ describe Api::Auth::EpisodesController do
     let (:other_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id + 1}", path: 'foo') }
     let (:other_unpublished_episode) { create(:episode, podcast: other_podcast, published_at: nil) }
 
-    it 'includes all episodes (including unpublished)' do
-      guids = [episode_unpublished.guid, other_unpublished_episode.guid]
+    it 'includes all episodes (including unpublished and deleted)' do
+      guids = [episode_unpublished.guid, other_unpublished_episode.guid, episode_deleted.guid]
       get(:index, { api_version: 'v1', format: 'json' } )
       assert_response :success
       list = JSON.parse(response.body)

--- a/test/controllers/api/auth/podcasts_controller_test.rb
+++ b/test/controllers/api/auth/podcasts_controller_test.rb
@@ -5,6 +5,7 @@ describe Api::Auth::PodcastsController do
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", published_at: nil) }
   let(:published_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", path: 'pod2') }
   let(:other_account_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/9876", path: 'pod3') }
+  let(:deleted_podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}", path: 'pod4', deleted_at: Time.now) }
   let(:token) { StubToken.new(account_id, ['feeder:read-private']) }
 
   before do
@@ -26,26 +27,28 @@ describe Api::Auth::PodcastsController do
   end
 
   it 'should only index account podcasts' do
-    podcast && published_podcast && other_account_podcast
+    podcast && published_podcast && other_account_podcast && deleted_podcast
     get(:index, api_version: 'v1')
     assert_response :success
     assert_not_nil assigns[:podcasts]
     assert_includes assigns[:podcasts], podcast
     assert_includes assigns[:podcasts], published_podcast
     refute_includes assigns[:podcasts], other_account_podcast
+    refute_includes assigns[:podcasts], deleted_podcast
   end
 
   describe 'with wildcard token' do
     let (:token) { StubToken.new('*', ['read-private']) }
 
     it 'includes all podcasts' do
-      podcast && published_podcast && other_account_podcast
+      podcast && published_podcast && other_account_podcast && deleted_podcast
       get(:index, api_version: 'v1')
       assert_response :success
       assert_not_nil assigns[:podcasts]
       assert_includes assigns[:podcasts], podcast
       assert_includes assigns[:podcasts], published_podcast
       assert_includes assigns[:podcasts], other_account_podcast
+      assert_includes assigns[:podcasts], deleted_podcast
     end
   end
 end


### PR DESCRIPTION
Castle uses a wildcard token to scrape Feeder data from the API, using the `?since=2021-06-25` query param to find updated_at >= some time.

We need castle to also be able to get deleted podcasts/episodes from that same API.