### PR TITLE
Podcast Planner verbiage and layout

### DIFF
--- a/app/assets/stylesheets/app/calendar.scss
+++ b/app/assets/stylesheets/app/calendar.scss
@@ -19,8 +19,9 @@
     }
 
     .day.current-month:hover {
-      background-color: $secondary !important;
+      background-color: $primary !important;
       color: $light;
+      cursor: pointer;
     }
   }
 }

--- a/app/assets/stylesheets/shared/layout.scss
+++ b/app/assets/stylesheets/shared/layout.scss
@@ -17,6 +17,10 @@ body {
   background-position: top left;
 }
 
+h3 {
+  color: $black;
+}
+
 .prx-main {
   position: relative;
   display: grid;

--- a/app/controllers/podcast_planner_controller.rb
+++ b/app/controllers/podcast_planner_controller.rb
@@ -6,7 +6,7 @@ class PodcastPlannerController < ApplicationController
   def show
     @planner = PodcastPlanner.new(planner_params)
     @planner.generate_dates!
-    @draft_dates = @podcast.episodes.draft.pluck(:released_at)
+    @draft_dates = @podcast.episodes.draft_or_scheduled.pluck(:released_at)
   end
 
   # POST /podcasts/1/planner

--- a/app/helpers/podcast_planner_helper.rb
+++ b/app/helpers/podcast_planner_helper.rb
@@ -61,7 +61,6 @@ module PodcastPlannerHelper
     if date_is_in_month?(day, month)
       data[:controller] = DATE_CONTROLLER
       data[:action] = [TOGGLE_ACTION, RECOUNT_ACTION].join(" ")
-      data["count-target"] = "counter"
     end
 
     content_tag(:td, class: calendar.td_classes_for(day), data: data) do

--- a/app/helpers/podcast_planner_helper.rb
+++ b/app/helpers/podcast_planner_helper.rb
@@ -5,6 +5,7 @@ module PodcastPlannerHelper
   MONTHLY_WEEKS = I18n.t([:first, :second, :third, :fourth, :fifth], scope: [:podcast_planner, :helper, :monthly_options])
   DATE_CONTROLLER = "date"
   TOGGLE_ACTION = "click->date#toggleSelect"
+  RECOUNT_ACTION = "click->count#recount"
 
   def day_options
     DateTime::DAYNAMES.map.with_index { |day, i| [day, i] }
@@ -59,7 +60,8 @@ module PodcastPlannerHelper
     data = {}
     if date_is_in_month?(day, month)
       data[:controller] = DATE_CONTROLLER
-      data[:action] = TOGGLE_ACTION
+      data[:action] = [TOGGLE_ACTION, RECOUNT_ACTION].join(" ")
+      data["count-target"] = "counter"
     end
 
     content_tag(:td, class: calendar.td_classes_for(day), data: data) do

--- a/app/javascript/controllers/count_controller.js
+++ b/app/javascript/controllers/count_controller.js
@@ -3,7 +3,7 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = ["counter", "display"]
   static values = {
-    selected: { type: Number, default: 0 }
+    selected: { type: Number, default: 0 },
   }
 
   connect() {
@@ -17,7 +17,7 @@ export default class extends Controller {
   }
 
   countSelectedTargets() {
-    const selectedTargets = this.counterTargets.filter(el => {
+    const selectedTargets = this.counterTargets.filter((el) => {
       return el.firstElementChild.disabled
     })
     return this.counterTargets.length - selectedTargets.length

--- a/app/javascript/controllers/count_controller.js
+++ b/app/javascript/controllers/count_controller.js
@@ -2,24 +2,15 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["counter", "display"]
-  static values = {
-    selected: { type: Number, default: 0 },
-  }
-
-  connect() {
-    this.selectedValue = this.countSelectedTargets()
-    this.displayTarget.innerHTML = this.selectedValue
-  }
 
   recount() {
-    this.selectedValue = this.countSelectedTargets()
-    this.displayTarget.innerHTML = this.selectedValue
+    this.displayTarget.innerHTML = this.countSelectedTargets()
   }
 
   countSelectedTargets() {
     const selectedTargets = this.counterTargets.filter((el) => {
-      return el.firstElementChild.disabled
+      return !el.disabled
     })
-    return this.counterTargets.length - selectedTargets.length
+    return selectedTargets.length
   }
 }

--- a/app/javascript/controllers/count_controller.js
+++ b/app/javascript/controllers/count_controller.js
@@ -1,0 +1,25 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["counter", "display"]
+  static values = {
+    selected: { type: Number, default: 0 }
+  }
+
+  connect() {
+    this.selectedValue = this.countSelectedTargets()
+    this.displayTarget.innerHTML = this.selectedValue
+  }
+
+  recount() {
+    this.selectedValue = this.countSelectedTargets()
+    this.displayTarget.innerHTML = this.selectedValue
+  }
+
+  countSelectedTargets() {
+    const selectedTargets = this.counterTargets.filter(el => {
+      return el.firstElementChild.disabled
+    })
+    return this.counterTargets.length - selectedTargets.length
+  }
+}

--- a/app/views/podcast_planner/_calendar.html.erb
+++ b/app/views/podcast_planner/_calendar.html.erb
@@ -1,4 +1,4 @@
-<div class="col <%= "d-none" if index >= range %>" data-pager-target="page">
+<div class="col col-xl-4 <%= "d-none" if index >= range %>" data-pager-target="page">
   <%= month_calendar(start_date: start_date) do |date| %>
     <% if date_is_in_month?(date, start_date.month) %>
       <%= date.day %>

--- a/app/views/podcast_planner/_calendar.html.erb
+++ b/app/views/podcast_planner/_calendar.html.erb
@@ -3,7 +3,7 @@
     <% if date_is_in_month?(date, start_date.month) %>
       <%= date.day %>
 
-      <%= form.hidden_field :selected_dates, multiple: true, data: {date_target: "preselected"}, value: date.to_datetime, disabled: !date_is_in_dates?(date, @planner.dates), draft: date_is_in_dates?(date, @draft_dates) %>
+      <%= form.hidden_field :selected_dates, multiple: true, data: {date_target: "preselected", count_target: "counter"}, value: date.to_datetime, disabled: !date_is_in_dates?(date, @planner.dates), draft: date_is_in_dates?(date, @draft_dates) %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/podcast_planner/_form_date_calculator.html.erb
+++ b/app/views/podcast_planner/_form_date_calculator.html.erb
@@ -1,12 +1,6 @@
 <section>
   <div class="mb-4">
-    <h2 class="fw-bold"><%= t(".header.date_calculation") %></h2>
-    <p><%= t(".help.date_calculation") %></p>
-  </div>
-
-  <div class="mb-4">
-    <h3 class="fw-bold"><%= t(".header.day_select") %></h3>
-    <p><%= t(".help.day_select") %></p>
+    <h3 class="mb-3"><%= t(".header.day_select") %></h3>
     <div class="col-lg-12">
       <div class="form-floating">
         <%= form.select :selected_days, day_options, {include_blank: true}, data: {action: "click#submit"}, multiple: true %>
@@ -16,11 +10,9 @@
   </div>
 
   <div class="mb-4" data-controller="toggle-field">
-    <h3 class="fw-bold"><%= t(".header.week_select") %></h3>
-    <p><%= t(".help.week_select") %></p>
+    <h3 class="mb-3"><%= t(".header.week_select") %></h3>
     <div class="row">
       <div class="col-lg-6">
-        <p><%= t(".help.calculate_weeks") %></p>
         <div class="form-floating">
           <%= form.select :week_condition, week_condition_options, {}, data: {action: "toggle-field#displayOnlyThisField click#submit"} %>
           <%= form.label t(".label.week_condition") %>
@@ -28,14 +20,12 @@
       </div>
       <div class="col-lg-6">
         <div class="" data-toggle-field-target="field" field="monthly">
-          <p><%= t(".help.select_weeks") %></p>
           <div class="form-floating">
             <%= form.select :monthly_weeks, monthly_weeks_options, {include_blank: true}, data: {action: "click#submit"}, multiple: true %>
             <%= form.label t(".label.week_of_month") %>
           </div>
         </div>
         <div class="d-none" data-toggle-field-target="field" field="periodic">
-          <p><%= t(".help.select_period") %></p>
           <div class="form-floating">
             <%= form.select :period, periodic_weeks_options, {}, data: {action: "click#submit"} %>
             <%= form.label t(".label.period") %>
@@ -46,11 +36,9 @@
   </div>
 
   <div class="mb-4" data-controller="toggle-field">
-    <h3 class="fw-bold"><%= t(".header.range_select") %></h3>
-    <p><%= t(".help.range_select") %></p>
+    <h3 class="mb-3"><%= t(".header.range_select") %></h3>
     <div class="row mb-4">
-      <div class="col-lg-6">
-        <p><%= t(".help.calculate_range") %></p>
+      <div class="col-12">
         <div>
           <div class="form-floating">
             <%= form.select :date_range_condition, end_condition_options, {}, data: {action: "toggle-field#displayOnlyThisField click#submit"} %>
@@ -58,13 +46,16 @@
           </div>
         </div>
       </div>
+    </div>
+    <div class="row mb-4">
       <div class="col-lg-6">
-        <p><%= t(".help.select_range") %></p>
-          <div class="form-floating mb-2">
-            <%= form.date_field :start_date, min: DateTime.tomorrow, max: DateTime.tomorrow + 1.years, value: DateTime.tomorrow, data: {action: "click#submit"} %>
-            <%= form.label :start_date %>
-          </div>
+        <div class="form-floating mb-2">
+          <%= form.date_field :start_date, min: DateTime.tomorrow, max: DateTime.tomorrow + 1.years, value: DateTime.tomorrow, data: {action: "click#submit"} %>
+          <%= form.label :start_date %>
+        </div>
+      </div>
 
+      <div class="col-lg-6">
         <div data-toggle-field-target="field" field="episodes">
           <div class="form-floating">
             <%= form.number_field :number_of_episodes, {min: 1, max: 100, step: 1, value: 10, data: {action: "click#submit"}} %>

--- a/app/views/podcast_planner/_form_main.html.erb
+++ b/app/views/podcast_planner/_form_main.html.erb
@@ -8,7 +8,7 @@
       }
     ) do |form| %>
     <h1 class="text-black fw-bold d-flex flex-fill"><%= t(".header") %></h1>
-    <p><%= t(".help_html", url: new_podcast_episode_path(@podcast)) %></p>
+    <p class="lh-sm"><%= t(".help_html", url: new_podcast_episode_path(@podcast)) %></p>
 
     <%= render "form_date_calculator", form: form %>
 

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(
-  url: podcast_planner_path(@podcast),
-  method: :post
-) do |form| %>
+      url: podcast_planner_path(@podcast),
+      method: :post
+    ) do |form| %>
   <div class="mb-4">
     <h3 class="mb-3"><%= t(".header.publish_time") %></h3>
     <div class="col-lg-12">

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -27,7 +27,7 @@
       <div data-controller="pager count" data-pager-range-value="6">
         <div class="d-flex justify-content-between">
           <h3 class="mb-3"><%= t(".header.number_of_drafts") %>
