### PR TITLE
Fix/guard on remote apple state

### DIFF
--- a/app/models/apple/api.rb
+++ b/app/models/apple/api.rb
@@ -198,9 +198,13 @@ module Apple
 
     def bridge_remote_and_retry!(bridge_resource, bridge_options)
       (oks, errs) = bridge_remote_and_retry(bridge_resource, bridge_options)
-      raise Apple::ApiError.new(JSON.pretty_generate(errs), nil) if errs.present?
+      raise_bridge_api_error(errs) if errs.present?
 
       oks
+    end
+
+    def raise_bridge_api_error(err)
+      raise Apple::ApiError.new(JSON.pretty_generate(err), nil)
     end
 
     def development_bridge_url?

--- a/app/models/apple/api_response.rb
+++ b/app/models/apple/api_response.rb
@@ -43,6 +43,8 @@ module Apple
     end
 
     def apple_id
+      raise "missing apple id" unless apple_data["id"].present?
+
       apple_data["id"]
     end
   end

--- a/app/models/apple/api_response.rb
+++ b/app/models/apple/api_response.rb
@@ -6,21 +6,71 @@ module Apple
 
     included do
       # assumes the apple_episode_id is present on the request metadata
-      def self.join_on_apple_episode_id(resources, results)
-        join_on("apple_episode_id", resources, results)
+      def self.join_on_apple_episode_id(resources, results, left_join: false)
+        join_on("apple_episode_id", resources, results, left_join: left_join)
       end
 
-      def self.join_on(id_attribute_key, resources, results)
-        raise "Resource missing join attribute" if resources.any? { |r| !r.respond_to?(id_attribute_key) }
+      def self.join_on(id_attribute_key, resources, results, left_join: false)
+        (resources_by_id, results_by_id) = one_to_one_lookup(id_attribute_key, resources, results)
 
-        resources_by_id = resources.map { |resource| [resource.send(id_attribute_key), resource] }.to_h
+        resource_key_set = Set.new(resources_by_id.keys)
+        result_key_set = Set.new(results_by_id.keys)
 
-        results.map do |row|
-          raise "request_metadata is missing" unless row["request_metadata"].present?
-
-          resource = resources_by_id.fetch(row["request_metadata"][id_attribute_key])
-          [resource, row]
+        if left_join
+          raise "Result keys are not a subset of resource keys" unless result_key_set.subset?(resource_key_set)
+        else
+          raise "Join key mismatch" unless resource_key_set == result_key_set
         end
+
+        resources_by_id.map do |join_key, resource|
+          result = results_by_id.fetch(join_key, nil)
+          [resource, result]
+        end
+      end
+
+      def self.join_many_on(id_attribute_key, resources, results, left_join: false)
+        (resources_by_id, results_by_id) = one_to_many_lookup(id_attribute_key, resources, results)
+
+        resource_key_set = Set.new(resources_by_id.keys)
+        result_key_set = Set.new(results_by_id.keys)
+
+        if left_join
+          raise "Result keys are not a subset of resource keys" unless result_key_set.subset?(resource_key_set)
+        else
+          raise "Join key mismatch" unless resource_key_set == result_key_set
+        end
+
+        resources_by_id.map do |join_key, resource|
+          result = results_by_id.fetch(join_key, nil)
+          [resource, result]
+        end
+      end
+
+      private
+
+      def self.one_to_one_lookup(id_attribute_key, resources, results)
+        (resources_by_id, results_by_id) = one_to_many_lookup(id_attribute_key, resources, results)
+
+        if results_by_id.values.any? { |v| v.length > 1 }
+          raise "Duplicate results found for '#{id_attribute_key}'"
+        end
+
+        [resources_by_id, results_by_id.transform_values(&:first)]
+      end
+
+      def self.one_to_many_lookup(id_attribute_key, resources, results)
+        raise "Resource missing join attribute" if resources.any? { |r| !r.respond_to?(id_attribute_key) }
+        raise "Result missing join attribute" if results.any? { |r| !r.dig("request_metadata", id_attribute_key).present? }
+
+        (resources_by_id, results_by_id) = [resources.group_by { |resource| resource.send(id_attribute_key) },
+          results.group_by { |result| result.dig("request_metadata", id_attribute_key) }]
+
+        if resources_by_id.values.any? { |v| v.length > 1 }
+          raise "Duplicate resources found for key '#{id_attribute_key}'"
+        end
+
+        # Joining on the resources which are uniq here
+        [resources_by_id.transform_values(&:first), results_by_id]
       end
     end
 

--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -282,11 +282,11 @@ module Apple
     end
 
     def audio_asset_vendor_id
-      apple_json&.dig("attributes", "appleHostedAudioAssetVendorId")
+      apple_attributes["appleHostedAudioAssetVendorId"]
     end
 
     def audio_hosted_audio_asset_container_id
-      apple_json&.dig("attributes", "appleHostedAudioAssetContainerId")
+      apple_attributes["appleHostedAudioAssetContainerId"]
     end
 
     def audio_asset_state

--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -40,7 +40,7 @@ module Apple
     end
 
     def self.get_episodes(api, episodes)
