### PR TITLE
Fix/constrain batch sizes

### DIFF
--- a/app/models/apple/api.rb
+++ b/app/models/apple/api.rb
@@ -98,10 +98,10 @@ module Apple
       URI.join(api_base, api_frag)
     end
 
-    def local_api_retry_errors
+    def local_api_retry_errors(tries: ERROR_RETRIES)
       count = 0
       last_resp = nil
-      while count < ERROR_RETRIES
+      while count < tries
         count += 1
         last_resp = yield
         break if ok_code(last_resp)
@@ -110,22 +110,31 @@ module Apple
       last_resp
     end
 
-    def get(api_frag)
+    def get(api_frag, tries: ERROR_RETRIES)
       uri = join_url(api_frag)
-      local_api_retry_errors do
+      local_api_retry_errors(tries: tries) do
         get_uri(uri)
       end
     end
 
-    def patch(api_frag, data_body)
-      local_api_retry_errors do
-        update_remote(Net::HTTP::Patch, api_frag, data_body)
+    def patch(api_frag, data_body, tries: ERROR_RETRIES)
+      uri = join_url(api_frag)
+      local_api_retry_errors(tries: tries) do
+        update_remote(Net::HTTP::Patch, uri, data_body)
       end
     end
 
-    def post(api_frag, data_body)
-      local_api_retry_errors do
-        update_remote(Net::HTTP::Post, api_frag, data_body)
+    def post(api_frag, data_body, tries: ERROR_RETRIES)
+      uri = join_url(api_frag)
+      local_api_retry_errors(tries: tries) do
+        update_remote(Net::HTTP::Post, uri, data_body)
+      end
+    end
+
+    def delete(api_frag, tries: ERROR_RETRIES)
+      uri = join_url(api_frag)
+      local_api_retry_errors(tries: tries) do
+        update_remote(Net::HTTP::Delete, uri, {})
       end
     end
 

--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -59,7 +59,7 @@ module Apple
       return if episodes.empty?
 
       episode_bridge_results = api.bridge_remote_and_retry!("createEpisodes",
-        episodes.map(&:create_episode_bridge_params))
+        episodes.map(&:create_episode_bridge_params), batch_size: Api::DEFAULT_WRITE_BATCH_SIZE)
 
       insert_sync_logs(episodes, episode_bridge_results)
     end

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -54,7 +54,7 @@ module Apple
 
       new_containers_response =
         api.bridge_remote_and_retry!("createPodcastContainers",
-          create_podcast_containers_bridge_params(api, episodes_to_create))
+          create_podcast_containers_bridge_params(api, episodes_to_create), batch_size: Api::DEFAULT_WRITE_BATCH_SIZE)
 
       join_on_apple_episode_id(episodes_to_create, new_containers_response).each do |ep, row|
         upsert_podcast_container(ep, row)
@@ -106,7 +106,7 @@ module Apple
     def self.get_podcast_containers_via_episodes(api, episodes)
       # Fetch the podcast containers from the episodes side of the API
       response =
-        api.bridge_remote_and_retry!("getPodcastContainers", get_podcast_containers_bridge_params(api, episodes))
+        api.bridge_remote_and_retry!("getPodcastContainers", get_podcast_containers_bridge_params(api, episodes), batch_size: 1)
 
       # Rather than mangling and persisting the enumerated view of the containers in the episodes,
       # just re-fetch the podcast containers from the non-list podcast container endpoint
@@ -119,8 +119,7 @@ module Apple
 
       formatted_bridge_params = formatted_bridge_params.flatten
 
-      api.bridge_remote_and_retry!("getPodcastContainers",
-        formatted_bridge_params)
+      api.bridge_remote_and_retry!("getPodcastContainers", formatted_bridge_params, batch_size: 2)
     end
 
     def self.get_urls_for_episode_podcast_containers(api, episode_podcast_containers_json)

--- a/app/models/apple/podcast_delivery.rb
+++ b/app/models/apple/podcast_delivery.rb
@@ -73,7 +73,7 @@ module Apple
 
       (response, errs) =
         api.bridge_remote_and_retry("createPodcastDeliveries",
-          create_podcast_deliveries_bridge_params(api, podcast_containers))
+          create_podcast_deliveries_bridge_params(api, podcast_containers), batch_size: Api::DEFAULT_WRITE_BATCH_SIZE)
 
       join_on("podcast_container_id", podcast_containers, response).map do |podcast_container, row|
         upsert_podcast_delivery(podcast_container, row)
@@ -91,7 +91,7 @@ module Apple
       end
 
       deliveries_response =
-        api.bridge_remote_and_retry!("getPodcastDeliveries", bridge_params)
+        api.bridge_remote_and_retry!("getPodcastDeliveries", bridge_params, batch_size: 1)
 
       # Rather than mangling and persisting the enumerated view of the deliveries from the containers endpoint,
       # Instead, re-fetch the podcast deliveries from the non-list podcast delivery endpoint
@@ -106,7 +106,7 @@ module Apple
       formatted_bridge_params = formatted_bridge_params.flatten
 
       api.bridge_remote_and_retry!("getPodcastDeliveries",
-        formatted_bridge_params)
+        formatted_bridge_params, batch_size: 1)
     end
 
     def self.upsert_podcast_delivery(podcast_container, row)

--- a/app/models/apple/upload_operation.rb
+++ b/app/models/apple/upload_operation.rb
@@ -49,7 +49,7 @@ module Apple
       chunk_size = operation_bridge_params.size / num_threads
       chunk_size = [chunk_size, 1].max
 
-      chunked_slices = operation_bridge_params.each_slice(num_threads).to_a
+      chunked_slices = operation_bridge_params.each_slice(chunk_size).to_a
 
       Parallel.map(chunked_slices, in_threads: num_threads) do |ops|
         api.bridge_remote_and_retry!("executeUploadOperations", ops, batch_size: 1)

--- a/app/models/apple/upload_operation.rb
+++ b/app/models/apple/upload_operation.rb
@@ -45,10 +45,14 @@ module Apple
     end
 
     def self.parallel_upload(api, operation_bridge_params)
-      chunked_slices = operation_bridge_params.each_slice(2).to_a
+      num_threads = 10
+      chunk_size = operation_bridge_params.size / num_threads
+      chunk_size = [chunk_size, 1].max
 
-      Parallel.map(chunked_slices, in_threads: chunked_slices.length) do |ops|
-        api.bridge_remote_and_retry!("executeUploadOperations", ops)
+      chunked_slices = operation_bridge_params.each_slice(num_threads).to_a
+
+      Parallel.map(chunked_slices, in_threads: num_threads) do |ops|
+        api.bridge_remote_and_retry!("executeUploadOperations", ops, batch_size: 1)
       end
     end
 


### PR DESCRIPTION
Merge after https://github.com/PRX/feeder.prx.org/pull/602

Counterpart to https://github.com/PRX/api-bridge-lambda/pull/17, this sets up a new batch size parameter to constrain the number of workers hitting the remote API.