-            <span data-count-target="display"></span>
+            <span data-count-target="display"><%= @planner.dates.present? ? @planner.dates.count : "0" %></span>
           </h3>
           <div class="mb-2">
             <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageBackward", pager_target: "prev"}, disabled: true do %>

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -23,29 +23,31 @@
   </div>
 
   <div class="card p-4 mt-4mb-4">
-    <div data-controller="pager" data-pager-range-value="6">
-      <div class="d-flex justify-content-between">
-        <h3 class="mb-3"><%= t(".header.number_of_drafts") %></h3>
-        <div class="mb-2">
-          <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageBackward", pager_target: "prev"}, disabled: true do %>
-            <span class="material-icons">arrow_left</span>
-            Month
-          <% end %>
-          <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageForward", pager_target: "next"} do %>
-            Month
-            <span class="material-icons">arrow_right</span>
-          <% end %>
+    <%= turbo_frame_tag "preview", target: "_top" do %>
+      <div data-controller="pager count" data-pager-range-value="6">
+        <div class="d-flex justify-content-between">
+          <h3 class="mb-3"><%= t(".header.number_of_drafts") %>
+            <span data-count-target="display"></span>
+          </h3>
+          <div class="mb-2">
+            <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageBackward", pager_target: "prev"}, disabled: true do %>
+              <span class="material-icons">arrow_left</span>
+              Month
+            <% end %>
+            <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageForward", pager_target: "next"} do %>
+              Month
+              <span class="material-icons">arrow_right</span>
+            <% end %>
+          </div>
+        </div>
+          <div class="row">
+            <% 24.times do |i| %>
+              <%= render "calendar", form: form, start_date: Date.today.beginning_of_month + i.months, planner: @planner, index: i, range: 6 %>
+            <% end %>
+          </div>
         </div>
       </div>
