### PR TITLE
File metadata modals

### DIFF
--- a/app/assets/stylesheets/shared/table.scss
+++ b/app/assets/stylesheets/shared/table.scss
@@ -55,6 +55,13 @@
   }
 }
 
+.table-sm {
+  td,
+  th {
+    padding: 0.25rem 0.25rem;
+  }
+}
+
 .table-loading {
   position: absolute;
   top: 0;

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,4 +30,14 @@ module ApplicationHelper
     # call through
     active_link_to(name, options, html_options)
   end
+
+  def blank_dash(*args, &block)
+    if args.any?(&:blank?)
+      "&mdash;".html_safe
+    elsif block
+      capture(&block)
+    else
+      args.last
+    end
+  end
 end

--- a/app/views/episodes/audio/_complete.html.erb
+++ b/app/views/episodes/audio/_complete.html.erb
@@ -32,7 +32,9 @@
     <label>Segment <%= content.position %></label>
   </div>
 
-  <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-html="true" data-bs-content="TODO: audio file info">
+  <button type="button" class="prx-btn-help" data-bs-toggle="modal" data-bs-target="#audio-modal-<%= content.id %>">
     <span class="material-icons">info</span>
   </button>
 </div>
+
+<%= render "episodes/audio/modal", content: content, id: "audio-modal-#{content.id}", title: "Segment #{content.position}" %>

--- a/app/views/episodes/audio/_modal.html.erb
+++ b/app/views/episodes/audio/_modal.html.erb
@@ -6,7 +6,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <table class="table">
+        <table class="table table-sm m-0">
           <tbody>
             <tr>
               <th scope="row"><strong>File:</strong></th>
@@ -40,20 +40,30 @@
               <td><%= content.duration.present? ? episode_content_duration(content) : "&mdash;" %></td>
             </tr>
             <tr>
-              <th scope="row"><strong>Content Type:</strong></th>
+              <th scope="row" class="text-nowrap"><strong>Content Type:</strong></th>
               <td><%= blank_dash(content.mime_type) %></td>
             </tr>
             <tr>
               <th scope="row"><strong>Frequency:</strong></th>
-              <td><%= blank_dash(content.frame_rate) %></td>
+              <td><%= blank_dash(content.sample_rate) { "#{content.sample_rate.to_f / 1000} kHz" } %></td>
             </tr>
             <tr>
               <th scope="row"><strong>Bitrate:</strong></th>
-              <td><%= blank_dash(content.bit_rate) %></td>
+              <td><%= blank_dash(content.bit_rate) { "#{content.bit_rate} kb/s" } %></td>
             </tr>
             <tr>
               <th scope="row"><strong>Channels:</strong></th>
-              <td><%= blank_dash(content.channels) %></td>
+              <td>
+                <%= blank_dash(content.channels) do %>
+                  <% if content.channels == 1 %>
+                    Mono
+                  <% elsif content.channels == 2 %>
+                    Stereo
+                  <% else %>
+                    <%= content.channels %> Channels
+                  <% end %>
+                <% end %>
+              </td>
             </tr>
             <% if content.frame_rate.present? %>
               <tr>
@@ -61,10 +71,10 @@
                 <td><%= content.frame_rate %></td>
               </tr>
             <% end %>
-            <% if content.height.present? && content.width.present? %>
+            <% if content.width.present? && content.height.present? %>
               <tr>
                 <th scope="row"><strong>Dimensions:</strong></th>
-                <td><%= content.height %> x <%= content.width %></td>
+                <td><%= content.width %> x <%= content.height %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/episodes/audio/_modal.html.erb
+++ b/app/views/episodes/audio/_modal.html.erb
@@ -1,0 +1,75 @@
+<div id="<%= id %>" class="modal" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><%= title %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <table class="table">
+          <tbody>
+            <tr>
+              <th scope="row"><strong>File:</strong></th>
+              <td>
+                <% if content.complete? %>
+                  <%= link_to content.file_name, content.url, target: "_blank", rel: "noopener" %>
+                <% else %>
+                  <%= content.file_name %>
+                <% end %>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Status:</strong></th>
+              <td>
+                <% case content.status %>
+                <% when "started", "created", "processing", "retrying" %>
+                  <span class="badge bg-secondary"><%= content.status.capitalize %></span>
+                <% when "complete" %>
+                  <span class="badge bg-success"><%= content.status.capitalize %></span>
+                <% else %>
+                  <span class="badge bg-danger"><%= content.status.capitalize %></span>
+                <% end %>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Size:</strong></th>
+              <td><%= blank_dash(content.file_size) { number_to_human_size(content.file_size) } %></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Duration:</strong></th>
+              <td><%= content.duration.present? ? episode_content_duration(content) : "&mdash;" %></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Content Type:</strong></th>
+              <td><%= blank_dash(content.mime_type) %></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Frequency:</strong></th>
+              <td><%= blank_dash(content.frame_rate) %></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Bitrate:</strong></th>
+              <td><%= blank_dash(content.bit_rate) %></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Channels:</strong></th>
+              <td><%= blank_dash(content.channels) %></td>
+            </tr>
+            <% if content.frame_rate.present? %>
+              <tr>
+                <th scope="row"><strong>Frame Rate:</strong></th>
+                <td><%= content.frame_rate %></td>
+              </tr>
+            <% end %>
+            <% if content.height.present? && content.width.present? %>
+              <tr>
+                <th scope="row"><strong>Dimensions:</strong></th>
+                <td><%= content.height %> x <%= content.width %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/images/_complete.html.erb
+++ b/app/views/images/_complete.html.erb
@@ -19,8 +19,8 @@
     <div class="prx-uploads-image mb-4">
       <%= image_tag image.url, alt: image.alt_text %>
 
-      <% if image.height.present? && image.width.present? %>
-        <aside><%= image.height %>x<%= image.width %></aside>
+      <% if image.width.present? && image.height.present? %>
+        <aside><%= image.width %>x<%= image.height %></aside>
       <% end %>
     </div>
 

--- a/app/views/images/_complete.html.erb
+++ b/app/views/images/_complete.html.erb
@@ -2,11 +2,15 @@
   <div class="card-header-info d-flex align-items-center">
     <h5 class="card-title flex-grow-1"><%= t("images.title.#{image.model_name.singular}") %></h5>
 
-    <button type="button" class="prx-btn-help me-1" data-bs-toggle="popover" data-bs-content="<%= t("images.help.#{image.model_name.singular}") %>">
+    <button type="button" class="prx-btn-help" data-bs-toggle="modal" data-bs-target="#image-modal-<%= image.id %>">
+      <span class="material-icons">info</span>
+    </button>
+
+    <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= t("images.help.#{image.model_name.singular}") %>">
       <span class="material-icons">help</span>
     </button>
 
-    <%= link_to delete_path, class: "btn btn-icon p-0" do %>
+    <%= link_to delete_path, class: "prx-btn-help" do %>
       <span class="material-icons">delete</span>
     <% end %>
   </div>
@@ -24,3 +28,5 @@
     <%= render "images/meta", form: form %>
   </div>
 </div>
+
+<%= render "images/modal", image: image, id: "image-modal-#{image.id}", title: t("images.title.#{image.model_name.singular}") %>

--- a/app/views/images/_modal.html.erb
+++ b/app/views/images/_modal.html.erb
@@ -1,0 +1,51 @@
+<div id="<%= id %>" class="modal" tabindex="-1">
+  <div class="modal-dialog modal-dialog-centered modal-sm">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title"><%= title %></h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <table class="table">
+          <tbody>
+            <tr>
+              <th scope="row"><strong>File:</strong></th>
+              <td>
+                <% if image.complete? %>
+                  <%= link_to image.file_name, image.url, target: "_blank", rel: "noopener" %>
+                <% else %>
+                  <%= image.file_name %>
+                <% end %>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Status:</strong></th>
+              <td>
+                <% case image.status %>
+                <% when "started", "created", "processing", "retrying" %>
+                  <span class="badge bg-secondary"><%= image.status.capitalize %></span>
+                <% when "complete" %>
+                  <span class="badge bg-success"><%= image.status.capitalize %></span>
+                <% else %>
+                  <span class="badge bg-danger"><%= image.status.capitalize %></span>
+                <% end %>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Size:</strong></th>
+              <td><%= blank_dash(image.size) { number_to_human_size(image.size) } %></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Format:</strong></th>
+              <td><%= blank_dash(image.format) %></td>
+            </tr>
+            <tr>
+              <th scope="row"><strong>Dimensions:</strong></th>
+              <td><%= blank_dash(image.height, image.width, image.alt_text) { "#{image.height} x #{image.width}" } %></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/images/_modal.html.erb
+++ b/app/views/images/_modal.html.erb
@@ -6,7 +6,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <table class="table">
+        <table class="table table-sm m-0">
           <tbody>
             <tr>
               <th scope="row"><strong>File:</strong></th>
@@ -41,7 +41,7 @@
             </tr>
             <tr>
               <th scope="row"><strong>Dimensions:</strong></th>
-              <td><%= blank_dash(image.height, image.width, image.alt_text) { "#{image.height} x #{image.width}" } %></td>
+              <td><%= blank_dash(image.width, image.height) { "#{image.width} x #{image.height}" } %></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
After #619.  Part of #618.

Display metadata for audio/video/image files.

![image](https://user-images.githubusercontent.com/1410587/234634816-3f8f922b-6142-4066-8df5-68571eeae17b.png)
