### PR TITLE
Find by item guid

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -3,9 +3,9 @@ class Api::EpisodesController < Api::BaseController
 
   api_versions :v1
   represent_with Api::EpisodeRepresenter
-  find_method :find_by_guid
   filter_resources_by :podcast_id
 
+  before_action :set_find_method
   after_action :process_media, only: [:create, :update]
   after_action :publish, only: [:create, :update, :destroy]
 
@@ -68,6 +68,16 @@ class Api::EpisodesController < Api::BaseController
 
   def sorted(res)
     res.order(Arel.sql('published_at DESC, id DESC'))
+  end
+
+  # alter find_by to search by guid OR item_guid
+  def set_find_method
+    self.class.find_method =
+      if request.path.include?('/guids/')
+        :find_by_item_guid
+      else
+        :find_by_guid
+      end
   end
 
   def process_media

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -72,6 +72,18 @@ class Episode < ApplicationRecord
     (story.links['self'].href || '').gsub('/authorization/', '/')
   end
 
+  def self.generate_item_guid(podcast_id, episode_guid)
+    "prx_#{podcast_id}_#{episode_guid}"
+  end
+
+  def self.decode_item_guid(item_guid)
+    item_guid.sub(/^prx_[0-9]+_/, '') if item_guid&.starts_with?('prx_')
+  end
+
+  def self.find_by_item_guid(guid)
+    where(original_guid: guid).or(where(original_guid: nil, guid: decode_item_guid(guid))).first
+  end
+
   def publish_updated
     podcast.publish_updated if podcast
   end
@@ -131,7 +143,7 @@ class Episode < ApplicationRecord
   end
 
   def item_guid
-    original_guid || "prx_#{podcast_id}_#{guid}"
+    original_guid || self.class.generate_item_guid(podcast_id, guid)
   end
 
   def item_guid=(new_guid)

--- a/app/representers/api/api_representer.rb
+++ b/app/representers/api/api_representer.rb
@@ -29,6 +29,17 @@ class Api::ApiRepresenter < Api::BaseRepresenter
     ]
   end
 
+  links :guid do
+    [
+      {
+        title:     "Get a single episode by item guid",
+        profile:   profile_url(:episode),
+        href:      api_podcast_guid_path_template(api_version: represented.version, podcast_id: '{id}', id: '{guid}'),
+        templated: true
+      }
+    ]
+  end
+
   links :podcast do
     [
       {

--- a/app/representers/api/auth/podcast_representer.rb
+++ b/app/representers/api/auth/podcast_representer.rb
@@ -14,6 +14,14 @@ class Api::Auth::PodcastRepresenter < Api::PodcastRepresenter
     } if represented.id
   end
 
+  # point to authorized item guids (including unpublished)
+  link :guid do
+    {
+      href: api_authorization_podcast_guid_path_template(podcast_id: represented.id.to_s, id: '{guid}'),
+      templated: true
+    } if represented.id
+  end
+
   # point to authorized feeds (including private)
   link :feeds do
     {

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -22,6 +22,17 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
     }
   end
 
+  links :guid do
+    [
+      {
+        title:     "Get a single episode by item guid",
+        profile:   profile_url(:episode),
+        href:      api_authorization_podcast_guid_path_template(api_version: represented.version, podcast_id: '{id}', id: '{guid}'),
+        templated: true
+      }
+    ]
+  end
+
   link :podcasts do
     {
       title: 'Get a paged collection of authorized podcasts',

--- a/app/representers/api/authorization_representer.rb
+++ b/app/representers/api/authorization_representer.rb
@@ -22,15 +22,13 @@ class Api::AuthorizationRepresenter < Api::BaseRepresenter
     }
   end
 
-  links :guid do
-    [
-      {
-        title:     "Get a single episode by item guid",
-        profile:   profile_url(:episode),
-        href:      api_authorization_podcast_guid_path_template(api_version: represented.version, podcast_id: '{id}', id: '{guid}'),
-        templated: true
-      }
-    ]
+  link :guid do
+    {
+      title: 'Get a single episode by item guid',
+      profile: profile_url(:episode),
+      href: api_authorization_podcast_guid_path_template(podcast_id: '{id}', id: '{guid}'),
+      templated: true
+    }
   end
 
   link :podcasts do

--- a/app/representers/api/podcast_representer.rb
+++ b/app/representers/api/podcast_representer.rb
@@ -68,6 +68,13 @@ class Api::PodcastRepresenter < Api::BaseRepresenter
     } if represented.id
   end
 