-      <%= turbo_frame_tag "preview", target: "_top" do %>
-        <div class="row">
-          <% 24.times do |i| %>
-            <%= render "calendar", form: form, start_date: Date.today.beginning_of_month + i.months, planner: @planner, index: i, range: 6 %>
-          <% end %>
-        </div>
-      <% end %>
-      </div>
-    </div>
+    <% end %>
   </div>
   <%= form.submit t(".label.submit"), class: "btn btn-primary mb-4" %>
 <% end %>

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -1,56 +1,51 @@
-<div class="card my-4 mx-2 g-0">
-  <div class="card-header-info">
-    <h5 class="card-title"><%= t(".header.preview") %></h5>
+<%= form_with(
+  url: podcast_planner_path(@podcast),
+  method: :post
+) do |form| %>
+  <div class="mb-4">
+    <h3 class="mb-3"><%= t(".header.publish_time") %></h3>
+    <div class="col-lg-12">
+      <div class="form-floating">
+        <%= form.select :publish_time, time_options %>
+        <%= form.label :publish_time %>
+      </div>
+    </div>
   </div>
 
-  <%= form_with(
-        url: podcast_planner_path(@podcast),
-        method: :post
-      ) do |form| %>
-      <div class="card-body">
-        <div class="row mb-4">
-          <div class="col-lg-6">
-            <h3 class="fw-bold"><%= t(".header.publish_time") %></h3>
-            <div class="form-floating">
-              <%= form.select :publish_time, time_options %>
-              <%= form.label :publish_time %>
-            </div>
-          </div>
+  <div class="mb-4">
+    <h3 class="mb-3"><%= t(".header.audio_segments") %></h3>
+    <div class="col-lg-12">
+      <div class="form-floating">
+        <%= form.number_field :segment_count, {min: 1, max: 10, step: 1, value: 2} %>
+        <%= form.label :segment_count %>
+      </div>
+    </div>
+  </div>
 
