### PR TITLE
Setup spring binstubs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,7 +404,7 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     smart_properties (1.17.0)
-    spring (2.1.1)
+    spring (4.1.1)
     sprockets (4.1.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/spring
+++ b/bin/spring
@@ -1,18 +1,14 @@
 #!/usr/bin/env ruby
 
-# This file loads spring without using Bundler, in order to be fast
-# It gets overwritten when you run the `spring binstub` command
+# This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
 
-unless defined?(Spring)
-  require "rubygems"
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
   require "bundler"
 
-  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
-    ENV["GEM_PATH"] = ([Bundler.bundle_path.to_s] + Gem.path).join(File::PATH_SEPARATOR)
-    ENV["GEM_HOME"] = ""
-    Gem.paths = ENV
-
-    gem "spring", match[1]
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem "spring", spring.version
     require "spring/binstub"
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,12 @@ module Feeder
     config.action_controller.forgery_protection_origin_check = false
 
     config.active_job.queue_adapter = :shoryuken
-    config.active_job.queue_name_prefix = ENV["ANNOUNCE_RESOURCE_PREFIX"] || ENV["RAILS_ENV"]
+    config.active_job.queue_name_prefix =
+      if ENV["ANNOUNCE_RESOURCE_PREFIX"].present?
+        ENV["ANNOUNCE_RESOURCE_PREFIX"]
+      else
+        ENV["RAILS_ENV"]
+      end
     config.active_job.queue_name_delimiter = "_"
 
     config.cache_store = :memory_store, {size: 128.megabytes}

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -8,8 +8,9 @@ require "active_support/core_ext/integer/time"
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Turn false under Spring and add config.action_view.cache_template_loading = true
-  config.cache_classes = true
+  # Using spring:
+  config.cache_classes = false
+  config.action_view.cache_template_loading = true
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration


### PR DESCRIPTION
This PR will:
- update spring
- setup binstubs to use spring

Most noticeable when you are running a single test repeatedly, for instance. This will speed up rails boot time.

```bash
# Invoking rails irb repeatedly on `main`
bash-5.1.16$ time : $(echo "1" | ./bin/rails c)                                                                
                                                                                                                       
real    0m5.128s                                                                                                       
user    0m2.220s    
sys     0m1.302s 

```

versus

```bash
# Invoking rails irb repeatedly on `chore/spring-for-binstubs`
bash-5.1.16$ time : $(echo "1" | ./bin/rails c)                                       
DEBUGGER[spring app    | feeder.prx.org | started 10 secs ago | development mode#61061]: Attaching after process 60898 fork to child process 61061
Running via Spring preloader in process 61061                                                                                                                                                                                                 
                                                                                                                       
real    0m0.678s                                                                                                       
user    0m0.218s                                           
sys     0m0.181s    