### PR TITLE
Fixup/exception handling

### DIFF
--- a/app/models/apple/api.rb
+++ b/app/models/apple/api.rb
@@ -144,13 +144,13 @@ module Apple
     end
 
     def unwrap_response(resp)
-      raise Apple::ApiError.new("Apple returning #{resp.code}"), resp.body unless ok_code(resp)
+      raise Apple::ApiError.new("Apple Api Error", resp) unless ok_code(resp)
 
       JSON.parse(resp.body)
     end
 
     def unwrap_bridge_response(resp)
-      raise Apple::ApiError.new("Bridge returning #{resp.code}"), resp.body unless ok_code(resp)
+      raise Apple::ApiError.new("Apple Api Bridge Error", resp) unless ok_code(resp)
 
       parsed = JSON.parse(resp.body)
 

--- a/app/models/apple/api_error.rb
+++ b/app/models/apple/api_error.rb
@@ -1,5 +1,18 @@
 # frozen_string_literal: true
 
 module Apple
-  class ApiError < StandardError; end
+  class ApiError < StandardError
+    attr_reader :formatted
+
+    def initialize(message, response)
+      @formatted = format_message(message, response)
+      super(formatted)
+    end
+
+    def format_message(message, response)
+      "#{message}\n" +
+        "HTTP resp code:#{response.code}\n" +
+        response.body.to_s
+    end
+  end
 end

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -57,9 +57,6 @@ module Apple
 
       # success
       SyncLog.create!(feeder_id: public_feed.id, feeder_type: :feeds, external_id: show.apple_id)
-    rescue Apple::ApiError => e
-      SyncLog.create!(feeder_id: public_feed.id, feeder_type: :feeds)
-      raise e
     end
 
     def wait_for_upload_processing

--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -95,9 +95,6 @@ module Apple
                       feeder_type: :feeds,
                       sync_completed_at: Time.now.utc,
                       external_id: apple_json['data']['id'])
-    rescue Apple::ApiError => e
-      puts e
-      SyncLog.create!(feeder_id: public_feed.id, feeder_type: :feeds)
     end
 
     def create_show!

--- a/test/models/apple/api_error_test.rb
+++ b/test/models/apple/api_error_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Apple::ApiError do
+
+  describe '.initialize' do
+    it 'should construct an exception object with a message and response object' do
+      response = OpenStruct.new(code: 200, body: 'body')
+      exception = Apple::ApiError.new('message', response)
+
+      assert_equal exception.message, "message\nHTTP resp code:200\nbody"
+    end
+  end
+end

--- a/test/models/apple/show_test.rb
+++ b/test/models/apple/show_test.rb
@@ -65,11 +65,13 @@ describe Apple::Show do
     end
 
     it 'logs an incomplete sync record if the upsert fails' do
-      raises_exception = ->(arg) { raise Apple::ApiError.new(arg) }
+      raises_exception = ->(_arg) { raise Apple::ApiError.new('Error', OpenStruct.new(code: 200, body: 'body')) }
       apple_show.stub(:create_or_update_show, raises_exception) do
-        sync = apple_show.sync!
-
-        assert_equal sync.complete?, false
+        sync = nil
+        assert_raises(Apple::ApiError) do
+          sync = apple_show.sync!
+        end
+        assert_nil apple_show.completed_sync_log
       end
     end
   end


### PR DESCRIPTION
Discovered that the Apple::ApiError exceptions were not being formatted correctly.  This PR:

- Fixes a problem where exceptions were not being raised.
- Formats the exception message and response body.