### PR TITLE
Fix form state styling

### DIFF
--- a/app/assets/stylesheets/shared/card.scss
+++ b/app/assets/stylesheets/shared/card.scss
@@ -29,7 +29,7 @@
     --#{$prefix}card-cap-bg: #{$value};
     --#{$prefix}card-cap-color: #{color-contrast($value)};
 
-    .help-text {
+    .prx-btn-help {
       color: #{color-contrast($value)};
       margin-right: 0;
 

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -308,20 +308,22 @@ small {
   font-size: 1rem;
 }
 
-.field-help-text {
-  display: flex;
-  justify-content: space-between;
+/* TODO: Apply prx prefix */
+
+.prx-field-group {
+  display: grid;
+  grid-template-columns: 1fr min-content;
+  grid-template-rows: $input-height;
+  grid-auto-rows: auto;
+  align-items: center;
 
   .form-floating {
-    flex: 1 0 auto;
+    grid-row: 1 / span 2;
   }
 
-  .help-text {
-    margin-top: 1.1rem;
-  }
 }
 
-.help-text {
+.prx-btn-help {
   display: flex;
   color: $gray-600;
   background: none;

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -94,47 +94,47 @@
   }
 
   // changed field stylez
-.form-check-input.is-changed:not(.is-invalid),
-.form-control.is-changed:not(.is-invalid),
-.form-select.is-changed:not(.is-invalid) {
-  border-color: $orange;
+  .form-check-input.is-changed:not(.is-invalid),
+  .form-control.is-changed:not(.is-invalid),
+  .form-select.is-changed:not(.is-invalid) {
+    border-color: $orange;
 
-  &:focus {
-    box-shadow: 0 0 $input-btn-focus-blur $input-btn-focus-width rgba($orange, $input-btn-focus-color-opacity);
+    &:focus {
+      box-shadow: 0 0 $input-btn-focus-blur $input-btn-focus-width rgba($orange, $input-btn-focus-color-opacity);
+    }
+
+    ~ label {
+      color: $orange;
+    }
+  }
+  .btn-discard-changed {
+    border-color: $orange;
+    &:hover {
+      border-color: $orange;
+    }
   }
 
-  ~ label {
-    color: $orange;
+  // bootstrap5-tags need help
+  .form-floating {
+    > .form-tag-select ~ label {
+      opacity: $form-floating-label-opacity !important;
+      transform: $form-floating-label-transform !important;
+    }
+    > .form-tag-select.form-control-blank:not(.form-control-focus) ~ label {
+      opacity: 1 !important;
+      transform: none !important;
+    }
   }
-}
-.btn-discard-changed {
-  border-color: $orange;
-  &:hover {
+  .is-changed ~ .form-tag-select {
     border-color: $orange;
   }
-}
-
-// bootstrap5-tags need help
-.form-floating {
-  > .form-tag-select ~ label {
-    opacity: $form-floating-label-opacity !important;
-    transform: $form-floating-label-transform !important;
+  .form-tag-select.form-control-focus {
+    color: $input-focus-color;
+    background-color: $input-focus-bg;
+    border-color: $input-focus-border-color;
+    outline: 0;
+    box-shadow: $input-focus-box-shadow;
   }
-  > .form-tag-select.form-control-blank:not(.form-control-focus) ~ label {
-    opacity: 1 !important;
-    transform: none !important;
-  }
-}
-.is-changed ~ .form-tag-select {
-  border-color: $orange;
-}
-.form-tag-select.form-control-focus {
-  color: $input-focus-color;
-  background-color: $input-focus-bg;
-  border-color: $input-focus-border-color;
-  outline: 0;
-  box-shadow: $input-focus-box-shadow;
-}
 
   // manually applied "blank" class (when the placeholder trick won't work)
   > .form-control-blank:not(:focus) ~ label {
@@ -320,7 +320,6 @@ small {
   .form-floating {
     grid-row: 1 / span 2;
   }
-
 }
 
 .prx-btn-help {

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -315,6 +315,10 @@ small {
   .form-floating {
     flex: 1 0 auto;
   }
+
+  .help-text {
+    margin-top: 1.1rem;
+  }
 }
 
 .help-text {
@@ -323,7 +327,7 @@ small {
   background: none;
   border: none;
   padding: 0;
-  margin: 1.1rem 0 0 0.5rem;
+  margin: 0 0 0 0.5rem;
   text-decoration: none;
 
   &:hover {

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -58,22 +58,6 @@
 
 // material style floating form labels
 .form-floating {
-  display: flex;
-  align-items: center;
-  border: $input-border-width $border-style $input-border-color;
-  border-radius: $input-border-radius;
-
-  &:focus-within {
-    border-color: $blue-light;
-    box-shadow: $input-focus-box-shadow;
-  }
-
-  &.textarea-help {
-    .form-control {
-      padding-right: 2.5rem;
-    }
-  }
-
   > label {
     color: $gray-600;
     height: auto;
@@ -97,13 +81,60 @@
 
   .form-control {
     color: #000;
-    border: none;
+    border: $input-border-width $border-style $input-border-color;
 
-    &:focus {
+    &.is-invalid {
+      border-color: $red;
+    }
+
+    /*&:focus {
       box-shadow: none;
       border-color: transparent;
-    }
+    }*/
   }
+
+  // changed field stylez
+.form-check-input.is-changed:not(.is-invalid),
+.form-control.is-changed:not(.is-invalid),
+.form-select.is-changed:not(.is-invalid) {
+  border-color: $orange;
+
+  &:focus {
+    box-shadow: 0 0 $input-btn-focus-blur $input-btn-focus-width rgba($orange, $input-btn-focus-color-opacity);
+  }
+
+  ~ label {
+    color: $orange;
+  }
+}
+.btn-discard-changed {
+  border-color: $orange;
+  &:hover {
+    border-color: $orange;
+  }
+}
+
+// bootstrap5-tags need help
+.form-floating {
+  > .form-tag-select ~ label {
+    opacity: $form-floating-label-opacity !important;
+    transform: $form-floating-label-transform !important;
+  }
+  > .form-tag-select.form-control-blank:not(.form-control-focus) ~ label {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+.is-changed ~ .form-tag-select {
+  border-color: $orange;
+}
+.form-tag-select.form-control-focus {
+  color: $input-focus-color;
+  background-color: $input-focus-bg;
+  border-color: $input-focus-border-color;
+  outline: 0;
+  box-shadow: $input-focus-box-shadow;
+}
 
   // manually applied "blank" class (when the placeholder trick won't work)
   > .form-control-blank:not(:focus) ~ label {
@@ -127,12 +158,7 @@
     padding: 0.75rem;
     min-height: $input-height;
     height: auto;
-    border: none;
-
-    &:focus {
-      box-shadow: none;
-      border-color: transparent;
-    }
+    // border: none;
   }
 
   // selection colors
@@ -282,10 +308,13 @@ small {
   font-size: 1rem;
 }
 
-.help-text-field {
-  position: absolute;
-  right: 0.5rem;
-  top: 1rem;
+.field-help-text {
+  display: flex;
+  justify-content: space-between;
+
+  .form-floating {
+    flex: 1 0 auto;
+  }
 }
 
 .help-text {
@@ -294,17 +323,11 @@ small {
   background: none;
   border: none;
   padding: 0;
-  margin: 0 0.5rem 0 0;
+  margin: 1.1rem 0 0 0.5rem;
   text-decoration: none;
 
   &:hover {
     text-decoration: none;
     color: $primary;
-  }
-
-  &.help-textarea {
-    position: absolute;
-    right: 0;
-    top: 1rem;
   }
 }

--- a/app/views/episodes/_form_audio.html.erb
+++ b/app/views/episodes/_form_audio.html.erb
@@ -1,9 +1,10 @@
 <h2><%= t(".title") %></h2>
 
-<div class="col-4 mb-4">
+<div class="col-4 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.number_field :segment_count, min: 1, max: 10 %>
     <%= form.label :segment_count %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.segment_count") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.segment_count") %>"><span class="material-icons">help</span></button>
 </div>

--- a/app/views/episodes/_form_audio.html.erb
+++ b/app/views/episodes/_form_audio.html.erb
@@ -1,10 +1,10 @@
 <h2><%= t(".title") %></h2>
 
-<div class="col-4 mb-4 field-help-text">
+<div class="col-4 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.number_field :segment_count, min: 1, max: 10 %>
     <%= form.label :segment_count %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.segment_count") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.segment_count") %>"><span class="material-icons">help</span></button>
 </div>

--- a/app/views/episodes/_form_image.html.erb
+++ b/app/views/episodes/_form_image.html.erb
@@ -1,7 +1,7 @@
 <div class="card shadow border-0">
   <div class="card-header card-header-info d-flex justify-content-between">
     <h5 class="card-title"><%= t(".title") %></h5>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.cover_image") %>"><span class="material-icons">help</span></button>
+    <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.cover_image") %>"><span class="material-icons">help</span></button>
   </div>
   <div class="card-body">
     <% if episode.image %>

--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -1,33 +1,37 @@
-<div class="col-12 mb-4 border-0">
-  <div class="form-floating">
-    <%= form.text_field :title %>
-    <%= form.label :title %>
+<div class="col-12 mb-4 border-0 field-help-text">
+    <div class="form-floating">
+      <%= form.text_field :title %>
+      <%= form.label :title %>
+    </div>
+
     <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.title") %>"><span class="material-icons">help</span></button>
-  </div>
 </div>
 
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :clean_title %>
     <%= form.label :clean_title %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.clean_title") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.clean_title") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :subtitle %>
     <%= form.label :subtitle %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating textarea-help">
     <%= form.text_area :description %>
     <%= form.label :description %>
-    <button type="button" class="help-text help-textarea" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text help-textarea" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-12 mb-4" data-controller="toggle-field">
@@ -45,58 +49,65 @@
   </div>
 </div>
 
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :production_notes %>
     <%= form.label :production_notes %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.production_notes") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.production_notes") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.select :explicit, podcast_explicit_options, {include_blank: true} %>
     <%= form.label :explicit %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.select :itunes_type, episode_itunes_type_options %>
     <%= form.label :itunes_type %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_type") %>" data-bs-html="true"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_type") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.number_field :season_number %>
     <%= form.label :season_number %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.season_number") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.season_number") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.number_field :episode_number %>
     <%= form.label :episode_number %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.episode_number") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.episode_number") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :author_name %>
     <%= form.label :author_name %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :author_email %>
     <%= form.label :author_email %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
 </div>

--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -1,37 +1,37 @@
-<div class="col-12 mb-4 border-0 field-help-text">
+<div class="col-12 mb-4 border-0 prx-field-group">
     <div class="form-floating">
       <%= form.text_field :title %>
       <%= form.label :title %>
     </div>
 
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.title") %>"><span class="material-icons">help</span></button>
+    <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.title") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :clean_title %>
     <%= form.label :clean_title %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.clean_title") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.clean_title") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :subtitle %>
     <%= form.label :subtitle %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating textarea-help">
     <%= form.text_area :description %>
     <%= form.label :description %>
   </div>
 
-  <button type="button" class="help-text help-textarea" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help prx-btn-helparea" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-12 mb-4" data-controller="toggle-field">
@@ -39,7 +39,7 @@
     <%= form.check_box :add_itunes_summary, class: "form-check-input", name: nil, checked: false, data: {toggle_field_target: "check", action: "toggle-field#changeCheck"} %>
     <div class="d-flex align-items-center">
       <%= form.label :add_itunes_summary %>
-      <button type="button" class="help-text ms-1" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
+      <button type="button" class="prx-btn-help ms-1" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
     </div>
   </div>
 
@@ -49,65 +49,65 @@
   </div>
 </div>
 
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :production_notes %>
     <%= form.label :production_notes %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.production_notes") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.production_notes") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.select :explicit, podcast_explicit_options, {include_blank: true} %>
     <%= form.label :explicit %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.select :itunes_type, episode_itunes_type_options %>
     <%= form.label :itunes_type %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_type") %>" data-bs-html="true"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_type") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.number_field :season_number %>
     <%= form.label :season_number %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.season_number") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.season_number") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.number_field :episode_number %>
     <%= form.label :episode_number %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.episode_number") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.episode_number") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :author_name %>
     <%= form.label :author_name %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :author_email %>
     <%= form.label :author_email %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
 </div>

--- a/app/views/episodes/_form_tags.html.erb
+++ b/app/views/episodes/_form_tags.html.erb
@@ -1,9 +1,10 @@
 <h2><%= t(".title") %></h2>
 
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.tag_select :categories, episode.categories, {}, data: {allow_new: true, allow_clear: true} %>
     <%= form.label :categories %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.categories") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.categories") %>"><span class="material-icons">help</span></button>
 </div>

--- a/app/views/episodes/_form_tags.html.erb
+++ b/app/views/episodes/_form_tags.html.erb
@@ -1,10 +1,10 @@
 <h2><%= t(".title") %></h2>
 
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.tag_select :categories, episode.categories, {}, data: {allow_new: true, allow_clear: true} %>
     <%= form.label :categories %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.categories") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.categories") %>"><span class="material-icons">help</span></button>
 </div>

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -1,10 +1,10 @@
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :title %>
     <%= form.label :title %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.title") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.title") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-6 mb-4">
@@ -21,22 +21,22 @@
   </div>
 </div>
 
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :subtitle %>
     <%= form.label :subtitle %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-12 mb-4 field-help-text">
+<div class="col-12 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_area :description %>
     <%= form.label :description %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.description") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.description") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-12 mb-4" data-controller="toggle-field">
@@ -44,7 +44,7 @@
     <%= form.check_box :add_itunes_summary, class: "form-check-input", name: nil, checked: false, data: {toggle_field_target: "check", action: "toggle-field#changeCheck"} %>
     <div class="d-flex align-items-center">
       <%= form.label :add_itunes_summary %>
-      <button type="button" class="help-text ms-1" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
+      <button type="button" class="prx-btn-help ms-1" data-bs-toggle="popover" data-bs-content="<%= t(".help.summary") %>"><span class="material-icons">help</span></button>
     </div>
   </div>
 
@@ -54,25 +54,25 @@
   </div>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :link %>
     <%= form.label :link %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.link") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.link") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.select :explicit, podcast_explicit_options %>
     <%= form.label :explicit %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <%# HACK: display nested validation errors %>
   <% nested_errors = podcast.errors.full_messages_for("itunes_categories.name").join(", ") %>
   <% klass = nested_errors.present? ? "is-invalid form-select" : "form-select" %>
@@ -84,7 +84,7 @@
     <%# update subcategory turbo-frame when category changes %>
     <a hidden href="<%= new_podcast_path %>" data-dynamic-form-target="link" data-turbo-frame="itunes-subcategory"></a>
   </div>
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_category") %>" data-bs-html="true"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_category") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
 
@@ -98,86 +98,86 @@
   <% end %>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.select :serial_order, podcast_serial_order_options %>
     <%= form.label :serial_order %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.serial_order") %>" data-bs-html="true"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.serial_order") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%# TODO: make this a select, but where to get the options? %>
     <%= form.text_field :language %>
     <%= form.label :language %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.language") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.language") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :owner_name %>
     <%= form.label :owner_name %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_name") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :owner_email %>
     <%= form.label :owner_email %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_email") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_email") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :author_name %>
     <%= form.label :author_name %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :author_email %>
     <%= form.label :author_email %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :managing_editor_name %>
     <%= form.label :managing_editor_name %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_name") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :managing_editor_email %>
     <%= form.label :managing_editor_email %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_email") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_email") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4 field-help-text">
+<div class="col-6 mb-4 prx-field-group">
   <div class="form-floating">
     <%= form.text_field :copyright %>
     <%= form.label :copyright %>
   </div>
 
-  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.copyright") %>"><span class="material-icons">help</span></button>
+  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.copyright") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-6 mb-4 d-flex align-items-center">
@@ -185,7 +185,7 @@
     <%= form.check_box :complete, class: "form-check-input" %>
     <div class="d-flex align-items-center">
       <%= form.label :complete %>
-      <button type="button" class="help-text ms-1" data-bs-toggle="popover" data-bs-content="<%= t(".help.complete") %>"><span class="material-icons">help</span></button>
+      <button type="button" class="prx-btn-help ms-1" data-bs-toggle="popover" data-bs-content="<%= t(".help.complete") %>"><span class="material-icons">help</span></button>
     </div>
   </div>
 </div>

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -29,10 +29,10 @@
 </div>
 
 <div class="col-12 mb-4">
-  <div class="form-floating textarea-help">
+  <div class="form-floating">
     <%= form.text_area :description %>
     <%= form.label :description %>
-    <button type="button" class="help-text help-textarea" data-bs-toggle="popover" data-bs-content="<%= t(".help.description") %>"><span class="material-icons">help</span></button>
+    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.description") %>"><span class="material-icons">help</span></button>
   </div>
 </div>
 

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -87,7 +87,6 @@
   <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_category") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-
 <div class="col-6 mb-4">
   <%= turbo_frame_tag "itunes-subcategory" do %>
     <div class="form-floating">

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -1,9 +1,10 @@
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :title %>
     <%= form.label :title %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.title") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.title") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-6 mb-4">
@@ -20,20 +21,22 @@
   </div>
 </div>
 
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :subtitle %>
     <%= form.label :subtitle %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.subtitle") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-12 mb-4">
+<div class="col-12 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_area :description %>
     <%= form.label :description %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.description") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.description") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-12 mb-4" data-controller="toggle-field">
