### PR TITLE
Feat/validate and test apple credentials

### DIFF
--- a/app/models/apple_credential.rb
+++ b/app/models/apple_credential.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AppleCredential < ActiveRecord::Base
+class AppleCredential < BaseModel
   belongs_to :public_feed, class_name: "Feed"
   belongs_to :private_feed, class_name: "Feed"
 
@@ -8,9 +8,9 @@ class AppleCredential < ActiveRecord::Base
   validates_presence_of :private_feed
   validates_associated :public_feed
   validates_associated :private_feed
-  validates_presence of :apple_provider_id
-  validates_presence_of :apple_key_id
-  validates_presence_of :apple_key_pem_b64
+  validates_presence_of :apple_provider_id, if: :any_apple_credentials_exist?
+  validates_presence_of :apple_key_id, if: :any_apple_credentials_exist?
+  validates_presence_of :apple_key_pem_b64, if: :any_apple_credentials_exist?
   validates :public_feed, uniqueness: { scope: :private_feed,
                                         message: "can only have one credential per public and private feed" }
   validates :public_feed, exclusion: { in: ->(apple_credential) { [apple_credential.private_feed] } }

--- a/app/models/apple_credential.rb
+++ b/app/models/apple_credential.rb
@@ -8,9 +8,14 @@ class AppleCredential < ActiveRecord::Base
   validates_presence_of :private_feed
   validates_associated :public_feed
   validates_associated :private_feed
+  validates_presence of :apple_provider_id
   validates_presence_of :apple_key_id
   validates_presence_of :apple_key_pem_b64
   validates :public_feed, uniqueness: { scope: :private_feed,
                                         message: "can only have one credential per public and private feed" }
   validates :public_feed, exclusion: { in: ->(apple_credential) { [apple_credential.private_feed] } }
+
+  def any_apple_credentials_exist?
+    apple_provider_id.present? || apple_key_id.present? || apple_key_pem_b64.present?
+  end
 end

--- a/test/factories/apple_credential_factory.rb
+++ b/test/factories/apple_credential_factory.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :apple_credential do
+    apple_provider_id 'gala apples'
     apple_key_id 'some-apple-key'
     apple_key_pem_b64 'c29tZS1hcHBsZS1rZXktcGVt'
   end

--- a/test/models/apple_credential_test.rb
+++ b/test/models/apple_credential_test.rb
@@ -52,19 +52,21 @@ describe AppleCredential do
       refute c5.valid?
     end
 
-    it 'requires all apple credentials to have a value or be blank' do
-      a1 = create(:apple_credential)
-      a2 = create(:apple_credential)
-      a3 = create(:apple_credential)
+    it 'requires all apple credentials to have a value or be nil' do
+      f1 = create(:feed)
+      f2 = create(:feed)
 
-      v1 = build(:apple_credential, apple_provider_id.blank?, apple_key_id.present?, apple_key_pem_b64.present?)
+      v1 = build(:apple_credential, public_feed: f1, private_feed: f2, apple_provider_id: nil, apple_key_id: 'blood', apple_key_pem_b64: 'orange')
       refute v1.valid?
 
-      v2 = build(:apple_credential, apple_provider_id.present?, apple_key_id.blank?, apple_key_pem_b64.present?)
+      v2 = build(:apple_credential, public_feed: f1, private_feed: f2, apple_provider_id: 'barlett', apple_key_id: nil, apple_key_pem_b64: 'pear')
       refute v2.valid?
 
-      v3 = build(:apple_credential, apple_provider_id.present?, apple_key_id.present?, apple_key_pem_b64.blank?)
+      v3 = build(:apple_credential, public_feed: f1, private_feed: f2, apple_provider_id: 'cotton candy', apple_key_id: 'grapes', apple_key_pem_b64: nil)
       refute v3.valid?
+
+      v4 = build(:apple_credential, public_feed: f1, private_feed: f2,apple_provider_id: nil, apple_key_id: nil, apple_key_pem_b64: nil)
+      assert v4.valid?
     end
   end
 end

--- a/test/models/apple_credential_test.rb
+++ b/test/models/apple_credential_test.rb
@@ -51,5 +51,20 @@ describe AppleCredential do
       c5 = build(:apple_credential, public_feed: f1, private_feed: f1)
       refute c5.valid?
     end
+
+    it 'requires all apple credentials to have a value or be blank' do
+      a1 = create(:apple_credential)
+      a2 = create(:apple_credential)
+      a3 = create(:apple_credential)
+
+      v1 = build(:apple_credential, apple_provider_id.blank?, apple_key_id.present?, apple_key_pem_b64.present?)
+      refute v1.valid?
+
+      v2 = build(:apple_credential, apple_provider_id.present?, apple_key_id.blank?, apple_key_pem_b64.present?)
+      refute v2.valid?
+
+      v3 = build(:apple_credential, apple_provider_id.present?, apple_key_id.present?, apple_key_pem_b64.blank?)
+      refute v3.valid?
+    end
   end
 end


### PR DESCRIPTION
Closes #480 

- [ ] Adds validations for all apple credentials: `apple_provider_id`, `apple_key_id`m `apple_pem_key_b64`
- [ ] Ensures all `apple_credential` fields will either have a value or be blank
- [ ] Includes tests