-      return if episodes.empty?
+      return [] if episodes.empty?
 
       api.bridge_remote_and_retry!("getEpisodes", episodes.map(&:get_episode_bridge_params))
     end

--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -278,7 +278,7 @@ module Apple
     def apple_upload_complete?
       pdfs = feeder_episode.apple_podcast_delivery_files
 
-      pdfs.all?(&:present?) && pdfs.to_a.flatten.all?(&:apple_complete?)
+      pdfs.present? && pdfs.to_a.flatten.all?(&:apple_complete?)
     end
 
     def audio_asset_vendor_id

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -57,6 +57,7 @@ module Apple
 
     def self.upsert_podcast_container(episode, row)
       external_id = row.dig("api_response", "val", "data", "id")
+      raise "Missing external_id in response" if external_id.blank?
 
       (pc, action) =
         if (pc = where(apple_episode_id: episode.apple_id,

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -36,7 +36,9 @@ module Apple
     def self.poll_podcast_container_state(api, episodes)
       results = get_podcast_containers_via_episodes(api, episodes)
 
-      join_on_apple_episode_id(episodes, results).each do |(ep, row)|
+      join_on_apple_episode_id(episodes, results, left_join: true).each do |(ep, row)|
+        next if row.nil?
+
         upsert_podcast_container(ep, row)
       end
     end

--- a/app/models/apple/podcast_delivery.rb
+++ b/app/models/apple/podcast_delivery.rb
@@ -98,6 +98,7 @@ module Apple
     def self.upsert_podcast_delivery(podcast_container, row)
       external_id = row.dig("api_response", "val", "data", "id")
       delivery_status = row.dig("api_response", "val", "data", "attributes", "status")
+      raise "Missing external_id" if external_id.blank?
 
       (pd, action) =
         if (delivery = where(episode_id: podcast_container.episode.id,

--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -77,7 +77,6 @@ module Apple
 
       bridge_params = pdfs.map { |pdf| mark_uploaded_delivery_file_bridge_params(api, pdf) }
 
-      # return results alongside potential errors
       (episode_bridge_results, errs) = api.bridge_remote_and_retry("updateDeliveryFiles", bridge_params)
 
       episode_bridge_results.map do |row|
@@ -101,16 +100,23 @@ module Apple
       end
 
       podcast_deliveries = podcast_deliveries.flatten
+
       # filter for only the podcast deliveries that have missing podcast delivery files
+      # TODO: replace assets on an episode
       podcast_deliveries = podcast_deliveries.select { |pd| pd.podcast_delivery_files.empty? }
 
-      result =
-        api.bridge_remote_and_retry!("createPodcastDeliveryFiles",
+      (result, errs) =
+        api.bridge_remote_and_retry("createPodcastDeliveryFiles",
           podcast_deliveries.map { |pd| create_delivery_file_bridge_params(api, pd) })
 
-      join_on(PODCAST_DELIVERY_ID_ATTR, podcast_deliveries, result).each do |(podcast_delivery, row)|
+      # Creating one podcast delivery file per podcast delivery
+      res = join_on(PODCAST_DELIVERY_ID_ATTR, podcast_deliveries, result).each do |(podcast_delivery, row)|
         upsert_podcast_delivery_file(podcast_delivery, row)
       end
+
+      api.raise_bridge_api_error(errs) if errs.present?
+
+      res
     end
 
     def self.poll_podcast_delivery_files_state(api, episodes)
@@ -123,15 +129,19 @@ module Apple
 
       results = get_podcast_delivery_files_via_deliveries(api, podcast_deliveries)
 
-      join_on(PODCAST_DELIVERY_ID_ATTR, podcast_deliveries, results).map do |(podcast_delivery, delivery_file_row)|
-        upsert_podcast_delivery_file(podcast_delivery, delivery_file_row)
+      join_many_on(PODCAST_DELIVERY_ID_ATTR, podcast_deliveries, results, left_join: true).map do |(podcast_delivery, delivery_file_rows)|
+        next if delivery_file_rows.nil?
+
+        delivery_file_rows.map do |delivery_file_row|
+          upsert_podcast_delivery_file(podcast_delivery, delivery_file_row)
+        end
       end
     end
 
     def self.get_podcast_delivery_files(api, pdfs)
       bridge_params = pdfs.map do |pdf|
         api_url = api.join_url("podcastDeliveryFiles/#{pdf.apple_id}").to_s
-        get_delivery_file_bridge_params(pdf.apple_episode_id, pdf.podcast_delivery_id, api_url)
+        get_delivery_file_bridge_params(pdf.apple_episode_id, pdf.podcast_delivery_id, pdf.apple_id, api_url)
       end
       api.bridge_remote_and_retry!("getPodcastDeliveryFiles", bridge_params)
     end
@@ -143,42 +153,46 @@ module Apple
 
       # Rather than mangling and persisting the enumerated view of the delivery files from the podcast delivery
       # Instead, re-fetch the podcast delivery file from the non-list podcast delivery file resource
-      formatted_bridge_params = join_on_apple_episode_id(podcast_deliveries, delivery_files_response).map do |(pd, row)|
-        # get the urls to fetch delivery files belonging to this podcast delivery (pd)
-        get_urls_for_delivery_podcast_delivery_files(api, row).map do |url|
-          get_delivery_file_bridge_params(pd.apple_episode_id, pd.id, url)
+      formatted_bridge_params =
+        join_on(PODCAST_DELIVERY_ID_ATTR, podcast_deliveries, delivery_files_response)
+          .map do |(podcast_delivery, row)|
+          podcast_delivery_files_ids =
+            row["api_response"]["val"]["data"].map do |podcast_delivery_file_data|
+              podcast_delivery_file_data["id"]
+            end
+
+          podcast_delivery_files_ids.map do |podcast_delivery_file_id|
+            url = api.join_url("podcastDeliveryFiles/#{podcast_delivery_file_id}").to_s
+            get_delivery_file_bridge_params(podcast_delivery.apple_episode_id, podcast_delivery.id, podcast_delivery_file_id, url)
+          end
         end
-      end
+          .flatten
 
-      formatted_bridge_params = formatted_bridge_params.flatten
-
-      api.bridge_remote_and_retry!("getPodcastDeliveryFiles",
-        formatted_bridge_params)
-    end
-
-    def self.get_urls_for_delivery_podcast_delivery_files(api, delivery_podcast_delivery_files_json)
-      delivery_podcast_delivery_files_json["api_response"]["val"]["data"].map do |podcast_delivery_file_data|
-        api.join_url("podcastDeliveryFiles/#{podcast_delivery_file_data["id"]}").to_s
-      end
+      api.bridge_remote_and_retry!("getPodcastDeliveryFiles", formatted_bridge_params)
     end
 
     # Map across the podcast deliveries and get the bridge params for each
     # delivery file via the podcast delivery api endpoint.
     def self.get_delivery_podcast_delivery_files_bridge_params(podcast_deliveries)
+      # Build up the bridge params for a single podcast delivery
       podcast_deliveries.map do |delivery|
-        get_delivery_file_bridge_params(delivery.apple_episode_id,
-          delivery.id,
-          delivery.podcast_delivery_files_url)
+        {
+          request_metadata: {
+            apple_episode_id: delivery.apple_episode_id,
+            podcast_delivery_id: delivery.id
+          },
+          api_url: delivery.podcast_delivery_files_url,
+          api_parameters: {}
+        }
       end
     end
 
-    # Build up the bridge params for a single podcast delivery file
-    # The api_url is agnostic as to which endpoint to hit, so we can use the same method
-    def self.get_delivery_file_bridge_params(apple_episode_id, podcast_delivery_id, api_url)
+    def self.get_delivery_file_bridge_params(apple_episode_id, podcast_delivery_id, apple_podcast_delivery_file_id, api_url)
       {
         request_metadata: {
           apple_episode_id: apple_episode_id,
-          podcast_delivery_id: podcast_delivery_id
+          podcast_delivery_id: podcast_delivery_id,
+          apple_podcast_delivery_file_id: apple_podcast_delivery_file_id
         },
         api_url: api_url,
         api_parameters: {}

--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -233,6 +233,7 @@ module Apple
     def self.upsert_podcast_delivery_file(podcast_delivery, row)
       external_id = row.dig("api_response", "val", "data", "id")
       podcast_delivery_id = row.dig("request_metadata", PODCAST_DELIVERY_ID_ATTR)
+      raise "Missing request metadata" unless external_id && podcast_delivery_id
 
       (pdf, action) =
         if (delivery_file = where(episode_id: podcast_delivery.episode.id,

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -29,7 +29,7 @@ module Apple
     end
 
     def episodes_to_sync
-      @episodes_to_sync ||= show.episodes
+      show.episodes
     end
 
     def poll!

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -94,7 +94,7 @@ module Apple
     end
 
     def wait_for_asset_state
-      eps = episodes_to_sync.filter { |e| e.podcast_delivery_files.any?(&:uploaded?) }
+      eps = episodes_to_sync.filter { |e| e.podcast_delivery_files.any?(&:api_marked_as_uploaded?) }
       Apple::Episode.wait_for_asset_state(api, eps)
     end
 

--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -38,6 +38,7 @@ module Apple
     def reload
       @feeder_episodes = nil
       @apple_episode_json = nil
+      @episodes = nil
     end
 
     def podcast
@@ -136,15 +137,17 @@ module Apple
     def episodes
       raise "Missing apple show id" unless apple_id.present?
 
-      eps = feeder_episodes.map do |ep|
-        Apple::Episode.new(show: self, feeder_episode: ep, api: api)
-      end
+      @episodes ||= begin
+        eps = feeder_episodes.map do |ep|
+          Apple::Episode.new(show: self, feeder_episode: ep, api: api)
+        end
 
-      results_by_guid = apple_episode_json.map { |e| [e["api_response"]["val"]["data"]["attributes"]["guid"], e] }.to_h
+        results_by_guid = apple_episode_json.map { |e| [e["api_response"]["val"]["data"]["attributes"]["guid"], e] }.to_h
 
-      eps.map do |ep|
-        ep.api_response = results_by_guid[ep.guid]
-        ep
+        eps.map do |ep|
+          ep.api_response = results_by_guid[ep.guid]
+          ep
+        end
       end
     end
 

--- a/app/models/apple/upload_operation.rb
+++ b/app/models/apple/upload_operation.rb
@@ -10,7 +10,10 @@ module Apple
     end
 
     def self.execute_upload_operations(api, episodes)
-      delivery_files = Apple::PodcastDeliveryFile.where(episode_id: episodes.map(&:feeder_id), uploaded: false)
+      delivery_files = Apple::PodcastDeliveryFile.where(
+        episode_id: episodes.map(&:feeder_id),
+        upload_operations_complete: false
+      )
 
       operation_bridge_params =
         delivery_files.map do |df|
@@ -18,6 +21,8 @@ module Apple
         end.flatten
 
       res = do_upload(api, operation_bridge_params)
+
+      Apple::PodcastDeliveryFile.where(id: delivery_files.map(&:id)).update_all(upload_operations_complete: true)
 
       res.flatten
     end

--- a/db/migrate/20230303221518_delivery_files_have_uploaded_state.rb
+++ b/db/migrate/20230303221518_delivery_files_have_uploaded_state.rb
@@ -1,0 +1,13 @@
+class DeliveryFilesHaveUploadedState < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :apple_podcast_delivery_files, :uploaded, :api_marked_as_uploaded
+    add_column :apple_podcast_delivery_files, :upload_operations_complete, :boolean, default: false
+
+    Apple::PodcastDeliveryFile.where(api_marked_as_uploaded: true).update_all(upload_operations_complete: true)
+  end
+
+  def down
+    rename_column :apple_podcast_delivery_files, :api_marked_as_uploaded, :uploaded
+    remove_column :apple_podcast_delivery_files, :upload_operations_complete
+  end
+end

--- a/db/migrate/20230303230552_remove_constraints_on_delivery.rb
+++ b/db/migrate/20230303230552_remove_constraints_on_delivery.rb
@@ -1,0 +1,12 @@
+class RemoveConstraintsOnDelivery < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :apple_podcast_deliveries, name: 'index_apple_podcast_deliveries_on_episode_id', unique: true
+    add_index :apple_podcast_deliveries, :episode_id
+
+    remove_index :apple_podcast_deliveries, name: 'index_apple_podcast_deliveries_on_podcast_container_id', unique: true
+    add_index :apple_podcast_deliveries, :podcast_container_id
+
+    remove_index :apple_podcast_delivery_files, name: 'index_apple_podcast_delivery_files_on_podcast_delivery_id', unique: true
+    add_index :apple_podcast_delivery_files, :podcast_delivery_id
+  end
+end

--- a/db/migrate/20230303230552_remove_constraints_on_delivery.rb
+++ b/db/migrate/20230303230552_remove_constraints_on_delivery.rb
@@ -1,12 +1,12 @@
 class RemoveConstraintsOnDelivery < ActiveRecord::Migration[7.0]
   def change
-    remove_index :apple_podcast_deliveries, name: 'index_apple_podcast_deliveries_on_episode_id', unique: true
+    remove_index :apple_podcast_deliveries, name: "index_apple_podcast_deliveries_on_episode_id", unique: true
     add_index :apple_podcast_deliveries, :episode_id
 
-    remove_index :apple_podcast_deliveries, name: 'index_apple_podcast_deliveries_on_podcast_container_id', unique: true
+    remove_index :apple_podcast_deliveries, name: "index_apple_podcast_deliveries_on_podcast_container_id", unique: true
     add_index :apple_podcast_deliveries, :podcast_container_id
 
-    remove_index :apple_podcast_delivery_files, name: 'index_apple_podcast_delivery_files_on_podcast_delivery_id', unique: true
+    remove_index :apple_podcast_delivery_files, name: "index_apple_podcast_delivery_files_on_podcast_delivery_id", unique: true
     add_index :apple_podcast_delivery_files, :podcast_delivery_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_03_221518) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_03_230552) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -51,9 +51,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_221518) do
     t.string "api_response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["episode_id"], name: "index_apple_podcast_deliveries_on_episode_id", unique: true
+    t.index ["episode_id"], name: "index_apple_podcast_deliveries_on_episode_id"
     t.index ["external_id"], name: "index_apple_podcast_deliveries_on_external_id", unique: true
-    t.index ["podcast_container_id"], name: "index_apple_podcast_deliveries_on_podcast_container_id", unique: true
+    t.index ["podcast_container_id"], name: "index_apple_podcast_deliveries_on_podcast_container_id"
   end
 
   create_table "apple_podcast_delivery_files", force: :cascade do |t|
@@ -66,7 +66,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_221518) do
     t.boolean "api_marked_as_uploaded", default: false
     t.boolean "upload_operations_complete", default: false
     t.index ["external_id"], name: "index_apple_podcast_delivery_files_on_external_id", unique: true
-    t.index ["podcast_delivery_id"], name: "index_apple_podcast_delivery_files_on_podcast_delivery_id", unique: true
+    t.index ["podcast_delivery_id"], name: "index_apple_podcast_delivery_files_on_podcast_delivery_id"
   end
 
   create_table "episode_images", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_02_09_165512) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_03_221518) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -63,7 +63,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_02_09_165512) do
     t.string "api_response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "uploaded", default: false
+    t.boolean "api_marked_as_uploaded", default: false
+    t.boolean "upload_operations_complete", default: false
     t.index ["external_id"], name: "index_apple_podcast_delivery_files_on_external_id", unique: true
     t.index ["podcast_delivery_id"], name: "index_apple_podcast_delivery_files_on_podcast_delivery_id", unique: true
   end

--- a/test/factories/apple_podcast_delivery_file_api_response_factory.rb
+++ b/test/factories/apple_podcast_delivery_file_api_response_factory.rb
@@ -1,7 +1,5 @@
 FactoryBot.define do
   factory :podcast_delivery_file_api_response, class: OpenStruct do
-    api_response { nil }
-
     transient do
       podcast_delivery_id { "podcast-delivery-id" }
       podcast_delivery_file_id { "podcast-delivery-file-id" }
@@ -18,7 +16,7 @@ FactoryBot.define do
     skip_create
 
     after(:build) do |response_container, evaluator|
-      response_container["api_response"] = {"request_metadata" => {"apple_episode_id" => evaluator.apple_episode_id, "podcast_delivery_id" => evaluator.podcast_delivery_id},
+      response_container["json"] = {"request_metadata" => {"apple_episode_id" => evaluator.apple_episode_id, "podcast_delivery_id" => evaluator.podcast_delivery_id},
        "api_url" => "https://api.podcastsconnect.apple.com/v1/podcastDeliveryFiles/#{evaluator.podcast_delivery_file_id}",
        "api_parameters" => {},
        "api_response" =>
@@ -43,6 +41,7 @@ FactoryBot.define do
               "assetDeliveryState" => {"errors" => evaluator.asset_delivery_errors,
                                        "warnings" => [],
                                        "state" => evaluator.asset_delivery_state}}}}}}
