### PR TITLE
More feeds APIs

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -58,7 +58,11 @@ class Feed < BaseModel
   end
 
   def published_url
-    "#{podcast.base_published_url}/#{published_path}"
+    if private?
+      "#{podcast.base_private_url}/#{published_path}{?auth}"
+    else
+      "#{podcast.base_published_url}/#{published_path}"
+    end
   end
 
   def published_path

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -16,7 +16,7 @@ class Feed < BaseModel
   serialize :audio_format, HashSerializer
 
   belongs_to :podcast, -> { with_deleted }
-  has_many :feed_tokens, dependent: :destroy
+  has_many :feed_tokens, autosave: true, dependent: :destroy
   alias_attribute :tokens, :feed_tokens
 
   validates :slug, allow_nil: true, uniqueness: { scope: :podcast_id, allow_nil: false }
@@ -39,6 +39,38 @@ class Feed < BaseModel
   def set_defaults
     self.file_name ||= DEFAULT_FILE_NAME
     self.enclosure_template ||= Feed.enclosure_template_default
+  end
+
+  def represented_tokens
+    feed_tokens.map do |t|
+      {
+        label: t.label,
+        token: t.token,
+        expires: t.expires_at
+      }.delete_if { |k, v| v.nil? }
+    end
+  end
+
+  def represented_tokens=(updates)
+    updates = (updates || []).map { |u| u.try(:with_indifferent_access) }
+
+    # update or destroy existing tokens
+    feed_tokens.each do |t|
+      if u = updates.find { |u| u[:token] == t.token }
+        t.label = u[:label]
+        t.expires_at = u[:expires]
+        updates.delete(u)
+      else
+        t.mark_for_destruction
+      end
+    end
+
+    # build new tokens with remaining updates
+    updates.each do |u|
+      tokens.build(token: u[:token], label: u[:label], expires_at: u[:expires])
+    end
+
+    tokens
   end
 
   def sanitize_text

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -160,6 +160,10 @@ class Podcast < BaseModel
     "https://#{feeder_cdn_host}/#{path}"
   end
 
+  def base_private_url
+    "https://#{feeder_cdn_private_host}/#{path}"
+  end
+
   def published_url
     "#{base_published_url}/#{default_feed.try(:file_name) || Feed::DEFAULT_FILE_NAME}"
   end
@@ -177,6 +181,10 @@ class Podcast < BaseModel
 
   def feeder_cdn_host
     ENV['FEEDER_CDN_HOST']
+  end
+
+  def feeder_cdn_private_host
+    ENV['FEEDER_CDN_PRIVATE_HOST']
   end
 
   def default_feed_settings?

--- a/app/representers/api/auth/feed_representer.rb
+++ b/app/representers/api/auth/feed_representer.rb
@@ -17,6 +17,9 @@ class Api::Auth::FeedRepresenter < Api::BaseRepresenter
   property :include_tags
   property :audio_format
 
+  # NOTE: bypass representers here, so getting/setting works correctly
+  property :represented_tokens, as: :tokens
+
   def self_url(feed)    
     api_authorization_podcast_feed_path(podcast_id: feed.podcast_id, id: feed.id)
   end

--- a/app/representers/api/auth/feed_representer.rb
+++ b/app/representers/api/auth/feed_representer.rb
@@ -24,4 +24,11 @@ class Api::Auth::FeedRepresenter < Api::BaseRepresenter
   link :podcast do
     api_authorization_podcast_path(represented.podcast) if represented.id && represented.podcast
   end
+
+  link :rss do
+    {
+      href: represented.published_url,
+      templated: true
+    }
+  end
 end

--- a/app/representers/api/auth/feed_representer.rb
+++ b/app/representers/api/auth/feed_representer.rb
@@ -28,10 +28,11 @@ class Api::Auth::FeedRepresenter < Api::BaseRepresenter
     api_authorization_podcast_path(represented.podcast) if represented.id && represented.podcast
   end
 
-  link :rss do
+  link :private_feed do
     {
       href: represented.published_url,
-      templated: true
+      templated: true,
+      type: 'application/rss+xml'
     }
   end
 end

--- a/env-example
+++ b/env-example
@@ -13,8 +13,8 @@ DB_ENV_POSTGRES_USER=feeder
 DB_PORT_5432_TCP_ADDR=db
 DB_PORT_5432_TCP_PORT=5432
 DOVETAIL_HOST=dovetail-staging.prxu.org
-# defaults to f.prxu.org in production, otherwise {env}-f.prxu.org
-# FEEDER_CDN_HOST=
+FEEDER_CDN_HOST=f-staging.prxu.org
+FEEDER_CDN_PRIVATE_HOST=p.staging.prxu.org
 # defaults to feeder.prx.org
 FEEDER_HOST=feeder.prx.docker
 # defaults to "PRX Feeder v#{Feeder::VERSION}"