-          <div class="col-lg-6">
-            <h3 class="fw-bold"><%= t(".header.audio_segments") %></h3>
-            <div class="form-floating">
-              <%= form.number_field :segment_count, {min: 1, max: 10, step: 1, value: 2} %>
-              <%= form.label :segment_count %>
-            </div>
-          </div>
-        </div>
-
-        <div class="col-lg">
-          <div data-controller="pager" data-pager-range-value="6">
-            <div class="mb-2">
-              <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageBackward", pager_target: "prev"}, disabled: true do %>
-                <span class="material-icons">arrow_left</span>
-                Month
-              <% end %>
-              <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageForward", pager_target: "next"} do %>
-                Month
-                <span class="material-icons">arrow_right</span>
-              <% end %>
-            </div>
-
-            <%= turbo_frame_tag "preview", target: "_top" do %>
-              <div class="row">
-                <% 24.times do |i| %>
-                  <%= render "calendar", form: form, start_date: Date.today.beginning_of_month + i.months, planner: @planner, index: i, range: 6 %>
-                <% end %>
-              </div>
-            <% end %>
-          </div>
+  <div class="card p-4 mt-4mb-4">
+    <div data-controller="pager" data-pager-range-value="6">
+      <div class="d-flex justify-content-between">
+        <h3 class="mb-3"><%= t(".header.number_of_drafts") %></h3>
+        <div class="mb-2">
+          <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageBackward", pager_target: "prev"}, disabled: true do %>
+            <span class="material-icons">arrow_left</span>
+            Month
+          <% end %>
+          <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageForward", pager_target: "next"} do %>
+            Month
+            <span class="material-icons">arrow_right</span>
+          <% end %>
         </div>
       </div>
