### PR TITLE
Cleanup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo follows the [standards for PRX services](https://github.com/PRX/docs.p
 - Ruby - runs all the things!
 - PostgreSQL - main database
 - AWS S3 - writing RSS files
+- AWS SQS - async job queue
 - NodeJS - for linting
 
 ### Integrations
@@ -28,6 +29,7 @@ This app additionally relies on other PRX services:
 - [id.prx.org](https://id.prx.org) - authorize PRX users/accounts
 - [Porter](https://github.com/PRX/Porter) - send tasks to analyze and manipulate audio/image files
 - [dovetail.prxu.org](https://dovetail.prxu.org) - calls feeder for info about episodes/feeds
+- [Apple API Bridge Lambda](https://github.com/PRX/api-bridge-lambda/) - for publishing subscribable podcasts to Apple
 
 ## Installation
 
@@ -80,7 +82,7 @@ bin/rails db:migrate
 Otherwise, it can be helpful to have a staging or production database to get started:
 
 ```sh
-TBD
+TODO
 ```
 
 ## Development
@@ -101,9 +103,33 @@ Run the rails development server at [localhost:3002](http://localhost:3002):
 bin/rails server
 ```
 
+At [localhost:3002/fake](http://localhost:3002/fake), you'll find the HTML user
+interface for Feeder. In addition to standard Rails, it uses [Turbo](https://turbo.hotwired.dev/),
+[Stimulus](https://stimulus.hotwired.dev/), and [Bootstrap 5](https://getbootstrap.com/docs/5.0/getting-started/introduction/).
+Whenever possible, we'd appreciate it if you stuck to this toolset!
+
+When you land on an authenticated page, you will be redirected to `ID_HOST` for authorization.
+Once you are logged in, you will be redirected back to (hopefully) your local `/auth/sessions`.
+If this is not working, you should check your `PRX_CLIENT_ID` ClientApplication and your
+`AccountApplication`s in the ID admin interface.
+
+#### HAL API
+
+At [localhost:3002/api/v1](http://localhost:3002/api/v1), you'll find the HAL API root.
+You can navigate around the public API endpoints by following the links. This is currently
+built with the [hal_api-rails](https://github.com/PRX/hal_api-rails) gem, but we have plans
+to eventually switch to [halbuilder](https://github.com/PRX/halbuilder) (an extension of Jbuilder).
+
+For `/api/v1/authorization` endpoints, you will need to provide a [JWT](https://jwt.io/) provided by
+PRX ID.
+
 ### Worker
 
-tbd
+In addition to the server, Feeder runs a worker for processing async jobs. This largely uses
+the [Shoryuken](https://github.com/ruby-shoryuken/shoryuken) gem and AWS SQS.
+
+Some jobs run completely in Ruby, while others will call out to [Porter](https://github.com/PRX/Porter)
+or the [Apple API Bridge Lambda](https://github.com/PRX/api-bridge-lambda/) to complete their work.
 
 #### File Handling
 
@@ -114,11 +140,32 @@ When an episode file has a new original url, that is considered a new file. When
 
 ### Tests
 
-tbd
+You should write/run the tests! With any PR, we expect some tests for your changes.
+
+```sh
+bin/rails test
+bin/rails test test/models/podcast_test.rb
+bin/rails test test/models/podcast_test.rb:9
+```
 
 ### Linting
 
-tbd
+This entire repo is linted using:
+
+- [standardrb](https://github.com/testdouble/standard) for ruby files
+- [erblint](https://github.com/Shopify/erb-lint) for `html.erb` files
+  - Note this _does not_ handle indentation at the moment, but you're encouraged to
+    use some other editor plugin to ensure your erb has the right indentation
+- [prettier](https://prettier.io/) for `js`, `scss`, and `md` files
+
+Your commits will be checked with these in Github, so you should lint your code before pushing.
+
+```sh
+bin/rails lint
+bin/rails lint:fix
+```
+
+TODO: editor integration. Because format-on-save is cool.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Try [asdf](https://asdf-vm.com/), or use something completely different!
 git clone git@github.com:PRX/feeder.prx.org.git
 cd feeder.prx.org
 
+# make your local git blame ignore giant linting commits
+git config --global blame.ignoreRevsFile .git-blame-ignore-revs
+
 # sane ENV defaults
 cp env-example .env
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,28 @@ If you're cool with a blank database, just run the migrations!
 bin/rails db:migrate
 ```
 
-Otherwise, it can be helpful to have a staging or production database to get started:
+Otherwise, it can be helpful to have a staging or production database to get started. First
+off, make sure you have our [homebrew dev tools](https://github.com/PRX/homebrew-dev-tools) installed,
+and you can successfully connect to the stag/prod environments via `awstunnel`.
+
+Then, set `DUMP_REMOTE_POSTGRES_USER` and `DUMP_REMOTE_POSTGRES_DATABASE` in your `.env`, for the
+staging or prod database you're copying.
 
 ```sh
-TODO
+# start staging tunnel
+awstunnel stag
+
+# in another tab, dump the database
+ops/bin/dump_db.sh stag
+
+# restore it to a clone db
+ops/bin/setup_clone_db.sh
+
+# and copy the clone to feeder_development
+ops/bin/load_db.sh
+
+# and if you ever need a fresh db, run it again
+ops/bin/load_db.sh
 ```
 
 ## Development

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -13,7 +13,7 @@ common: &default_settings # Required license key associated with your New Relic 
 
   # Your application name. Renaming here affects where data displays in New
   # Relic.  For more details, see https://docs.newrelic.com/docs/apm/new-relic-apm/maintenance/renaming-applications
-  app_name: feeder.prx.org
+  app_name: <%= ENV['NEW_RELIC_NAME'] %>
 
   # To disable the agent regardless of other settings, uncomment the following:
   # agent_enabled: false

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -15,7 +15,7 @@ worker_timeout 3600 if ENV.fetch("RAILS_ENV", "development") == "development"
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port ENV.fetch("PORT", 3000)
+port ENV.fetch("PORT", 3002)
 
 # Specifies the `environment` that Puma will run in.
 #

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -12,6 +12,7 @@ services:
     environment:
       VIRTUAL_HOST: feeder.prx.docker
       RAILS_ENV: test
+      POSTGRES_HOST: db
   db:
     image: postgres
     env_file:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
     command: web
     environment:
       VIRTUAL_HOST: feeder.prx.docker
-      LOCAL_ENV: "true"
     networks:
       - feeder-net
   worker:

--- a/env-example
+++ b/env-example
@@ -1,53 +1,55 @@
-LOCAL_ENV=true
+PORT=3002
 RAILS_ENV=development
 SECRET_KEY_BASE=rake-secret-here
 
 # local database
-POSTGRES_DATABASE=feeder
-POSTGRES_HOST=db
+DATABASE_POOL_SIZE=16
+POSTGRES_DATABASE=feeder_development
+POSTGRES_HOST=localhost
 POSTGRES_PASSWORD=password
-DATABASE_POOL_SIZE=10
 POSTGRES_PORT=5432
 POSTGRES_USER=feeder
 
-WORKER_DATABASE_POOL_SIZE=10
-WORKER_COUNT=10
-
-LANG=en_US.UTF-8
-NEW_RELIC_KEY=
+# async jobs
 PORTER_SNS_TOPIC=
+START_SAY_WHEN=
+WORKER_COUNT=
+WORKER_PAUSE=
 
+# AWS credentials
 AWS_ACCESS_KEY_ID=
 AWS_ACCOUNT_ID=
 AWS_REGION=
 AWS_SECRET_ACCESS_KEY=
 
+# monitoring
+NEW_RELIC_KEY=
+NEW_RELIC_NAME=
+
+# authentication
 PRX_CLIENT_ID=
-PRX_HOST=beta.prx.org
 PRX_SECRET=
 
+# prx hosts
 CMS_HOST=cms-staging.prx.tech
-CRIER_HOST=crier-staging.prx.tech
-DATABASE_POOL_SIZE=16
 DOVETAIL_HOST=dovetail-staging.prxu.org
+FEEDER_HOST=feeder.staging.prx.tech
 FEEDER_CDN_HOST=f-staging.prxu.org
 FEEDER_CDN_PRIVATE_HOST=p.staging.prxu.org
-# defaults to feeder.prx.org
-FEEDER_HOST=feeder.prx.docker
-# defaults to "PRX Feeder v#{Feeder::VERSION}"
-# FEEDER_GENERATOR=
-# defaults to 300
-# FEEDER_RELEASE_CHECK_DELAY=
-# defaults to prx-feed in production, otherwise {env}-prx-feed
-# FEEDER_STORAGE_BUCKET=
-# defaults to 'help@prx.org (PRX)'
-# FEEDER_WEB_MASTER=
-FEEDS_TOKEN=
 ID_HOST=id-staging.prx.tech
+PRX_HOST=beta.staging.prx.tech
 
+# RSS settings
+# FEEDER_GENERATOR=
+# FEEDER_RELEASE_CHECK_DELAY=
+# FEEDER_STORAGE_BUCKET=
+# FEEDER_WEB_MASTER=
+
+# auth token access for dovetail-router
+FEEDS_TOKEN=
+
+# apple API
 APPLE_PROVIDER_ID=
 APPLE_KEY_ID=
 APPLE_KEY_PEM_B64=
 APPLE_API_BRIDGE_URL=
-
-RAILS_SERVE_STATIC_FILES=enabled


### PR DESCRIPTION
- [x] Moved to port 3002, to avoid conflicts with other apps.  (Staging/Prod set their `PORT` env to 3000, so they will continue to work as-is).
- [x] Removed deprecated envs, and sorted/organized `env-example`
- [x] Updated the README to reflect the near-future state of things
  - Doesn't talk about docker - assume local dev
  - No mention of CMS, Publish or Crier - those are on the way out