--- a/test/controllers/api/auth/feeds_controller_test.rb
+++ b/test/controllers/api/auth/feeds_controller_test.rb
@@ -39,6 +39,20 @@ describe Api::Auth::FeedsController do
       _(feed.title).must_equal 'new title'
     end
 
+    it 'can update nested tokens' do
+      feed.tokens.create!(label: 'something', token: 'tok1')
+      feed.tokens.create!(token: 'tok2')
+
+      update_tok1 = { token: 'tok1', label: 'else', expires: '2023-02-01' }
+      create_tok3 = { token: 'tok3' }
+      update_hash = { tokens: [ update_tok1, create_tok3 ] }
+
+      put :update, update_hash.to_json, api_version: 'v1', format: 'json', podcast_id: feed.podcast_id, id: feed.id
+      assert_response :success
+
+      _(feed.reload.tokens.count).must_equal 2
+    end
+
     it 'ignores updating invalid overrides' do
       fua = feed.updated_at
       update_hash = { title: 'new title2', slug: 'somesluggy2', display_episodes_count: 1 }

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 describe Feed do
   let(:podcast) { create(:podcast) }
   let(:feed1) { podcast.default_feed }
-  let(:feed2) { create(:feed, podcast: podcast, slug: 'adfree') }
-  let(:feed3) { create(:feed, podcast: podcast, slug: 'other', file_name: 'something') }
+  let(:feed2) { create(:feed, private: false, podcast: podcast, slug: 'adfree') }
+  let(:feed3) { create(:feed, private: false, podcast: podcast, slug: 'other', file_name: 'something') }
 
   describe '.new' do
     it 'sets a default file name' do
@@ -103,6 +103,16 @@ describe Feed do
     it 'returns slugged feed urls' do
       assert_equal feed2.published_url, "#{podcast.base_published_url}/adfree/feed-rss.xml"
       assert_equal feed3.published_url, "#{podcast.base_published_url}/other/something"
+    end
+
+    it 'returns templated private feed urls' do
+      feed1.private = true
+      feed2.private = true
+      feed3.private = true
+
+      assert_equal feed1.published_url, "#{podcast.base_private_url}/feed-rss.xml{?auth}"
+      assert_equal feed2.published_url, "#{podcast.base_private_url}/adfree/feed-rss.xml{?auth}"
+      assert_equal feed3.published_url, "#{podcast.base_private_url}/other/something{?auth}"
     end
   end
 end

--- a/test/representers/api/auth/feed_representer_test.rb
+++ b/test/representers/api/auth/feed_representer_test.rb
@@ -16,6 +16,8 @@ describe Api::Auth::FeedRepresenter do
   end
 
   it 'has a feed rss link' do
-    _(json['_links']['prx:rss']['href']).must_equal feed.published_url
+    _(json['_links']['prx:private-feed']['href']).must_equal feed.published_url
+    _(json['_links']['prx:private-feed']['templated']).must_equal true
+    _(json['_links']['prx:private-feed']['type']).must_equal 'application/rss+xml'
   end
 end

--- a/test/representers/api/auth/feed_representer_test.rb
+++ b/test/representers/api/auth/feed_representer_test.rb
@@ -14,4 +14,8 @@ describe Api::Auth::FeedRepresenter do
     _(json['_links']['self']['href']).must_equal "/api/v1/authorization/podcasts/#{feed.podcast.id}/feeds/#{feed.id}"
     _(json['_links']['prx:podcast']['href']).must_equal "/api/v1/authorization/podcasts/#{feed.podcast.id}"
   end
+
+  it 'has a feed rss link' do
+    _(json['_links']['prx:rss']['href']).must_equal feed.published_url
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,7 @@ end
 ENV['CMS_HOST']        = 'cms.prx.org'
 ENV['FEEDER_HOST']     = 'feeder.prx.org'
 ENV['FEEDER_CDN_HOST'] = 'f.prxu.org'
+ENV['FEEDER_CDN_PRIVATE_HOST'] = 'p.prxu.org'
 ENV['ID_HOST']         = 'id.prx.org'
 ENV['META_HOST']       = 'meta.prx.org'
 ENV['PRX_HOST']        = 'www.prx.org'


### PR DESCRIPTION
Couple more Podcast-Feed APIs needed to build out the Publish pages.

- Include a link on the feed, for the _private_ feed proxy `p.prxu.org`.  Will need to add those ENVs to Feeder.
- Simple attribute getter/setter for feed tokens.  (Will be easier than attempting a nested resource for them).