### PR TITLE
Breakout enclosure / source urls

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -84,6 +84,29 @@ module Apple
       episode_bridge_results
     end
 
+    def self.remove_audio_container_reference(api, show, episodes)
+      return [] if episodes.empty?
+
+      (episode_bridge_results, errs) =
+        api.bridge_remote_and_retry(
+          "updateEpisodes",
+          episodes.map(&:remove_episode_audio_container_bridge_params)
+        )
+
+      insert_sync_logs(episodes, episode_bridge_results)
+
+      join_on_apple_episode_id(episodes, episode_bridge_results).each do |(ep, row)|
+        ep.podcast_container.podcast_delivery_files.each(&:destroy)
+        ep.podcast_container.podcast_deliveries.each(&:destroy)
+      end
+
+      show.reload
+
+      api.raise_bridge_api_error(errs) if errs.present?
+
+      episode_bridge_results
+    end
+
     def self.publish(api, episodes)
       return [] if episodes.empty?
 
@@ -196,6 +219,10 @@ module Apple
 
     def update_episode_audio_container_bridge_params
       {
+        request_metadata: {
+          apple_episode_id: apple_id,
+          guid: guid
+        },
         api_url: api.join_url("episodes/#{apple_id}").to_s,
         api_parameters: update_episode_audio_container_parameters
       }
@@ -210,6 +237,30 @@ module Apple
           attributes: {
             appleHostedAudioAssetContainerId: podcast_container.apple_id,
             appleHostedAudioIsSubscriberOnly: true
+          }
+        }
+      }
+    end
+
+    def remove_episode_audio_container_bridge_params
+      {
+        request_metadata: {
+          apple_episode_id: apple_id,
+          guid: guid
+        },
+        api_url: api.join_url("episodes/#{apple_id}").to_s,
+        api_parameters: remove_episode_audio_container_parameters
+      }
+    end
+
+    def remove_episode_audio_container_parameters
+      {
+        data:
+        {
+          type: "episodes",
+          id: apple_id,
+          attributes: {
+            appleHostedAudioAssetContainerId: nil
           }
         }
       }

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -42,6 +42,8 @@ module Apple
 
       join_on_apple_episode_id(episodes, results, left_join: true).each do |(ep, row)|
         next if row.nil?
+        apple_id = row.dig("api_response", "val", "data", "id")
+        raise "missing apple id!" unless apple_id.present?
 
         upsert_podcast_container(ep, row)
       end

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -21,12 +21,16 @@ module Apple
 
       api.bridge_remote_and_retry!("headFileSizes", containers.map(&:head_file_size_bridge_params))
         .map do |row|
-        content_length = row.dig("api_response", "val", "data", "content-length")
+        content_length = row.dig("api_response", "val", "data", "headers", "content-length")
+        cdn_url = row.dig("api_response", "val", "data", "redirect_chain_end_url")
+        raise "Missing content-length in response" if content_length.blank?
+        raise "Missing cdn_url in response" if cdn_url.blank?
 
         podcast_container_id = row["request_metadata"]["podcast_container_id"]
 
         container = containers_by_id.fetch(podcast_container_id)
         container.source_size = content_length
+        container.source_url = cdn_url
 
         container.save!
         container
@@ -68,7 +72,7 @@ module Apple
           vendor_id: episode.audio_asset_vendor_id).first)
 
           pc.update(api_response: row,
-            source_url: episode.enclosure_url,
+            enclosure_url: episode.enclosure_url,
             source_filename: episode.enclosure_filename,
             updated_at: Time.now.utc)
           [pc, :updated]
@@ -77,7 +81,7 @@ module Apple
             apple_episode_id: episode.apple_id,
             external_id: external_id,
             source_filename: episode.enclosure_filename,
-            source_url: episode.enclosure_url,
+            enclosure_url: episode.enclosure_url,
             vendor_id: episode.audio_asset_vendor_id,
             episode_id: episode.feeder_id)
           [pc, :created]
