### PR TITLE
Sort episodes by published_at

### DIFF
--- a/app/controllers/api/auth/episodes_controller.rb
+++ b/app/controllers/api/auth/episodes_controller.rb
@@ -25,6 +25,10 @@ class Api::Auth::EpisodesController < Api::EpisodesController
     visible
   end
 
+  def sorted(res)
+    res.order('COALESCE(published_at, released_at) DESC NULLS LAST, id DESC')
+  end
+
   def resources_base
     @episodes ||= super.merge(authorization.token_auth_episodes)
   end

--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -68,6 +68,10 @@ class Api::EpisodesController < Api::BaseController
     super.with_deleted
   end
 
+  def sorted(res)
+    res.order('published_at DESC, id DESC')
+  end
+
   def process_media
     resource.copy_media if resource
   end


### PR DESCRIPTION
Hit a bug with a script scraping the Feeder API -

Expected the most recent feed-rss episode to be first at `/api/v1/episodes`.  But because the episode was actually created 3 years ago and we're sorting by `id: :desc` ... it was way down the list.

This sorts both the authorized and public episode endpoints by published_at (and released_at) DESC.  I don't think this will cause any issues, with an API user depending on that `id desc` order.  The main feed-scraper is Castle, and since it uses `?since` it's already getting an explicit `order('updated_at asc')`.