### PR TITLE
Handle video enclosures in feeds differently

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -143,7 +143,12 @@ class Episode < BaseModel
   end
 
   def content_type(feed = nil)
-    feed.try(:mime_type) || first_media_resource.try(:mime_type) || 'audio/mpeg'
+    media_content_type = first_media_resource.try(:mime_type)
+    if (media_content_type || '').starts_with?('video')
+      media_content_type
+    else
+      feed.try(:mime_type) || media_content_type || 'audio/mpeg'
+    end
   end
 
   def duration

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -71,6 +71,24 @@ describe Episode do
     assert_equal episode.content_type, 'audio/mpeg'
   end
 
+  it 'returns the feed content type for audio' do
+    feed = build_stubbed(:feed)
+    assert_equal feed.mime_type, 'audio/flac'
+    assert_equal episode.first_media_resource.mime_type, 'audio/mpeg'
+    assert_equal episode.content_type(feed), 'audio/flac'
+  end
+
+  it 'returns the file content type for video' do
+    feed = build_stubbed(:feed)
+    episode = build(:episode)
+    video_enclosure = create(:enclosure, episode: episode, status: 'complete', mime_type: 'video/mp4')
+    episode.enclosures = [video_enclosure]
+    
+    assert_equal video_enclosure.mime_type, 'video/mp4'
+    assert_equal episode.first_media_resource.mime_type, 'video/mp4'
+    assert_equal episode.content_type(feed), 'video/mp4'
+  end
+
   it 'has no audio file until processed' do
     episode = build_stubbed(:episode)
     assert_equal episode.media_files.length, 0


### PR DESCRIPTION
If the episode has video enclosures, use that type, not the feed.