@@ -51,23 +54,25 @@
   </div>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :link %>
     <%= form.label :link %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.link") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.link") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.select :explicit, podcast_explicit_options %>
     <%= form.label :explicit %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.explicit") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <%# HACK: display nested validation errors %>
   <% nested_errors = podcast.errors.full_messages_for("itunes_categories.name").join(", ") %>
   <% klass = nested_errors.present? ? "is-invalid form-select" : "form-select" %>
@@ -76,12 +81,12 @@
     <%= form.select :itunes_category, itunes_category_options, {include_blank: true}, class: klass, data: {action: "dynamic-form#change"} %>
     <% if nested_errors.present? %><div class="invalid-feedback"><%= nested_errors %></div><% end %>
     <%= form.label :itunes_category %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_category") %>" data-bs-html="true"><span class="material-icons">help</span></button>
-
     <%# update subcategory turbo-frame when category changes %>
     <a hidden href="<%= new_podcast_path %>" data-dynamic-form-target="link" data-turbo-frame="itunes-subcategory"></a>
   </div>
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.itunes_category") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
+
 
 <div class="col-6 mb-4">
   <%= turbo_frame_tag "itunes-subcategory" do %>
@@ -93,77 +98,86 @@
   <% end %>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.select :serial_order, podcast_serial_order_options %>
     <%= form.label :serial_order %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.serial_order") %>" data-bs-html="true"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.serial_order") %>" data-bs-html="true"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%# TODO: make this a select, but where to get the options? %>
     <%= form.text_field :language %>
     <%= form.label :language %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.language") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.language") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :owner_name %>
     <%= form.label :owner_name %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_name") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :owner_email %>
     <%= form.label :owner_email %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_email") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.owner_email") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :author_name %>
     <%= form.label :author_name %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :author_email %>
     <%= form.label :author_email %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.author_email") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :managing_editor_name %>
     <%= form.label :managing_editor_name %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_name") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_name") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :managing_editor_email %>
     <%= form.label :managing_editor_email %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_email") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.managing_editor_email") %>"><span class="material-icons">help</span></button>
 </div>
 
-<div class="col-6 mb-4">
+<div class="col-6 mb-4 field-help-text">
   <div class="form-floating">
     <%= form.text_field :copyright %>
     <%= form.label :copyright %>
-    <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.copyright") %>"><span class="material-icons">help</span></button>
   </div>
+
+  <button type="button" class="help-text" data-bs-toggle="popover" data-bs-content="<%= t(".help.copyright") %>"><span class="material-icons">help</span></button>
 </div>
 
 <div class="col-6 mb-4 d-flex align-items-center">


### PR DESCRIPTION
- Restyles help text (creates a few custom classes)
- Renamed help-text button
- Reinstates changed state styling (`.is-changed`)
- Moves the help-text button outside of `form-floating` class (this is the bulk of the code change you'll see)
- Creates the `prx-field-group` class that uses CSS grid to allow `invalid-feedback` text appears on its own row without affecting the rest of the styling

h/t @rpeterman-gp 