### PR TITLE
Init toasts for flash messages

### DIFF
--- a/app/controllers/fake_controller.rb
+++ b/app/controllers/fake_controller.rb
@@ -4,5 +4,9 @@ class FakeController < ApplicationController
 
   def show
     @fake = "some/fake/model/#{params[:id]}"
+
+    if params[:id] == "8888"
+      flash.now[:notice] = "This is a notice, okay?"
+    end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,14 @@
 module ApplicationHelper
+  def toast_class(level)
+    classes = {
+      "notice" => "toast bg-success",
+      "success" => "toast bg-success",
+      "error" => "toast bg-danger",
+      "alert" => "toast bg-danger"
+    }
+    classes[level]
+  end
+
   def tab_link_to(*args, &block)
     name = block ? capture(&block) : args.shift
     options = args.shift || {}

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -12,3 +12,11 @@ document.addEventListener("turbo:frame-missing", function (event) {
   //   err => console.log('GOT ERR:', err)
   // )
 })
+
+// prevent flickering toasts in the turbo cache
+document.addEventListener("turbo:before-cache", function () {
+  const toasts = document.getElementById("toast-alerts")
+  if (toasts) {
+    toasts.innerHTML = ""
+  }
+})

--- a/app/javascript/controllers/toast_controller.js
+++ b/app/javascript/controllers/toast_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    new bootstrap.Toast(this.element).show()
+  }
+}

--- a/app/views/layouts/_alerts.html.erb
+++ b/app/views/layouts/_alerts.html.erb
@@ -1,0 +1,12 @@
+<div id="toast-alerts" class="toaster position-fixed top-0 start-50 translate-middle-x p-4 <%= "d-none" if flash.empty? %>">
+  <% flash.each do |k, v| %>
+    <div class="<%= toast_class(k) %> align-items-center p-0 m-0" role="alert" aria-live="assertive" aria-atomic="true" data-controller="toast">
+      <div class="d-flex">
+        <div class="toast-body">
+          <%= v %>
+        </div>
+        <button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,8 @@
       <%= render "layouts/subnav" %>
     </header>
 
+    <%= render "layouts/alerts" %>
+
     <% if content_for? :tabs %>
       <div class="container-fluid">
         <div class="row full-vertical-height">


### PR DESCRIPTION
Use toasts to display flash messages.  Setup a demo for `flash.now[:notice]`.

![image](https://user-images.githubusercontent.com/1410587/214426683-2a943985-f5e9-4d20-b0de-7aea82bd545a.png)