@@ -186,7 +190,7 @@ module Apple
           apple_episode_id: apple_episode_id,
           podcast_container_id: id
         },
-        api_url: source_url,
+        api_url: source_url || enclosure_url,
         api_parameters: {}
       }
     end

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -6,7 +6,7 @@ module Apple
 
     serialize :api_response, JSON
 
-    has_many :podcast_deliveries
+    has_many :podcast_deliveries, dependent: :destroy
     has_many :podcast_delivery_files, through: :podcast_deliveries
     belongs_to :episode, class_name: "::Episode"
 

--- a/app/models/apple/podcast_delivery.rb
+++ b/app/models/apple/podcast_delivery.rb
@@ -6,7 +6,7 @@ module Apple
 
     serialize :api_response, JSON
 
-    has_many :podcast_delivery_files
+    has_many :podcast_delivery_files, dependent: :destroy
     belongs_to :episode, class_name: "::Episode"
     belongs_to :podcast_container, class_name: "::Apple::PodcastContainer"
 

--- a/app/models/apple/podcast_delivery.rb
+++ b/app/models/apple/podcast_delivery.rb
@@ -4,6 +4,8 @@ module Apple
   class PodcastDelivery < ActiveRecord::Base
     include Apple::ApiResponse
 
+    acts_as_paranoid
+
     serialize :api_response, JSON
 
     has_many :podcast_delivery_files, dependent: :destroy
@@ -113,7 +115,7 @@ module Apple
       raise "Missing external_id" if external_id.blank?
 
       (pd, action) =
-        if (delivery = where(episode_id: podcast_container.episode.id,
+        if (delivery = with_deleted.where(episode_id: podcast_container.episode.id,
           external_id: external_id,
           podcast_container: podcast_container).first)
 

--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -5,6 +5,8 @@ module Apple
     include Apple::ApiResponse
     include Apple::ApiWaiting
 
+    acts_as_paranoid
+
     serialize :api_response, JSON
 
     belongs_to :podcast_delivery
@@ -104,7 +106,7 @@ module Apple
       podcast_deliveries = podcast_deliveries.flatten
 
       # filter for only the podcast deliveries that have missing podcast delivery files
-      # TODO: replace assets on an episode
+      # podcast_delivery_files are soft deleted in rails when they are replaced
       podcast_deliveries = podcast_deliveries.select { |pd| pd.podcast_delivery_files.empty? }
 
       (result, errs) =
@@ -252,7 +254,7 @@ module Apple
       raise "Missing request metadata" unless external_id && podcast_delivery_id
 
       (pdf, action) =
-        if (delivery_file = where(episode_id: podcast_delivery.episode.id,
+        if (delivery_file = with_deleted.where(episode_id: podcast_delivery.episode.id,
           external_id: external_id,
           podcast_delivery_id: podcast_delivery_id).first)
 

--- a/db/migrate/20230303221518_delivery_files_have_uploaded_state.rb
+++ b/db/migrate/20230303221518_delivery_files_have_uploaded_state.rb
@@ -3,7 +3,7 @@ class DeliveryFilesHaveUploadedState < ActiveRecord::Migration[7.0]
     rename_column :apple_podcast_delivery_files, :uploaded, :api_marked_as_uploaded
     add_column :apple_podcast_delivery_files, :upload_operations_complete, :boolean, default: false
 
-    Apple::PodcastDeliveryFile.where(api_marked_as_uploaded: true).update_all(upload_operations_complete: true)
+    Apple::PodcastDeliveryFile.with_deleted.where(api_marked_as_uploaded: true).update_all(upload_operations_complete: true)
   end
 
   def down

--- a/db/migrate/20230323211452_podcast_container_has_router_url.rb
+++ b/db/migrate/20230323211452_podcast_container_has_router_url.rb
@@ -1,0 +1,11 @@
+class PodcastContainerHasRouterUrl < ActiveRecord::Migration[7.0]
+  def change
+    add_column :apple_podcast_containers, :enclosure_url, :text
+
+    reversible do |dir|
+      dir.up do
+        execute("UPDATE apple_podcast_containers SET enclosure_url = source_url;")
+      end
+    end
+  end
+end

--- a/db/migrate/20230324205952_paranoid_deliveries_delivery_files.rb
+++ b/db/migrate/20230324205952_paranoid_deliveries_delivery_files.rb
@@ -1,0 +1,6 @@
+class ParanoidDeliveriesDeliveryFiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :apple_podcast_deliveries, :deleted_at, :timestamp
+    add_column :apple_podcast_delivery_files, :deleted_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_03_230552) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_23_211452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_03_230552) do
     t.string "source_url"
     t.string "source_filename"
     t.bigint "source_size"
+    t.text "enclosure_url"
     t.index ["episode_id"], name: "index_apple_podcast_containers_on_episode_id", unique: true
     t.index ["external_id"], name: "index_apple_podcast_containers_on_external_id", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_23_211452) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_24_205952) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -52,6 +52,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_211452) do
     t.string "api_response"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deleted_at", precision: nil
     t.index ["episode_id"], name: "index_apple_podcast_deliveries_on_episode_id"
     t.index ["external_id"], name: "index_apple_podcast_deliveries_on_external_id", unique: true
     t.index ["podcast_container_id"], name: "index_apple_podcast_deliveries_on_podcast_container_id"