+      response_container
     end
 
     initialize_with { attributes }

--- a/test/factories/apple_podcast_delivery_file_api_response_factory.rb
+++ b/test/factories/apple_podcast_delivery_file_api_response_factory.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
     skip_create
 
     after(:build) do |response_container, evaluator|
-      response_container["json"] = {"request_metadata" => {"apple_episode_id" => evaluator.apple_episode_id, "podcast_delivery_id" => evaluator.podcast_delivery_id},
+      response_container["api_response"] = {"request_metadata" => {"apple_episode_id" => evaluator.apple_episode_id, "podcast_delivery_id" => evaluator.podcast_delivery_id},
        "api_url" => "https://api.podcastsconnect.apple.com/v1/podcastDeliveryFiles/#{evaluator.podcast_delivery_file_id}",
        "api_parameters" => {},
        "api_response" =>

--- a/test/models/apple/api_response_test.rb
+++ b/test/models/apple/api_response_test.rb
@@ -52,29 +52,78 @@ describe Apple::ApiResponse do
     end
   end
 
-  describe ".join_on_apple_episode_id" do
-    it "uses the request metadata to join a set of resources responging to `apple_episode_id`" do
-      row_results = [{request_metadata: {apple_episode_id: "1"}, api_response: {foo: "111"}},
-        {request_metadata: {apple_episode_id: "2"}, api_response: {foo: "222"}},
-        {request_metadata: {apple_episode_id: "3"}, api_response: {foo: "333"}}]
-      row_results = row_results.map(&:with_indifferent_access)
+  describe "joins" do
+    let(:row_results) do
+      [
+        {"request_metadata" => {"apple_episode_id" => "1", "bar" => "111"}, "api_response" => {"foo" => "111"}},
+        {"request_metadata" => {"apple_episode_id" => "2", "bar" => "222"}, "api_response" => {"foo" => "222"}},
+        {"request_metadata" => {"apple_episode_id" => "3", "bar" => "333"}, "api_response" => {"foo" => "333"}}
+      ]
+    end
 
-      resources = [
+    let(:resources) do
+      [
         OpenStruct.new(apple_episode_id: "1", bar: "111"),
         OpenStruct.new(apple_episode_id: "2", bar: "222"),
         OpenStruct.new(apple_episode_id: "3", bar: "333")
       ]
+    end
 
-      zipped = TestResponse.join_on_apple_episode_id(resources, row_results)
+    describe "many to one joins" do
+      it "joins on apple_episode_id" do
+        zipped = TestResponse.join_many_on("apple_episode_id", resources, row_results)
+        assert zipped.length == 3
+        # Still have a pair of resource and rows
+        assert(zipped.all? { |r| r.length == 2 })
 
-      assert zipped.length == 3
-      assert(zipped.all? { |r| r.length == 2 })
+        # But the returned rows are now an array
+        assert_equal zipped[0][1].length, 1
+      end
 
-      zipped.each_with_index do |(resource, row), index|
-        assert row[:request_metadata][:apple_episode_id] == resource.apple_episode_id
+      it "can join a single key against multiple results" do
+        row_results << {"request_metadata" => {"apple_episode_id" => "1", "bar" => "777"}, "api_response" => {"foo" => "999"}}
+        zipped = TestResponse.join_many_on("apple_episode_id", resources, row_results)
+        assert zipped.length == 3
 
-        assert row[:request_metadata][:apple_episode_id] == row_results[index][:request_metadata][:apple_episode_id]
-        assert resource.apple_episode_id == resources[index].apple_episode_id
+        assert_equal zipped[0][1].length, 2
+        # The resource not an array
+        assert_equal zipped[0][0].length, 1
+
+        # Can return more than one api result per resource
+        assert_equal zipped[0][1].map { |r| r["api_response"]["foo"] }, ["111", "999"]
+        assert_equal zipped[0][1].map { |r| r["request_metadata"]["bar"] }, ["111", "777"]
+      end
+    end
+
+    describe "one to one joins" do
+      it "throws when the join results in more than one result" do
+        row_results << {"request_metadata" => {"apple_episode_id" => "3", "bar" => "333"}, "api_response" => {"foo" => "444"}}
+        assert_raises(RuntimeError, "Duplicate results found for 'bar'") { TestResponse.join_on("bar", resources, row_results) }
+      end
+
+      it "throws when the join results in no results" do
+        assert_raises(RuntimeError, "Resource missing join attribute") { TestResponse.join_on("baz", resources, row_results) }
+      end
+
+      it "throws when the join results in partial results" do
+        row_results << {"request_metadata" => {"apple_episode_id" => "4", "bar" => "444"}, "api_response" => {"foo" => "444"}}
+        assert_raises(RuntimeError, "Join key mismatch") { TestResponse.join_on("bar", resources, row_results) }
+      end
+    end
+
+    describe ".join_on_apple_episode_id" do
+      it "uses the request metadata to join a set of resources responging to `apple_episode_id`" do
+        zipped = TestResponse.join_on_apple_episode_id(resources, row_results)
+
+        assert zipped.length == 3
+        assert(zipped.all? { |r| r.length == 2 })
+
+        zipped.each_with_index do |(resource, row), index|
+          assert row["request_metadata"]["apple_episode_id"] == resource.apple_episode_id
+
+          assert row["request_metadata"]["apple_episode_id"] == row_results[index]["request_metadata"]["apple_episode_id"]
+          assert resource.apple_episode_id == resources[index].apple_episode_id
+        end
       end
     end
   end

--- a/test/models/apple/api_response_test.rb
+++ b/test/models/apple/api_response_test.rb
@@ -87,7 +87,8 @@ describe Apple::ApiResponse do
 
         assert_equal zipped[0][1].length, 2
         # The resource not an array
-        assert_equal zipped[0][0].length, 1
+        assert_equal zipped[0][0].apple_episode_id, "1"
+        assert_equal zipped[0][0].bar, "111"
 
         # Can return more than one api result per resource
         assert_equal zipped[0][1].map { |r| r["api_response"]["foo"] }, ["111", "999"]

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -60,7 +60,7 @@ describe Apple::Episode do
     it "instantiates with a nil api_response" do
       ep = build(:apple_episode, show: apple_show, feeder_episode: episode, api_response: nil)
       assert_nil ep.apple_id
-      assert_nil ep.audio_asset_vendor_id
+      assert_raises(RuntimeError, "incomplete api response") { ep.audio_asset_vendor_id }
       # It does not exists yet, so it is not drafting
       assert_equal false, ep.drafting?
       # Comes from the feeder model
@@ -156,6 +156,8 @@ describe Apple::Episode do
 
     it "should be false if the episode has a non complete apple hosted audio asset state" do
       apple_episode.api_response["api_response"]["val"]["data"]["attributes"]["appleHostedAudioAssetState"] = Apple::Episode::AUDIO_ASSET_FAILURE
+
+      delivery_file.update(**build(:podcast_delivery_file_api_response))
       apple_episode.podcast_delivery_files.reset
 
       assert_equal false, apple_episode.waiting_for_asset_state?

--- a/test/models/apple/podcast_delivery_file_test.rb
+++ b/test/models/apple/podcast_delivery_file_test.rb
@@ -23,7 +23,7 @@ class ApplePodcastDeliveryFileTest < ActiveSupport::TestCase
     let(:asset_delivery_state) { "COMPLETE" }
 
     let(:pdf_resp_container) { build(:podcast_delivery_file_api_response, asset_delivery_state: asset_delivery_state, asset_processing_state: asset_processing_state) }
-    let(:pdf) { Apple::PodcastDeliveryFile.new(api_response: pdf_resp_container["json"]) }
+    let(:pdf) { Apple::PodcastDeliveryFile.new(**pdf_resp_container) }
 
     describe "#delivery_awaiting_upload?" do
       it "should be false if the status is delivery_status is false" do
@@ -37,12 +37,12 @@ class ApplePodcastDeliveryFileTest < ActiveSupport::TestCase
       end
 
       it "will not be complete if either of the two state statues are not complete" do
-        json = build(:podcast_delivery_file_api_response, asset_delivery_state: asset_delivery_state, asset_processing_state: "VALIDATION_FAILED")["json"]
-        pdf = Apple::PodcastDeliveryFile.new(api_response: json)
+        pdf_resp_container = build(:podcast_delivery_file_api_response, asset_delivery_state: asset_delivery_state, asset_processing_state: "VALIDATION_FAILED")
+        pdf = Apple::PodcastDeliveryFile.new(**pdf_resp_container)
         assert_equal false, pdf.apple_complete?
 
-        json = build(:podcast_delivery_file_api_response, asset_delivery_state: "FAILED", asset_processing_state: asset_processing_state)["json"]
-        pdf = Apple::PodcastDeliveryFile.new(api_response: json)
+        pdf_resp_container = build(:podcast_delivery_file_api_response, asset_delivery_state: "FAILED", asset_processing_state: asset_processing_state)
+        pdf = Apple::PodcastDeliveryFile.new(**pdf_resp_container)
         assert_equal false, pdf.apple_complete?
       end
     end

--- a/test/models/apple/podcast_delivery_file_test.rb
+++ b/test/models/apple/podcast_delivery_file_test.rb
@@ -6,33 +6,45 @@ class ApplePodcastDeliveryFileTest < ActiveSupport::TestCase
       assert_equal({
         request_metadata: {
           apple_episode_id: "some-apple-id",
-          podcast_delivery_id: "podcast-delivery-id"
+          podcast_delivery_id: "podcast-delivery-id",
+          apple_podcast_delivery_file_id: "podcast-delivery-file-id"
         },
         api_url: "http://apple", api_parameters: {}
       },
         Apple::PodcastDeliveryFile.get_delivery_file_bridge_params("some-apple-id",
           "podcast-delivery-id",
+          "podcast-delivery-file-id",
           "http://apple"))
     end
   end
 
-  describe ".get_urls_for_delivery_podcast_delivery_files" do
-    let(:podcast_delivery_json) do
-      {"request_metadata" => {"apple_episode_id" => "apple-episode-id", "podcast_container_id" => 1},
-       "api_url" => "https://api.podcastsconnect.apple.com/v1/podcastDeliveries/fd178589-6c75-4439-931b-813ac5ae4ff0/podcastDeliveryFiles",
-       "api_parameters" => {},
-       "api_response" => {"ok" => true,
-                          "err" => false,
-                          "val" =>
-                        {"data" => [{"type" => "podcastDeliveryFiles",
-                                     "id" => "1111111111111111111111111"}]}}}
-    end
-    let(:apple_api) { build(:apple_api) }
+  describe "delivery and processing state methods" do
+    let(:asset_processing_state) { "COMPLETED" }
+    let(:asset_delivery_state) { "COMPLETE" }
 
-    it "should format a new set of podcast delivery urls" do
-      assert_equal ["https://api.podcastsconnect.apple.com/v1/podcastDeliveryFiles/1111111111111111111111111"],
-        Apple::PodcastDeliveryFile.get_urls_for_delivery_podcast_delivery_files(apple_api,
-          podcast_delivery_json)
+    let(:pdf_resp_container) { build(:podcast_delivery_file_api_response, asset_delivery_state: asset_delivery_state, asset_processing_state: asset_processing_state) }
+    let(:pdf) { Apple::PodcastDeliveryFile.new(api_response: pdf_resp_container["json"]) }
+
+    describe "#delivery_awaiting_upload?" do
+      it "should be false if the status is delivery_status is false" do
+        assert_equal false, pdf.delivery_awaiting_upload?
+      end
+    end
+
+    describe "#apple_complete?" do
+      it "should be true if the the two statuses is complete" do
+        assert_equal true, pdf.apple_complete?
+      end
+
+      it "will not be complete if either of the two state statues are not complete" do
+        json = build(:podcast_delivery_file_api_response, asset_delivery_state: asset_delivery_state, asset_processing_state: "VALIDATION_FAILED")["json"]
+        pdf = Apple::PodcastDeliveryFile.new(api_response: json)
+        assert_equal false, pdf.apple_complete?
+
+        json = build(:podcast_delivery_file_api_response, asset_delivery_state: "FAILED", asset_processing_state: asset_processing_state)["json"]
+        pdf = Apple::PodcastDeliveryFile.new(api_response: json)
+        assert_equal false, pdf.apple_complete?
+      end
     end
   end
 end

--- a/test/models/apple/podcast_delivery_test.rb
+++ b/test/models/apple/podcast_delivery_test.rb
@@ -10,7 +10,8 @@ class Apple::PodcastDeliveryTest < ActiveSupport::TestCase
     let(:apple_show) { Apple::Show.new(feed) }
     let(:apple_episode) { build(:apple_episode, show: apple_show, feeder_episode: episode) }
 
-    let(:podcast_delivery_json) { {val: {data: {id: "123"}}} }
+    let(:podcast_delivery_json) { {data: {id: "123"}} }
+    let(:podcast_delivery_json_api_response) { {api_response: {val: podcast_delivery_json}}.with_indifferent_access }
 
     let(:podcast_container) do
       pc = Apple::PodcastContainer.new
@@ -25,29 +26,25 @@ class Apple::PodcastDeliveryTest < ActiveSupport::TestCase
       assert_equal SyncLog.count, 0
       assert_equal Apple::PodcastDelivery.count, 0
 
-      Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container,
-        api_response: podcast_delivery_json)
+      Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container, podcast_delivery_json_api_response)
 
       assert_equal SyncLog.count, 1
       assert_equal Apple::PodcastDelivery.count, 1
 
       # Now upsert existing record
-      Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container,
-        api_response: podcast_delivery_json)
+      Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container, podcast_delivery_json_api_response)
 
       assert_equal SyncLog.count, 2
       assert_equal Apple::PodcastDelivery.count, 1
     end
 
     it "should update timestamps" do
