### PR TITLE
Extract a base enclosure url

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -47,14 +47,6 @@ module Apple
       end
     end
 
-    def self.add_no_imp_param(url)
-      # use the URI class to add a 'noImp' query param
-      url = URI.parse(url)
-      decoded_query = URI.decode_www_form(url.query.to_s) << ["noImp", "1"]
-      url.query = URI.encode_www_form(decoded_query)
-      url.to_s
-    end
-
     def initialize(show:, feeder_episode:, api: nil)
       @show = show
       @feeder_episode = feeder_episode
@@ -69,8 +61,18 @@ module Apple
       feeder_episode.id
     end
 
+    def private_feed
+      show.private_feed
+    end
+
+    def podcast
+      show.podcast
+    end
+
     def enclosure_url
-      self.class.add_no_imp_param(feeder_episode.enclosure_url)
+      url = EnclosureUrlBuilder.new.base_enclosure_url(podcast, feeder_episode, private_feed)
+      url = EnclosureUrlBuilder.mark_no_imp(url)
+      EnclosureUrlBuilder.mark_authorized(url, show.private_feed)
     end
 
     def enclosure_filename

--- a/app/models/enclosure_url_builder.rb
+++ b/app/models/enclosure_url_builder.rb
@@ -76,6 +76,7 @@ class EnclosureUrlBuilder
 
   def enclosure_prefix_url(u, prefix)
     return u if prefix.blank?
+
     pre = Addressable::URI.parse(prefix)
     orig = Addressable::URI.parse(u)
     orig.path = File.join(pre.path, orig.host, orig.path)
@@ -83,8 +84,6 @@ class EnclosureUrlBuilder
     orig.host = pre.host
     orig.to_s
   end
-
-  private
 
   def self.add_query_param(url, key, value)
     url = URI.parse(url)

--- a/app/models/enclosure_url_builder.rb
+++ b/app/models/enclosure_url_builder.rb
@@ -2,6 +2,13 @@ require "addressable/uri"
 require "addressable/template"
 
 class EnclosureUrlBuilder
+  def self.add_query_param(url, key, value)
+    url = URI.parse(url)
+    decoded_query = URI.decode_www_form(url.query.to_s) << [key, value]
+    url.query = URI.encode_www_form(decoded_query)
+    url.to_s
+  end
+
   def self.mark_authorized(enclosure_url, feed)
     return enclosure_url unless feed.private?
     raise "Missing tokens for private feed #{feed.id}" if feed.private? && !feed.tokens.any?
@@ -83,12 +90,5 @@ class EnclosureUrlBuilder
     orig.scheme = pre.scheme
     orig.host = pre.host
     orig.to_s
-  end
-
-  def self.add_query_param(url, key, value)
-    url = URI.parse(url)
-    decoded_query = URI.decode_www_form(url.query.to_s) << [key, value]
-    url.query = URI.encode_www_form(decoded_query)
-    url.to_s
   end
 end

--- a/app/models/enclosure_url_builder.rb
+++ b/app/models/enclosure_url_builder.rb
@@ -2,12 +2,32 @@ require "addressable/uri"
 require "addressable/template"
 
 class EnclosureUrlBuilder
+  def self.mark_authorized(enclosure_url, feed)
+    return enclosure_url unless feed.private?
+    raise "Missing tokens for private feed #{feed.id}" if feed.private? && !feed.tokens.any?
+
+    token = feed.tokens.first.token
+    add_query_param(enclosure_url, "auth", token)
+  end
+
+  # Marks the url as a `noImp`
+  # Used by Dovetail to skip the impression tracking
+  def self.mark_no_imp(enclosure_url)
+    add_query_param(enclosure_url, "noImp", "1")
+  end
+
   def podcast_episode_url(podcast, episode, feed = nil)
     feed ||= podcast.default_feed
-    template = feed.try(:enclosure_template)
     prefix = feed.try(:enclosure_prefix)
+
+    url = base_enclosure_url(podcast, episode, feed)
+    enclosure_prefix_url(url, prefix)
+  end
+
+  def base_enclosure_url(podcast, episode, feed)
+    template = feed.try(:enclosure_template)
     expansions = podcast_episode_expansions(podcast, episode, feed)
