### PR TITLE
Cleanup DT3 enclosure templates

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -269,7 +269,7 @@ class Episode < BaseModel
   end
 
   def podcast_slug
-    podcast.path
+    podcast_id
   end
 
   # used in the API, both read and write

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -61,7 +61,7 @@ class Podcast < BaseModel
   end
 
   def enclosure_template_default
-    "https://#{ENV['DOVETAIL_HOST']}/_/{slug}/{guid}/{original_filename}"
+    "https://#{ENV['DOVETAIL_HOST']}/{slug}/{guid}/{original_filename}"
   end
 
   def publish_updated

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -63,11 +63,11 @@ describe Episode do
     assert_equal episode.content_type, 'audio/mpeg'
   end
 
-  it 'proxies podcast_slug to #podcast' do
+  it 'uses the podcast_id as the slug' do
     podcast = build_stubbed(:podcast)
     episode = build_stubbed(:episode, podcast: podcast)
     podcast.stub(:path, 'podcast path!') do
-      assert_equal episode.podcast_slug, 'podcast path!'
+      assert_equal episode.podcast_slug, podcast.id
     end
   end
 
@@ -259,7 +259,7 @@ describe Episode do
       episode.podcast.enclosure_template = template
       episode.podcast.enclosure_prefix = nil
       new_url = episode.enclosure_url(base_url, original_url)
-      assert_equal new_url, "https://#{ENV['DOVETAIL_HOST']}/foo/guid/filename.mp3"
+      assert_equal new_url, "https://#{ENV['DOVETAIL_HOST']}/#{episode.podcast.id}/guid/filename.mp3"
     end
 
     it 'applies prefix to enclosure url' do
@@ -282,7 +282,7 @@ describe Episode do
       episode.podcast.enclosure_template = template
       episode.podcast.enclosure_prefix = pre
       new_url = episode.enclosure_url(base_url, original_url)
-      assert_equal new_url, "#{pre}/#{ENV['DOVETAIL_HOST']}/foo/guid/filename.mp3"
+      assert_equal new_url, "#{pre}/#{ENV['DOVETAIL_HOST']}/#{episode.podcast.id}/guid/filename.mp3"
     end
 
     it 'applies template to audio file link' do
@@ -295,7 +295,7 @@ describe Episode do
 
     it 'can include the slug from the podcast' do
       episode.podcast.enclosure_template = "{slug}"
-      assert_equal episode.enclosure_template_url("http://example.com/foo.mp3"), "foo"
+      assert_equal episode.enclosure_template_url("http://example.com/foo.mp3"), "#{episode.podcast.id}"
     end
 
     it 'can include the guid' do
@@ -306,7 +306,7 @@ describe Episode do
     it 'can include all properties' do
       episode.podcast.enclosure_template = "http://fake.host/{slug}/{guid}{extension}{?host}"
       url = episode.enclosure_template_url("http://example.com/path/filename.extension")
-      assert_equal url, "http://fake.host/foo/guid.extension?host=example.com"
+      assert_equal url, "http://fake.host/#{episode.podcast.id}/guid.extension?host=example.com"
     end
 
     it 'gets expansions for original and base urls' do


### PR DESCRIPTION
Cleanup inconsistencies in the `podcasts.enclosure_template` field, ahead of multi-feed work.

- Fix default enclosure templates - the `/_/` in the path is no longer necessary since DTR gets all the ALB traffic.
- We don't set `podcasts.path` anymore - but make sure we always use the podcast_id instead of the path in enclosure urls.  
  - DTR only understands podcast_ids, not aliases, so I've already hardcoded the id into a bunch of enclosure templates that were aliased.

After this deploys, will need to do some manual database cleanup to get as many shows as possible back to the default: 

```
https://dovetail.prxu.org/{slug}/{guid}/{original_filename}
```

This includes:

- [ ] 209 podcasts have the underscore still in there `https://dovetail.prxu.org/_/{slug}/{guid}/{original_filename}`.
- [ ] A ~dozen have their podcast_ids hardcoded to avoid the custom path/alias that DTR can't understand `https://dovetail.prxu.org/_/36/{guid}/{original_filename}`
- [ ] 5 demo/test podcasts have just plain weird enclosures set, and can revert to the default to avoid confusing myself (ids = 1, 10, 12, 13, 21)

I don't love the spotify redownloads and listener_episode churn when enclosures change.  But it might be worth doing that late at night (lowest traffic) to get everything back in line.  Heck, we could consider dropping the `enclosure_template` field entirely at that point.  Except for Memory Palace, which hardcodes all filenames to `/thememorypalace.mp3` for some reason.