### PR TITLE
Move subtitle/description/summary to feed

### DIFF
--- a/app/helpers/podcasts_helper.rb
+++ b/app/helpers/podcasts_helper.rb
@@ -19,10 +19,14 @@ module PodcastsHelper
   end
 
   def show_itunes_summary?(model)
-    model.summary || model.description
+    model.summary.present? || model.description.present?
   end
 
   def itunes_summary(model)
-    model.summary || sanitize_links_only(model.description)
+    if model.summary.present?
+      model.summary
+    else
+      sanitize_links_only(model.description || '')
+    end
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -47,6 +47,9 @@ class Feed < BaseModel
   end
 
   def sanitize_text
+    self.description = sanitize_white_list(description) if description_changed?
+    self.subtitle = sanitize_text_only(subtitle) if subtitle_changed?
+    self.summary = sanitize_links_only(summary) if summary_changed?
     self.title = sanitize_text_only(title) if title_changed?
   end
 

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -1,6 +1,6 @@
 class Podcast < BaseModel
-  FEED_GETTERS = %i(url new_feed_url display_episodes_count display_full_episodes_count enclosure_prefix enclosure_template feed_image itunes_image)
-  FEED_SETTERS = %i(url= new_feed_url= display_episodes_count= display_full_episodes_count= enclosure_prefix= enclosure_template= feed_image= itunes_image=)
+  FEED_GETTERS = %i(subtitle description summary url new_feed_url display_episodes_count display_full_episodes_count enclosure_prefix enclosure_template feed_image itunes_image)
+  FEED_SETTERS = %i(subtitle= description= summary= url= new_feed_url= display_episodes_count= display_full_episodes_count= enclosure_prefix= enclosure_template= feed_image= itunes_image=)
 
   include TextSanitizer
 
@@ -150,9 +150,6 @@ class Podcast < BaseModel
   end
 
   def sanitize_text
-    self.description = sanitize_white_list(description) if description_changed?
-    self.subtitle = sanitize_text_only(subtitle) if subtitle_changed?
-    self.summary = sanitize_links_only(summary) if summary_changed?
     self.title = sanitize_text_only(title) if title_changed?
   end
 

--- a/app/representers/api/auth/feed_representer.rb
+++ b/app/representers/api/auth/feed_representer.rb
@@ -7,6 +7,10 @@ class Api::Auth::FeedRepresenter < Api::BaseRepresenter
   property :file_name
   property :private
   property :title
+  property :subtitle
+  property :description
+  property :summary
+  property :summary_preview, exec_context: :decorator, if: ->(_o) { represented.summary.blank? }
   property :url
   property :new_feed_url
   property :enclosure_prefix

--- a/app/representers/api/podcast_representer.rb
+++ b/app/representers/api/podcast_representer.rb
@@ -21,7 +21,7 @@ class Api::PodcastRepresenter < Api::BaseRepresenter
   property :subtitle
   property :description
   property :summary
-  property :summary_preview, exec_context: :decorator, if: ->(_o) { !represented.summary }
+  property :summary_preview, exec_context: :decorator, if: ->(_o) { represented.summary.blank? }
   property :itunes_block
 
   property :explicit

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -14,7 +14,13 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
     xml.language @podcast.language || 'en-us'
     xml.copyright @podcast.copyright unless @podcast.copyright.blank?
     xml.webMaster @podcast.web_master unless @podcast.web_master.blank?
-    xml.description { xml.cdata!(@podcast.description || '') } unless @podcast.description.blank?
+
+    if @feed.description.present?
+      xml.description { xml.cdata!(@feed.description) }
+    elsif @podcast.description.present?
+      xml.description { xml.cdata!(@podcast.description) }
+    end
+
     xml.managingEditor @podcast.managing_editor unless @podcast.managing_editor.blank?
 
     Array(@podcast.categories).each { |cat| xml.category(cat) }
@@ -61,8 +67,18 @@ xml.rss 'xmlns:atom' => 'http://www.w3.org/2005/Atom',
       xml.itunes :name, @podcast.send("#{rel}_name") if @podcast.send("#{rel}_name")
     end
 
-    xml.itunes :subtitle, @podcast.subtitle unless @podcast.subtitle.blank?
-    xml.itunes(:summary) { xml.cdata!(itunes_summary(@podcast)) } if show_itunes_summary?(@podcast)
+    if @feed.subtitle.present?
+      xml.itunes :subtitle, @feed.subtitle
+    elsif @podcast.subtitle.present?
+      xml.itunes :subtitle, @podcast.subtitle
+    end
+
+    if show_itunes_summary?(@feed)
+      xml.itunes(:summary) { xml.cdata!(itunes_summary(@feed)) }
+    elsif show_itunes_summary?(@podcast)
+      xml.itunes(:summary) { xml.cdata!(itunes_summary(@podcast)) }
+    end
+
     xml.itunes :keywords, @podcast.keywords.join(',') unless @podcast.keywords.blank?
 
     xml.media :copyright, @podcast.copyright unless @podcast.copyright.blank?