-      pd = Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container,
-        api_response: podcast_delivery_json)
+      pd = Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container, podcast_delivery_json_api_response)
 
       # Now upsert existing record and overwrite timestamps
       pd.update(updated_at: Time.now - 1.year)
       # modify the json so that the podcast_delivery_changes
-      pd2 = Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container,
-        api_response: podcast_delivery_json)
+      pd2 = Apple::PodcastDelivery.upsert_podcast_delivery(podcast_container, podcast_delivery_json_api_response)
       assert pd2.updated_at > pd.updated_at
     end
   end
@@ -70,9 +67,7 @@ class Apple::PodcastDeliveryTest < ActiveSupport::TestCase
         },
         api_url: "http://apple", api_parameters: {}
       },
-        Apple::PodcastDelivery.get_podcast_containers_deliveries_bridge_param("some-apple-id",
-          "podcast-container-id",
-          "http://apple"))
+        Apple::PodcastDelivery.get_podcast_containers_deliveries_bridge_param(OpenStruct.new(apple_episode_id: "some-apple-id", id: "podcast-container-id", podcast_deliveries_url: "http://apple")))
     end
   end
 

--- a/test/models/apple/show_test.rb
+++ b/test/models/apple/show_test.rb
@@ -19,9 +19,11 @@ describe Apple::Show do
     it "flushes memoized attrs" do
       apple_show.instance_variable_set(:@apple_episode_json, "foo")
       apple_show.instance_variable_set(:@feeder_episodes, "foo")