-    enclosure_url(template, expansions, prefix)
+    enclosure_url(template, expansions)
   end
 
   def podcast_episode_expansions(podcast, episode, feed)
@@ -45,9 +65,8 @@ class EnclosureUrlBuilder
     format ? ".#{format}" : nil
   end
 
-  def enclosure_url(template, expansions, prefix = nil)
-    url = enclosure_template_url(template, expansions)
-    enclosure_prefix_url(url, prefix)
+  def enclosure_url(template, expansions)
+    enclosure_template_url(template, expansions)
   end
 
   def enclosure_template_url(template, expansions)
@@ -63,5 +82,14 @@ class EnclosureUrlBuilder
     orig.scheme = pre.scheme
     orig.host = pre.host
     orig.to_s
+  end
+
+  private
+
+  def self.add_query_param(url, key, value)
+    url = URI.parse(url)
+    decoded_query = URI.decode_www_form(url.query.to_s) << [key, value]
+    url.query = URI.encode_www_form(decoded_query)
+    url.to_s
   end
 end

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -6,7 +6,7 @@ describe Apple::Episode do
   let(:podcast) { create(:podcast) }
 
   let(:public_feed) { create(:feed, podcast: podcast, private: false) }
-  let(:private_feed) { create(:feed, podcast: podcast, private: true) }
+  let(:private_feed) { create(:feed, podcast: podcast, private: true, tokens: [FeedToken.new]) }
 
   let(:apple_creds) { build(:apple_credential) }
   let(:apple_api) { Apple::Api.from_apple_credentials(apple_creds) }

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -85,14 +85,4 @@ describe Apple::Episode do
       assert_match(/noImp=1/, apple_episode.enclosure_url)
     end
   end
-
-  describe ".add_no_imp_param" do
-    it "should add a noImp query param" do
-      assert_equal "http://example.com?noImp=1", Apple::Episode.add_no_imp_param("http://example.com")
-    end
-
-    it "should preserve existing query params" do
-      assert_equal "http://example.com?foo=bar&noImp=1", Apple::Episode.add_no_imp_param("http://example.com?foo=bar")
-    end
-  end
 end

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -8,7 +8,7 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
 
   let(:apple_creds) { build(:apple_credential) }
   let(:apple_api) { Apple::Api.from_apple_credentials(apple_creds) }
-  let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+  let(:public_feed) { create(:feed, podcast: podcast, private: false, tokens: [FeedToken.new]) }
   let(:private_feed) { create(:feed, podcast: podcast, private: true) }
   let(:apple_show) { Apple::Show.new(api: apple_api, public_feed: public_feed, private_feed: private_feed) }
 

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -8,8 +8,8 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
 
   let(:apple_creds) { build(:apple_credential) }
   let(:apple_api) { Apple::Api.from_apple_credentials(apple_creds) }
-  let(:public_feed) { create(:feed, podcast: podcast, private: false, tokens: [FeedToken.new]) }
-  let(:private_feed) { create(:feed, podcast: podcast, private: true) }
+  let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+  let(:private_feed) { create(:feed, podcast: podcast, private: true, tokens: [FeedToken.new]) }
   let(:apple_show) { Apple::Show.new(api: apple_api, public_feed: public_feed, private_feed: private_feed) }
 
   let(:apple_episode) { build(:apple_episode, show: apple_show, feeder_episode: episode) }


### PR DESCRIPTION
This PR Fixes a couple problems with the urls that the Apple Subscriptions code uses:

1) It removes the `prefix` from the enclosures that the apple api uses.  This decouples the GET from the Dovetail CDN from the typical redirect flow that end users experience. The 'reduced' enclosure url should directly reference the DTR redirect endpoint.
2) It fixes up the feed enclosure to make sure that we're building _authed_ enclosures for the episodes -- the same as what are referenced in the private feed.  This ensures that we are getting the stitched audio from the private feed.  Previously this was getting the enclosure for the default (public) feed. 