### PR TITLE
Polling and dropdowns

### DIFF
--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -165,6 +165,10 @@
     // border: none;
   }
 
+  .ss-values .ss-single {
+    margin-left: 0;
+  }
+
   // selection colors
   .ss-values .ss-value {
     animation: none;

--- a/app/javascript/controllers/polling_controller.js
+++ b/app/javascript/controllers/polling_controller.js
@@ -6,12 +6,24 @@ export default class extends Controller {
   static values = { debounce: Number }
 
   connect() {
+    this.frame = this.element.closest("turbo-frame")
     this.interval = setInterval(() => {
-      this.element.click()
+      this.clickOrTurbo()
     }, this.debounceValue || DEFAULT_DEBOUNCE)
   }
 
   disconnect() {
     clearInterval(this.interval)
+  }
+
+  // use a turbo-frame to reload if possible, to dodge document.click events
+  clickOrTurbo() {
+    if (this.frame && this.frame.src) {
+      this.frame.reload()
+    } else if (this.frame && this.element.href) {
+      this.frame.src = this.element.href
+    } else {
+      this.element.click()
+    }
   }
 }

--- a/app/views/episodes/audio/_modal.html.erb
+++ b/app/views/episodes/audio/_modal.html.erb
@@ -11,7 +11,7 @@
             <tr>
               <th scope="row"><strong>File:</strong></th>
               <td>
-                <% if content.complete? %>
+                <% if content.status_complete? %>
                   <%= link_to content.file_name, content.url, target: "_blank", rel: "noopener" %>
                 <% else %>
                   <%= content.file_name %>

--- a/app/views/images/_modal.html.erb
+++ b/app/views/images/_modal.html.erb
@@ -11,7 +11,7 @@
             <tr>
               <th scope="row"><strong>File:</strong></th>
               <td>
-                <% if image.complete? %>
+                <% if image.status_complete? %>
                   <%= link_to image.file_name, image.url, target: "_blank", rel: "noopener" %>
                 <% else %>
                   <%= image.file_name %>


### PR DESCRIPTION
Part of #629.

When audio/images were processing, we were clicking a link within a turbo-frame, to poll for changes.  Every time this happened, the slim-select `document.onClick` listener would see a click even occurred outside of the dropdown, and close the dropdown.

This switches to using the parent turbo-frame ["src" property](https://turbo.hotwired.dev/reference/frames#properties) instead.  (With a graceful fallback to clicking the link).

Also fixed a bug with the metadata-modals ... branches got a bit out of sync there.