-      <div class="card-footer">
-        <%= form.submit t(".label.submit"), class: "btn btn-primary" %>
+      <%= turbo_frame_tag "preview", target: "_top" do %>
+        <div class="row">
+          <% 24.times do |i| %>
+            <%= render "calendar", form: form, start_date: Date.today.beginning_of_month + i.months, planner: @planner, index: i, range: 6 %>
+          <% end %>
+        </div>
+      <% end %>
       </div>
-  <% end %>
-</div>
+    </div>
+  </div>
+  <%= form.submit t(".label.submit"), class: "btn btn-primary mb-4" %>
+<% end %>

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -1,5 +1,5 @@
-<div class="card">
-  <div class="card-header-primary">
+<div class="card my-4 mx-2 g-0">
+  <div class="card-header-info">
     <h5 class="card-title"><%= t(".header.preview") %></h5>
   </div>
 

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -46,8 +46,10 @@
             <% end %>
           </div>
         </div>
+        <p class="mb-0 fs-6">Key: <span class="badge bg-warning text-dark">Existing Episode Draft</span> <span class="badge bg-primary">New Episode Draft</span></p>
       </div>
     <% end %>
+
   </div>
   <%= form.submit t(".label.submit"), class: "btn btn-primary mb-4" %>
 <% end %>

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -40,7 +40,7 @@
             <% end %>
           </div>
         </div>
-          <div class="row">
+          <div class="row d-flex flex-wrap gx-4">
             <% 24.times do |i| %>
               <%= render "calendar", form: form, start_date: Date.today.beginning_of_month + i.months, planner: @planner, index: i, range: 6 %>
             <% end %>

--- a/app/views/podcast_planner/show.html.erb
+++ b/app/views/podcast_planner/show.html.erb
@@ -1,9 +1,6 @@
 <%= render "podcasts/tabs" %>
 
-<div class="col col-md-12 my-4 px-2">
+<div class="my-4 px-2">
   <%= render "form_main" %>
-</div>
-
-<div class="col col-md-12">
-    <%= render "form_side" %>
+  <%= render "form_side" %>
 </div>

--- a/app/views/podcast_planner/show.html.erb
+++ b/app/views/podcast_planner/show.html.erb
@@ -1,10 +1,9 @@
 <%= render "podcasts/tabs" %>
 
-<div class="row my-4 px-2">
-  <div class="col-lg-4">
-    <%= render "form_main" %>
-  </div>
-  <div class="col-lg-8">
+<div class="col col-md-12 my-4 px-2">
+  <%= render "form_main" %>
+</div>
+
+<div class="col col-md-12">
     <%= render "form_side" %>
-  </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,13 +230,13 @@ en:
       success: Episode drafts generated.
     form_main:
       header: Plan Episodes