--- a/db/migrate/20220817212106_move_description_to_feed.rb
+++ b/db/migrate/20220817212106_move_description_to_feed.rb
@@ -1,0 +1,37 @@
+class MoveDescriptionToFeed < ActiveRecord::Migration
+  def up
+    add_column :feeds, :subtitle, :text
+    add_column :feeds, :description, :text
+    add_column :feeds, :summary, :text
+
+    Podcast.with_deleted.each do |podcast|
+      next unless feed = podcast.default_feed
+      feed.subtitle = podcast.subtitle
+      feed.description = podcast.description
+      feed.summary = podcast.summary
+      feed.save!
+    end
+
+    remove_column :podcasts, :subtitle
+    remove_column :podcasts, :description
+    remove_column :podcasts, :summary
+  end
+
+  def down
+    add_column :podcasts, :subtitle, :text
+    add_column :podcasts, :description, :text
+    add_column :podcasts, :summary, :text
+
+    Podcast.with_deleted.each do |podcast|
+      next unless feed = podcast.default_feed
+      podcast.subtitle = feed.subtitle
+      podcast.description = feed.description
+      podcast.summary = feed.summary
+      podcast.save!
+    end
+
+    remove_column :feeds, :subtitle
+    remove_column :feeds, :description
+    remove_column :feeds, :summary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20220707204115) do
+ActiveRecord::Schema.define(version: 20220817212106) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,9 @@ ActiveRecord::Schema.define(version: 20220707204115) do
     t.datetime "updated_at",                                 null: false
     t.string   "enclosure_prefix"
     t.string   "enclosure_template"
+    t.text     "subtitle"
+    t.text     "description"
+    t.text     "summary"
   end
 
   add_index "feeds", ["podcast_id", "slug"], name: "index_feeds_on_podcast_id_and_slug", unique: true, where: "(slug IS NOT NULL)", using: :btree
@@ -201,12 +204,9 @@ ActiveRecord::Schema.define(version: 20220707204115) do
     t.datetime "updated_at"
     t.text     "title"
     t.string   "link"
-    t.text     "description"
     t.string   "language"
     t.string   "managing_editor_name"
     t.string   "categories"
-    t.text     "subtitle"
-    t.text     "summary"
     t.string   "keywords"
     t.string   "update_period"
     t.integer  "update_frequency"

--- a/test/factories/feed_factory.rb
+++ b/test/factories/feed_factory.rb
@@ -3,6 +3,11 @@ FactoryGirl.define do
     sequence(:slug) { |n| "myfeed#{n}" }
     file_name 'feed-rss.xml'
     audio_format { Hash(f: 'flac', b: 16, c: 2, s: 44100) }
+
+    subtitle 'Goofy laughsters'
+    description 'A goofy fun-time laughcast with doofuses'
+    summary 'Public radio host Jesse Thorn and @midnight writer Jordan Morris goof around'
+
     url 'http://feeds.feedburner.com/thornmorris'
     new_feed_url 'http://feeds.feedburner.com/newthornmorris'
     enclosure_template { Feed.enclosure_template_default }

--- a/test/factories/podcast_factory.rb
+++ b/test/factories/podcast_factory.rb
@@ -6,7 +6,6 @@ FactoryGirl.define do
     path 'jjgo'
     link 'http://www.maximumfun.org/jjgo'
     title 'Jordan, Jesse GO!'
-    description 'A goofy fun-time laughcast with doofuses'
     copyright 'Copyright © 2014 Jordan, Jesse GO!. All rights reserved.'
     language 'en-us'
     managing_editor_name 'Jesse Thorn'
@@ -17,8 +16,6 @@ FactoryGirl.define do
     owner_email 'jesse@maximumfun.org'
     categories ['Humor', 'Entertainment']
     explicit 'true'
-    subtitle 'Goofy laughsters'
-    summary 'Public radio host Jesse Thorn and @midnight writer Jordan Morris goof around'
     keywords ['laffs', 'comedy', 'good-times']
     update_period 'weekly'
     update_frequency 1

--- a/test/representers/api/auth/feed_representer_test.rb
+++ b/test/representers/api/auth/feed_representer_test.rb
@@ -8,6 +8,17 @@ describe Api::Auth::FeedRepresenter do
 
   it 'includes basic properties' do
     _(json['slug']).must_match /myfeed(\d+)/
+    _(json['subtitle']).must_equal feed.subtitle
+    _(json['description']).must_equal feed.description
+    _(json['summary']).must_equal feed.summary
+    _(json['summaryPreview']).must_be_nil
+  end
+
+  it 'returns a summary preview when blank' do
+    feed.summary = ''
+    feed.description = 'A <b>rich text</d> <h2>description</h2> <a href="/">with links</a>'
+
+    _(json['summaryPreview']).must_equal 'A rich text description <a href="/">with links</a>'
   end
 
   it 'has links' do


### PR DESCRIPTION
Backend work for #436.

Moves 3 fields from `Podcast` to `Feed`.  But keeps them proxied to the `podcast.default_feed` so existing APIs continue working.