### PR TITLE
Create styles for episode list cards

### DIFF
--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -97,6 +97,60 @@
   }
 }
 
+.episode-card {
+  border-top: none;
+  border-left: 5px solid $primary;
+  border-right: none;
+  border-bottom: none;
+  border-radius: 0;
+  margin-bottom: 0.25rem;
+  height: 100px;
+
+  .card-body {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 0;
+    padding-bottom: 0;
+
+    &:hover {
+      background: rgba(140, 210, 244, 0.1);
+    }
+  }
+
+  .episode-card-info {
+    display: flex;
+    justify-content: start;
+    align-items: center;
+
+    .episode-card-date {
+      font-size: 1.5rem;
+      margin-right: 1rem;
+    }
+
+    .episode-card-title {
+      margin-bottom: 0.25rem;
+      font-weight: bold;
+      font-size: 1rem;
+      line-height: 1.2;
+      color: $primary;
+    }
+
+    p {
+      font-size: 0.875rem;
+      line-height: 1.2;
+      margin-bottom: 0;
+    }
+
+    .stretched-link {
+      inset: 0;
+      overflow: hidden;
+      position: absolute;
+      text-indent: -2000vw;
+    }
+  }
+}
+
 .bg-info,
 .bg-warning,
 .bg-danger {

--- a/app/assets/stylesheets/card.scss
+++ b/app/assets/stylesheets/card.scss
@@ -65,7 +65,7 @@
 
   .podcast-card-info {
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-items: center;
 
     img {
@@ -120,7 +120,7 @@
 
   .episode-card-info {
     display: flex;
-    justify-content: start;
+    justify-content: flex-start;
     align-items: center;
 
     .episode-card-date {

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -28,6 +28,15 @@
 
 .prx-dovetail-nav {
   background: $blue-dark;
+  margin: 0;
+  padding: 0;
+
+  .navbar-nav {
+    display: flex;
+    flex-direction: row;
+    justify-content: end;
+    align-items: center;
+  }
 
   .dropdown-menu {
     background: $blue-dark;
@@ -80,7 +89,21 @@
 }
 
 .prx-app-nav {
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+  margin: 0;
+  padding: 0;
   border-bottom: 1px solid $gray-300;
+
+  .navbar-nav {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+  }
 }
 
 .prx-podcast-switcher {
@@ -100,6 +123,9 @@
   .dropdown-toggle {
     width: 100%;
     border: none;
+    display: flex;
+    justify-content: start;
+    align-items: center;
 
     &:after {
       display: none;
@@ -128,6 +154,23 @@
 
     &:hover {
       text-decoration: underline;
+    }
+  }
+}
+
+.dashboard-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1.5rem;
+
+  .filter-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: end;
+
+    & > * {
+      margin-left: 1rem;
     }
   }
 }

--- a/app/views/fake/index.html.erb
+++ b/app/views/fake/index.html.erb
@@ -92,9 +92,9 @@
   </div>
 
   <!-- Example for the podcasts list-->
-  <div class="row mt-4">
+  <div class="row mt-4 mb-4">
     <div class="col-lg-12">
-      <div class="dashboard-header d-flex align-items-center mb-4">
+      <div class="dashboard-header">
         <div class="col d-flex align-items-center">
           <h1 class="text-black fw-bold me-4 mb-0">My Podcasts</h1>
           <div class="btn-group">
@@ -152,4 +152,87 @@
     </div>
 
   </div>
+
+  <!-- Example of Episode cards -->
+  <div class="row my-4">
+    <div class="dashboard-header">
+      <div class="flex-grow-1 d-flex align-items-center">
+        <h1 class="text-black fw-bold me-4 mb-0">Episodes</h1>
+      </div>
+      <div class="filter-group">
+        <a href="#" class="btn btn-primary d-flex align-items-center">Create Episode <span class="material-icons ms-2" aria-hidden="true">mic</span></a>
+        <a href="#" class="btn btn-primary d-flex align-items-center">Plan Episodes <span class="material-icons ms-2" aria-hidden="true">calendar_today</span></a>
+        <div class="form-floating">
+          <select class="form-select" data-action="blur->blank-field#blur" disabled="disabled" name="episode[itunes_type]" id="episode_itunes_type"><option value="" label=" "></option>
+            <option selected="selected" value="full">Episode Name</option>
+            <option value="bonus">Episode Name</option>
+            <option value="invalid">Episode Name</option></select>
+          <label for="episode_itunes_type">Filter Episodes</label>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <h3 class="fw-bold">Draft and Scheduled Episodes</h3>
+      <div class="card episode-card border-warning">
+        <div class="card-body">
+          <div class="episode-card-info">
+            <p class="episode-card-date">1/30</p>
+            <div>
+              <h2 class="episode-card-title">Episode Name</h2>
+              <p class="card-text text-small">Episode Description</p>
+              <div>
+                <span class="badge rounded-pill text-bg-light">Category</span>
+                <span class="badge rounded-pill text-bg-light">Category</span>
+              </div>
+              <%= link_to "Go to Podcast", fake_path(123), class: "stretched-link" %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card episode-card border-success">
+        <div class="card-body">
+          <div class="episode-card-info">
+            <p class="episode-card-date">2/2</p>
+            <div>
+              <h2 class="episode-card-title">February 2nd, 2013</h2>
+              <%= link_to "Go to Podcast", fake_path(123), class: "stretched-link" %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="col-md-6">
+      <h3 class="fw-bold">Published Episodes</h3>
+      <div class="card episode-card border-primary">
+        <div class="card-body">
+          <div class="episode-card-info">
+            <p class="episode-card-date">12/12</p>
+            <div>
+              <h2 class="episode-card-title">Episode Name</h2>
+              <p class="card-text text-small">Episode Description</p>
+              <div>
+                <span class="badge rounded-pill text-bg-light">Category</span>
+                <span class="badge rounded-pill text-bg-light">Category</span>
+              </div>
+              <%= link_to "Go to Podcast", fake_path(123), class: "stretched-link" %>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="card episode-card border-primary">
+        <div class="card-body">
+          <div class="episode-card-info">
+            <p class="episode-card-date">11/11</p>
+            <div>
+              <h2 class="episode-card-title">Episode Name that happens to be long enough to cause display issues</h2>
+              <p class="card-text text-small">This is the episode description, which is also very long.</p>
+              <%= link_to "Go to Podcast", fake_path(123), class: "stretched-link" %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
 </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,7 +1,7 @@
-<nav class="prx-dovetail-nav navbar navbar-expand-sm navbar-dark m-0 p-0">
+<nav class="prx-dovetail-nav navbar navbar-expand-sm navbar-dark">
   <div class="container-fluid pe-0">
     <%= link_to "Dovetail", main_app.fake_index_path, class: "navbar-brand" %>
-    <ul class="navbar-nav d-flex flex-row justify-content-end align-items-center">
+    <ul class="navbar-nav">
       <li class="nav-item">
         <a class="nav-link active" href="/">Podcasts</a>
       </li>

--- a/app/views/layouts/_subnav.html.erb
+++ b/app/views/layouts/_subnav.html.erb
@@ -1,8 +1,8 @@
-<nav class="prx-app-nav navbar bg-white d-flex flex-row flex-wrap justify-content-start m-0 p-0">
+<nav class="prx-app-nav navbar bg-white">
 
     <!-- PODCAST SWITCHER -->
     <div class="prx-podcast-switcher dropdown">
-      <button class=" btn btn-white dropdown-toggle d-flex .justify-content-start align-items-center" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="btn btn-white dropdown-toggle" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
           <span class="material-icons size-30 me-2" aria-label="hidden">square</span>
           <em class="flex-grow-1 text-start">Select a podcast</em>
           <span class="material-icons justify-self-end ms-2" aria-label="hidden">expand_more</span>
@@ -28,7 +28,7 @@
     <!-- END PODCAST SWITCHER -->
 
     <% if content_for :subnav %>
-    <ul class="navbar-nav col d-flex flex-row flex-wrap m-0 p-0">
+    <ul class="navbar-nav col">
       <li class="nav-item"><%= link_to "Subnav", main_app.fake_index_path, class: "nav-link" %></li>
       <li class="nav-item"><%= link_to "Subnav 2", main_app.fake_index_path, class: "nav-link" %></li>
       <li class="nav-item"><%= link_to "Subnav 3", main_app.fake_index_path, class: "nav-link" %></li>


### PR DESCRIPTION
Realized, I forgot about these when creating the Card PR last week. 

- This sets up the patterns for the two column episode list. `.episode-card` (Check it own on the fake/index path)
- It also touches nav files a little by moving away from bootstrap classes to styles defined in stylesheets as we resolved to do that in the cards PR. Should be cleaner.
