### PR TITLE
No sessions for api requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -43,6 +43,6 @@ class ApplicationController < ActionController::Base
   end
 
   def skip_session
-    request.session_options[:drop] = true
+    request.session_options[:skip] = true
   end
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :active_record_store, key: "_feeder_session"
+# customized AR-store, which doesn't run SQL on API requests
+require "feeder_active_record_store"
+Rails.application.config.session_store :feeder_active_record_store, key: "_feeder_session"

--- a/lib/feeder_active_record_store.rb
+++ b/lib/feeder_active_record_store.rb
@@ -1,0 +1,11 @@
+# customized AR-store, which doesn't run SQL on API requests
+class FeederActiveRecordStore < ActionDispatch::Session::ActiveRecordStore
+  def find_session(request, id)
+    # TODO: how to determine if request.session_options[:skip], before that before_action has even run?
+    # or just check request path?
+    # or a controller class method/var?
+    # binding.pry
+    # then return nil instead of super
+    super
+  end
+end


### PR DESCRIPTION
Our sessions options had `drop: true`.  Which would still run an insert/select/delete on the sessions table.

Changing to `skip: true`, and it just runs an insert.

Trying to add a custom session store that skips even that insert.