@@ -66,6 +67,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_03_23_211452) do
     t.datetime "updated_at", null: false
     t.boolean "api_marked_as_uploaded", default: false
     t.boolean "upload_operations_complete", default: false
+    t.datetime "deleted_at", precision: nil
     t.index ["external_id"], name: "index_apple_podcast_delivery_files_on_external_id", unique: true
     t.index ["podcast_delivery_id"], name: "index_apple_podcast_delivery_files_on_podcast_delivery_id"
   end

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -186,4 +186,21 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#destroy" do
+    it "should destroy the podcast container and cascade to the delivery and delivery file" do
+      apple_episode.stub(:apple_id, apple_episode_id) do
+        apple_episode.stub(:audio_asset_vendor_id, apple_audio_asset_vendor_id) do
+          pc = Apple::PodcastContainer.upsert_podcast_container(apple_episode, podcast_container_json_row)
+          pd = pc.podcast_deliveries.create!(episode: pc.episode)
+          pdf = pd.podcast_delivery_files.create!(episode: pc.episode)
+
+          pc.destroy
+
+          assert_raises(ActiveRecord::RecordNotFound) { pd.reload }
+          assert_raises(ActiveRecord::RecordNotFound) { pdf.reload }
+        end
+      end
+    end
+  end
 end

--- a/test/models/apple/podcast_delivery_file_test.rb
+++ b/test/models/apple/podcast_delivery_file_test.rb
@@ -47,4 +47,23 @@ class ApplePodcastDeliveryFileTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#destroy" do
+    let(:podcast_container) { create(:apple_podcast_container) }
+    let(:podcast_delivery) {
+      Apple::PodcastDelivery.create!(podcast_container: podcast_container,
+        episode: podcast_container.episode)
+    }
+
+    it "should soft delete the delivery" do
+      pdf_resp_container = build(:podcast_delivery_file_api_response)
+      pdf = Apple::PodcastDeliveryFile.create!(**pdf_resp_container.merge(podcast_delivery: podcast_delivery, episode: podcast_container.episode))
+
+      assert_equal [pdf], podcast_delivery.podcast_delivery_files.reset
+
+      pdf.destroy
+
+      assert_equal [], podcast_delivery.podcast_delivery_files.reset
+    end
+  end
 end


### PR DESCRIPTION
Hit a case where the private branch redirect was alternating across a set of arrangements. 

This PR sets up some guards on the redirect, and tracks the resultant CDN url so that the delivery files are based on that single arrangement.

This also sets up a way to recover from bad audio data in Apple's system:

- Allow replacing audio by marking existing audio as deleted
- Mark the episode's podcast container to immediately disconnect from Apple hosted audio (if needed).