### PR TITLE
Fix js import used by audio segmenter page controllers

### DIFF
--- a/app/javascript/controllers/audio_breakpoint_controller.js
+++ b/app/javascript/controllers/audio_breakpoint_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
-import convertSecondsToDuration from "../util/convertSecondsToDuration"
-import convertToSeconds from "../util/convertToSeconds"
+import convertSecondsToDuration from "util/convertSecondsToDuration"
+import convertToSeconds from "util/convertToSeconds"
 
 export default class extends Controller {
   static targets = ["label", "startTime", "endTime"]

--- a/app/javascript/controllers/audio_breakpoints_controller.js
+++ b/app/javascript/controllers/audio_breakpoints_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import convertToSeconds from "../util/convertToSeconds"
+import convertToSeconds from "util/convertToSeconds"
 
 export default class extends Controller {
   static targets = ["waveformInspector", "markersInput", "controls", "controlTemplate"]

--- a/app/javascript/controllers/waveform_inspector_controller.js
+++ b/app/javascript/controllers/waveform_inspector_controller.js
@@ -1,10 +1,10 @@
 import { Controller } from "@hotwired/stimulus"
 import Peaks from "peaks.js"
 import _ from "lodash"
-import convertToSeconds from "../util/convertToSeconds"
-import convertSecondsToDuration from "../util/convertSecondsToDuration"
-import PrxPointMarker from "../custom/PrxPointMarker"
-import PrxSegmentMarker from "../custom/PrxSegmentMarker"
+import convertToSeconds from "util/convertToSeconds"
+import convertSecondsToDuration from "util/convertSecondsToDuration"
+import PrxPointMarker from "custom/PrxPointMarker"
+import PrxSegmentMarker from "custom/PrxSegmentMarker"
 
 export default class extends Controller {
   static targets = ["overview", "zoom", "scrollbar", "seekInput"]

--- a/app/javascript/util/convertSecondsToDuration.js
+++ b/app/javascript/util/convertSecondsToDuration.js
@@ -1,4 +1,4 @@
-import convertToSeconds from "./convertToSeconds"
+import convertToSeconds from "util/convertToSeconds"
 
 /**
  * Convert a number into string in duration format ([HH:]MM:SS[.ss]).

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -25,3 +25,5 @@ pin "lodash", to: "https://ga.jspm.io/npm:lodash@4.17.21/lodash.js"
 pin "slim-select", preload: true # @2.4.1
 
 pin_all_from "app/javascript/controllers", under: "controllers"
+pin_all_from "app/javascript/custom", under: "custom"
+pin_all_from "app/javascript/util", under: "util"


### PR DESCRIPTION
This should run locally, but the real test is if the imports continue to 404 on staging.