-      help_html: Save yourself some time by automatically creating multiple episode drafts to create a production schedule, it may also help your revenue as our sales teams will have access to dropdates to sell against. If you only wish to add a single episode, <a href="%{url}">go here</a>.
+      help_html: Add multiple episode drafts to create a production schedule. Episode drafts improve the accuracy of your podcast's forecasts. If you only need to add a single episode, <a href="%{url}">go here</a>.
     form_date_calculator:
       header:
         date_calculation: Date Calculation of Draft Batch
-        day_select: Day Selection
-        week_select: Week Selection
-        range_select: Date Range Selection
+        day_select: Which day of the week do you plan to publish your episodes?
+        week_select: Which weeks of each month do you plan to publish on?
+        range_select: How long will episodes recur?
       help:
         date_calculation: Calculate release dates for your drafts by selecting which days and weeks you plan to publish, and then select a date range.
         day_select: Which day of the week do you plan to publish your episodes? Select all that apply.
@@ -248,16 +248,19 @@ en:
         calculate_range: Calculate the end of the batch by
         select_range: Select range
       label:
-        week_condition: Weekly rhythm
-        week_of_month: Week of the month
-        period: Interval
-        date_range_condition: End range
+        week_condition: Calculate the weeks by
+        week_of_month: Select Week of the month
+        period: Select weekly interval
+        date_range_condition: Calculate the end of the batch by
     form_side:
       header:
-        preview: Schedule Preview
+        preview: 4. Preview Draft Schedule
         publish_time: Publish Time
         audio_segments: Audio Segments
+        segment_count: Number of segments
         number_of_drafts: "Number of Draft Episodes: %{count}"
+        help:
+          segment_count: Enter the number of original audio segments. The number of segments helps determine the number and location of ad breaks for this episode.
       help:
         preview: Select more options to get a schedule preview.
       label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,11 +254,11 @@ en:
         date_range_condition: Calculate the end of the batch by
     form_side:
       header:
-        preview: 4. Preview Draft Schedule
-        publish_time: Publish Time
-        audio_segments: Audio Segments
+        preview: Preview Draft Schedule
+        publish_time: What time of day do you plan to publish the episodes?
+        audio_segments: How many audio segments?
         segment_count: Number of segments
-        number_of_drafts: "Number of Draft Episodes: %{count}"
+        number_of_drafts: "Planning %{count} drafts"
         help:
           segment_count: Enter the number of original audio segments. The number of segments helps determine the number and location of ad breaks for this episode.
       help:
@@ -277,10 +277,10 @@ en:
         third: Third
         fourth: Fourth
         fifth: Fifth
-      episodes: number of episodes
-      end_date: end date
-      month: month
-      period: interval
+      episodes: Number of episodes
+      end_date: End date
+      month: Weeks of the Month
+      period: Weekly interval
   podcast_switcher:
     dropdown:
       all: View all my Podcasts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -258,7 +258,7 @@ en:
         publish_time: What time of day do you plan to publish the episodes?
         audio_segments: How many audio segments?
         segment_count: Number of segments
-        number_of_drafts: "Planning %{count} drafts"
+        number_of_drafts: "Drafts planned: "
         help:
           segment_count: Enter the number of original audio segments. The number of segments helps determine the number and location of ad breaks for this episode.
       help:


### PR DESCRIPTION
closes: #606 

Now that we have a working calendar (!!!EXCITING!!!) I thought we could take a pass at the verbiage and the layout of the calendar. This PR's changes will get us closer to what exists in Publish currently where we've received a lot of neutral to positive feedback. (NOTE: I think we can open a new ticket to explore enhancements to this feature that go beyond the existing functionality in this PR.)

There were a lot of places where we had help text, headers, and field labels that felt a little redundant or overly technical in its use, so I attempted to clean It up.

Also, I reverted this to a single column layout like we have now. I think this will serve our producers finely enough until we get the time to really rethink the feature in the future. 