### PR TITLE
Skip setting session for api

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -59,10 +59,6 @@ class Api::BaseController < ApplicationController
   def options
     head :no_content
   end
-
-  def skip_session
-    request.session_options[:drop] = true
-  end
 end
 
 class ResourceGone < HalApi::Errors::ApiError

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -10,6 +10,8 @@ class Api::BaseController < ApplicationController
   # default to public API (unless including ApiAuthenticated)
   skip_before_action :authenticate!
 
+  before_action :skip_session
+
   def self.responder
     Api::ApiResponder
   end
@@ -56,6 +58,10 @@ class Api::BaseController < ApplicationController
 
   def options
     head :no_content
+  end
+
+  def skip_session
+    request.session_options[:drop] = true
   end
 end
 

--- a/app/controllers/api/feeds_controller.rb
+++ b/app/controllers/api/feeds_controller.rb
@@ -2,6 +2,8 @@ class Api::FeedsController < ApplicationController
   skip_before_action :authenticate!
   before_action :authenticate_feeds_token!
 
+  before_action :skip_session
+
   def index
     max_updated_at = Feed.maximum(:updated_at)
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,4 +41,8 @@ class ApplicationController < ActionController::Base
       super(jwt_ttl)
     end
   end
+
+  def skip_session
+    request.session_options[:drop] = true
+  end
 end


### PR DESCRIPTION
For api requests, this PR prevents setting a session.

To verify:

- `/fake`: does set a cookie and insert a row in the sessions table
- `/api/v1`: (api base controller) does not set a cookie or insert a row into the sessions table
- `/api/v1/feeds`: feeds controller (application controller), does not set a cookie or insert a row into the sessions table