+      apple_show.instance_variable_set(:@episodes, "foo")
       apple_show.reload
       assert_nil apple_show.instance_variable_get(:@apple_episode_json)
       assert_nil apple_show.instance_variable_get(:@feeder_episodes)
+      assert_nil apple_show.instance_variable_get(:@episodes)
     end
 
     it "doesn't raise an error if the attr isn't memoized" do
@@ -31,17 +33,21 @@ describe Apple::Show do
     it "doesn't raise an error if the attr is nil" do
       apple_show.instance_variable_set(:@apple_episode_json, nil)
       apple_show.instance_variable_set(:@feeder_episodes, nil)
+      apple_show.instance_variable_set(:@episodes, nil)
       apple_show.reload
       assert_nil apple_show.instance_variable_get(:@feeder_episodes)
       assert_nil apple_show.instance_variable_get(:@apple_episode_json)
+      assert_nil apple_show.instance_variable_get(:@episodes)
     end
 
     it "doesn't raise an error if the attr is false" do
       apple_show.instance_variable_set(:@apple_episode_json, false)
       apple_show.instance_variable_set(:@feeder_episodes, false)
+      apple_show.instance_variable_set(:@episodes, false)
       apple_show.reload
       assert_nil apple_show.instance_variable_get(:@feeder_episodes)
       assert_nil apple_show.instance_variable_get(:@apple_episode_json)
