### PR TITLE
Fix/ops scripts skip session

### DIFF
--- a/ops/bin/dump_db.sh
+++ b/ops/bin/dump_db.sh
@@ -46,6 +46,7 @@ echo "Feeder remote"
 time pg_dump --verbose -Fc -h 127.0.0.1 \
   -p $DB_DUMP_PORT \
   --exclude-table-data 'public.say_when_job_executions' \
+  --exclude-table-data 'sessions' \
   --exclude-table-data 'tasks' \
   -W -d $DUMP_REMOTE_POSTGRES_DATABASE -U $DUMP_REMOTE_POSTGRES_USER -f $OUTPUT_FILE
 echo "Wrote: $OUTPUT_FILE"

--- a/ops/bin/psql.sh
+++ b/ops/bin/psql.sh
@@ -8,4 +8,4 @@ export PGPASSWORD=$POSTGRES_PASSWORD
 export PGUSER=$POSTGRES_USER
 export PGHOST=$POSTGRES_HOST
 
-psql
+psql feeder_development


### PR DESCRIPTION
A couple of minor changes:

- skip the sessions table when dumping databases
- make sure to connect to the local dev database with the psql.sh helper