+  link :guid do
+    {
+      href: api_podcast_guid_path_template(podcast_id: represented.id.to_s, id: '{guid}'),
+      templated: true
+    } if represented.id
+  end
+
   link :series do
     URI.join(cms_root, represented.prx_uri).to_s if represented.prx_uri
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
     scope ':api_version', api_version: 'v1', defaults: { format: 'hal' } do
       resources :podcasts, except: [:new, :edit] do
         resources :episodes, except: [:new, :edit]
+        resources :guids, only: :show, controller: :episodes, id: /[^\/]+/
       end
       resources :episodes, except: [:new, :edit]
 
@@ -17,6 +18,7 @@ Rails.application.routes.draw do
         resources :podcasts, except: [:new, :edit], module: :auth do
           resources :episodes, except: [:new, :edit]
           resources :feeds, except: [:new, :edit]
+          resources :guids, only: :show, controller: :episodes, id: /[^\/]+/
         end
 
         resources :episodes, except: [:new, :edit], module: :auth

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -24,6 +24,19 @@ describe Api::EpisodesController do
     assert_response :success
   end
 
+  it 'should show by item guid' do
+    refute_nil episode.id
+
+    # mock request path to be /guids/ (actual values don't matter for tests)
+    request.path = '/api/v1/podcasts/1234/guids/abcd1234'
+
+    get(:show, params: { api_version: 'v1', format: 'json', id: episode.item_guid })
+    assert_response :success
+
+    get(:show, params: { api_version: 'v1', format: 'json', id: episode.guid })
+    assert_response 404
+  end
+
   it 'should return resource gone for deleted resource' do
     refute_nil episode_deleted.id
     get(:show, params: { api_version: 'v1', format: 'json', id: episode_deleted.guid })

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -50,6 +50,28 @@ describe Episode do
   it 'returns a guid to use in the channel item' do
     episode.guid = 'guid'
     assert_equal episode.item_guid, "prx_#{episode.podcast_id}_guid"
+    assert_equal Episode.generate_item_guid(123, 'abc'), 'prx_123_abc'
+  end
+
+  it 'decodes guids from channel item guids' do
+    assert_equal Episode.decode_item_guid('prx_123_abc'), 'abc'
+    assert_equal Episode.decode_item_guid('prx_123_abc_def_ghi'), 'abc_def_ghi'
+    assert_nil Episode.decode_item_guid('anything')
+  end
+
+  it 'finds episodes by item guid' do
+    episode = create(:episode)
+    generated_guid = "prx_#{episode.podcast_id}_#{episode.guid}"
+
+    assert_nil episode.original_guid
+    assert_equal episode.item_guid, generated_guid
+    assert_equal Episode.find_by_item_guid(generated_guid), episode
+    assert_nil Episode.find_by_item_guid('anything-else')
+
+    episode.update!(original_guid: 'something-original')
+    assert_equal episode.item_guid, 'something-original'
+    assert_equal Episode.find_by_item_guid('something-original'), episode
+    assert_nil Episode.find_by_item_guid(generated_guid)
   end
 
   it 'is ready to add to a feed' do


### PR DESCRIPTION
Closes #487.

- [x] Adds `Episode.find_by_item_guid` helper to look for _either_ `original_guid`s OR our generated guids when nil
- [x] Adds 2 routes:
    ```
    GET /api/v1/podcasts/:podcast_id/guids/:id
    GET /api/v1/authorization/podcasts/:podcast_id/guids/:id
    ```
- [x] Add links to podcast representers
