### PR TITLE
Use standard PRX favicon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,10 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
-    <%= favicon_link_tag asset_path("favicon.ico") %>
+    <link rel="icon" href="https://media.prx.org/favicon/icon-32.ico" sizes="any">
+    <link rel="icon" href="https://media.prx.org/favicon/icon.svg" type="image/svg+xml">
+    <link rel="apple-touch-icon" href="https://media.prx.org/favicon/icon-180.png">
+
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>


### PR DESCRIPTION
My recommendation would be to standardize on the PRX icon for the time being. If we want to develop a meaningful set of icons for each app (Feeder, Augury, etc), or functions (publishing, metrics, etc) down the road, that could be beneficial. But until then, I think just using the vanilla icon gets us in a good spot.