### PR TITLE
updated styles for slim select v2

### DIFF
--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -39,115 +39,130 @@
   }
 }
 
-// TODO: these don't really with with slimselect v2
+// These styles work with Slim Select v2, not tested with v1
 .ss-main {
   &.form-select {
-    padding: 0;
+    padding: 0.75rem 0.75rem;
     min-height: $input-height;
     height: auto;
   }
 
-  .ss-single-selected,
-  .ss-multi-selected {
-    padding: $input-btn-padding-y $input-btn-padding-x;
-    line-height: $line-height-base;
-    border: 0;
-    border-radius: $input-border-radius;
-    color: $input-color;
-
-    &.ss-disabled {
-      background: $input-disabled-bg;
-      border-color: $input-disabled-border-color;
-      cursor: default;
-    }
-  }
-
-  .ss-single-selected {
-    height: 3.5rem;
-    background: transparent;
-  }
-
-  .ss-arrow {
-    visibility: hidden;
-  }
-
-  &.form-select.is-invalid:not([multiple]):not([size]) {
-    padding-right: 0;
-  }
-
-  .ss-search input {
-    border-radius: $input-border-radius;
-    padding: $input-btn-padding-y $input-btn-padding-x;
-    height: 3rem;
-  }
-
-  // more x-ish deselect
-  .ss-single-selected .ss-deselect {
-    color: transparent;
-    position: relative;
-    transform: rotate(45deg);
-
-    &::before {
-      background: #666;
-      content: "";
-      position: absolute;
-      height: 10px;
-      width: 2px;
-      left: 4px;
-      top: 12px;
-    }
-
-    &::after {
-      background: #666;
-      content: "";
-      position: absolute;
-      height: 2px;
-      width: 10px;
-      left: 0px;
-      top: 16px;
-    }
-  }
-
-  // faster!
-  .ss-content {
-    transition-duration: 0.1s;
-
-    .ss-list {
-      .ss-option,
-      .ss-optgroup-label {
-        line-height: 2;
-      }
-
-      .ss-option.ss-highlighted,
-      .ss-option:hover,
-      .ss-optgroup-label.ss-highlighted,
-      .ss-optgroup-label:hover {
-        background-color: $primary;
-      }
-    }
-  }
-
   // selection colors
-  .ss-multi-selected .ss-values .ss-value {
+  .ss-values .ss-value {
     animation: none;
     background-color: $primary;
     margin: 2px 5px 0 0;
+
+    .ss-value-delete,
+    .ss-value-delete svg {
+      width: 16px;
+      height: 16px;
+      border-left: none;
+    }
   }
 
   .ss-multi-selected .ss-add {
     margin-top: 12px;
     margin-right: 8px;
   }
+}
 
-  // undo bootstrap placeholder class
-  .placeholder {
-    display: flex;
-    min-height: auto;
-    vertical-align: baseline;
-    cursor: pointer;
-    background-color: transparent;
-    opacity: 1;
+.ss-single-selected,
+.ss-multi-selected {
+  padding: $input-btn-padding-y $input-btn-padding-x;
+  line-height: $line-height-base;
+  border: 0;
+  border-radius: $input-border-radius;
+  color: $input-color;
+
+  &.ss-disabled {
+    background: $input-disabled-bg;
+    border-color: $input-disabled-border-color;
+    cursor: default;
   }
+}
+
+.ss-single-selected {
+  height: 3.5rem;
+  background: transparent;
+}
+
+.ss-arrow {
+  visibility: hidden;
+}
+
+.ss-main.form-select.is-invalid:not([multiple]):not([size]) {
+  padding-right: 0;
+}
+
+.ss-search input {
+  border-radius: $input-border-radius;
+  padding: $input-btn-padding-y $input-btn-padding-x;
+  height: 3rem;
+}
+
+// more x-ish deselect
+.ss-single-selected .ss-deselect {
+  color: transparent;
+  position: relative;
+  transform: rotate(45deg);
+
+  &::before {
+    background: #666;
+    content: "";
+    position: absolute;
+    height: 10px;
+    width: 2px;
+    left: 4px;
+    top: 12px;
+  }
+
+  &::after {
+    background: #666;
+    content: "";
+    position: absolute;
+    height: 2px;
+    width: 10px;
+    left: 0px;
+    top: 16px;
+  }
+}
+
+// faster!
+.ss-content {
+  transition-duration: 0.1s;
+
+  &.form-select {
+    padding: 0;
+    border-radius: 0;
+    box-shadow: $box-shadow;
+    background-image: none;
+  }
+
+  .ss-list {
+    .ss-option,
+    .ss-optgroup-label {
+      line-height: 2;
+    }
+
+    .ss-option.ss-selected:not(.ss-disabled),
+    .ss-option.ss-highlighted,
+    .ss-option:hover,
+    .ss-optgroup-label.ss-highlighted,
+    .ss-optgroup-label:hover {
+      background-color: $primary;
+    }
+  }
+}
+
+// undo bootstrap placeholder class
+.placeholder {
+  display: flex;
+  min-height: auto;
+  vertical-align: baseline;
+  cursor: pointer;
+  background-color: transparent;
+  opacity: 1;
 }
 
 // maybe a bad idea ... but hide options on multiselects, so things don't

--- a/app/helpers/feeder_form_builder.rb
+++ b/app/helpers/feeder_form_builder.rb
@@ -125,8 +125,7 @@ class FeederFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def add_slim_select_controller(opts)
-    # TODO: slimselect 2 styles messed up at the moment
-    # add_data(opts, :controller, SLIM_SELECT_CONTROLLER)
+    add_data(opts, :controller, SLIM_SELECT_CONTROLLER)
   end
 
   def add_flatpickr_controller(opts)

--- a/app/javascript/controllers/slim_select_controller.js
+++ b/app/javascript/controllers/slim_select_controller.js
@@ -8,18 +8,18 @@ export default class extends Controller {
     this.select = new SlimSelect({
       select: this.element,
       settings: {
-        selectByGroup: this.groupSelectValue,
-        placeholder: " ",
+        // TODO: broken
+        // selectByGroup: this.groupSelectValue,
+        placeholderText: "",
         allowDeselect: this.hasEmpty(this.element),
         showSearch: this.showSearch(this.element),
-        onChange: function (info) {
-          const val = Array.isArray(info) ? info.length > 0 : info.value
-          if (val) {
-            this.select.element.classList.remove("form-control-blank")
-            this.slim.container.classList.remove("form-control-blank")
+      },
+      events: {
+        afterChange: (val) => {
+          if (val.length > 0) {
+            this.select.selectEl.classList.remove("form-control-blank")
           } else {
-            this.select.element.classList.add("form-control-blank")
-            this.slim.container.classList.add("form-control-blank")
+            this.select.selectEl.classList.add("form-control-blank")
           }
         },
       },

--- a/app/views/fake/show.html.erb
+++ b/app/views/fake/show.html.erb
@@ -36,7 +36,7 @@
 
           <div class="col-xl-6 mb-4">
             <div class="form-floating">
-              <%= form.select :itunes_type, [["Full", "full"], ["Bonus", "bonus"], ["Invalid", "invalid"]], include_blank: true %>
+              <%= form.select :itunes_type, [["Full", "full"], ["Invalid", "invalid"]], include_blank: true %>
               <%= form.label :itunes_type %>
             </div>
           </div>

--- a/app/views/fake/show.html.erb
+++ b/app/views/fake/show.html.erb
@@ -43,7 +43,7 @@
 
           <div class="col-xl-6 mb-4">
             <div class="form-floating">
-              <%= form.select :categories, [["One", "one"], ["Two", "two"], ["Three", "three"]], {}, multiple: true %>
+              <%= form.select :categories, [["One", "one"], ["Two", "two"], ["Three", "three"]], {include_blank: true}, multiple: true %>
               <%= form.label :categories %>
             </div>
           </div>


### PR DESCRIPTION
Wooo! Slim Select V2 is not backwards compatible from a styling perspective. But I think I got all the differences.

This will be a big diff as slim-select got rid of some wrapper classes, so many things have been moved around the file.

When we port this over to the other sites, we will need to upgrade slim select, otherwise many selects will have weird styling.