### PR TITLE
Init pundit error handling

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "redis", "~> 4.0"
 gem "oauth2", "~> 1.4.7"
 gem "prx_auth"
 gem "prx_auth-rails", "~> 4.0.0"
-gem "pundit", "~> 2.0.0"
+gem "pundit", "~> 2.3.0"
 gem "rack-cors"
 
 # html views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
-    pundit (2.0.1)
+    pundit (2.3.0)
       activesupport (>= 3.0.0)
     racc (1.6.1)
     rack (2.2.6.2)
@@ -494,7 +494,7 @@ DEPENDENCIES
   pry
   pry-byebug
   puma (~> 5.0)
-  pundit (~> 2.0.0)
+  pundit (~> 2.3.0)
   rack-cors
   rails (~> 7.0.0)
   rails-controller-testing

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -11,7 +11,6 @@ class Api::BaseController < ApplicationController
     Api::ApiResponder
   end
 
-  include Pundit
   include ApiVersioning
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,6 +10,6 @@ class ApplicationController < ActionController::Base
   def user_not_authorized(exception)
     @policy = exception.policy.class.to_s.underscore
     @query = exception.query
-    render 'errors/forbidden', status: :forbidden
+    render "errors/forbidden", status: :forbidden
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,15 @@
 class ApplicationController < ActionController::Base
+  include Pundit::Authorization
+
   protect_from_forgery with: :exception
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+  protected
+
+  def user_not_authorized(exception)
+    @policy = exception.policy.class.to_s.underscore
+    @query = exception.query
+    render 'errors/forbidden', status: :forbidden
+  end
 end

--- a/app/controllers/fake_controller.rb
+++ b/app/controllers/fake_controller.rb
@@ -4,5 +4,11 @@ class FakeController < ApplicationController
 
   def show
     @fake = "some/fake/model/#{params[:id]}"
+
+    if params[:id] == "8888"
+      flash.now[:notice] = "This is a notice, okay?"
+    elsif params[:id] == "9999"
+      authorize Podcast.new, :create?
+    end
   end
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,4 @@
+<h5 class="text-center p-5"><%= t 'pundit.title' %></h5>
+<% if I18n.exists? "pundit.#{@policy}.#{@query}" %>
+  <p class="text-center"><%= t "pundit.#{@policy}.#{@query}" %></p>
+<% end %>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,4 +1,4 @@
-<h5 class="text-center p-5"><%= t "pundit.title" %></h5>
+<h1 class="text-center p-5 pb-0 fw-bold"><%= t "pundit.title" %></h1>
 <% if I18n.exists? "pundit.#{@policy}.#{@query}" %>
   <p class="text-center"><%= t "pundit.#{@policy}.#{@query}" %></p>
 <% end %>

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,4 +1,4 @@
-<h5 class="text-center p-5"><%= t 'pundit.title' %></h5>
+<h5 class="text-center p-5"><%= t "pundit.title" %></h5>
 <% if I18n.exists? "pundit.#{@policy}.#{@query}" %>
   <p class="text-center"><%= t "pundit.#{@policy}.#{@query}" %></p>
 <% end %>

--- a/app/views/fake/show.html.erb
+++ b/app/views/fake/show.html.erb
@@ -10,7 +10,7 @@
     <%= tab_link_to "Look", fake_path(456) %>
     <%= tab_link_to "Look", fake_path(7) %>
     <%= tab_link_to "ALERT", fake_path(8888) %>
-    <%= tab_link_to "Look", fake_path(9) %>
+    <%= tab_link_to "Pundit Error", fake_path(9999) %>
     <%= tab_link_to "Look", fake_path(10) %>
   </div>
   <a class="btn btn-secondary-link align-self-center flex-shrink-1" href="#">New Something Button</a>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,7 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  pundit:
+    title: "Not Authorized"
+    podcast_policy:
+      create?: "You are not authorized to create a podcast"


### PR DESCRIPTION
Feeder already has the pundit gem for its API endpoints.

This adds it for the top-level controller, and adds some custom handling.  Users will normally never see these pages unless they're doing something nefarious.  But good to handle them.

![image](https://user-images.githubusercontent.com/1410587/214431973-89af8ec4-dfba-4f89-9455-53832d79b50a.png)