+      assert_nil apple_show.instance_variable_get(:@episodes)
     end
   end
 
@@ -58,11 +64,11 @@ describe Apple::Show do
       end
     end
 
-    it "returns new instances of Apple::Episode" do
+    it "returns memoized instances of Apple::Episode" do
       Apple::Episode.stub(:get_episodes_via_show, []) do
         obj_id = apple_show.episodes.first.object_id
         # These are not the same objects
-        refute_equal apple_show.episodes.first.object_id, obj_id
+        assert_equal apple_show.episodes.first.object_id, obj_id
       end
     end
 


### PR DESCRIPTION
Fixes a couple of problems:

- Apple validates attributes after they are persisted.  The RSS scraper apparently does not validate any data before persisting it in the Apple episode model. Then if we're PATCHing a single, unrelated, field. We get back errors on the unvalidated.  So for example when updating the audio container reference on the episode, we can get back validation errors on an associated email address
- In debugging the prior issue,  I discovered that the my assumption that delivery and delivery files associated with the PodcastsConnect UI are not exposed through the UI.  And in my initial testing, I was not getting any back for UI uploaded subscriber audio.  In testing the mix of API and UI uploads, it turns out that the UI _does_ create delivery and delivery files that are exposed via the API.

To fix the above two issues, this PR:

- Makes the error handling reentrant across container/delivery/delivery-file update and create actions (something we needed anyways). So this sets up checks on the results / errors and makes sure to update local state for those requests that succeeded.
- Handles the `has_many` relations on `podcast_container->deliveries` and `delivery->delivery_files` by extending the system that joins local resources (state) to some set of remote api responses. 
   - Adds a new `join_on_many` helper in the api_response module.
   - Checks for join key overlap in the local resources and the request responses
   - Checks for join key equality in the case of the 'ordinary' one to one join
   - adds a `left_join` option for those resources that do not expect a row to be returned from set of (chained) remote api calls