### PR TITLE
Re-copying complete media

### DIFF
--- a/app/models/concerns/image_file.rb
+++ b/app/models/concerns/image_file.rb
@@ -79,7 +79,7 @@ module ImageFile
   end
 
   def href
-    status_complete? ? url : original_url
+    (status_complete? || status_invalid?) ? url : original_url
   end
 
   def href=(h)

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -57,7 +57,7 @@ class MediaResource < ApplicationRecord
   end
 
   def href
-    status_complete? ? url : original_url
+    (status_complete? || status_invalid?) ? url : original_url
   end
 
   def href=(h)

--- a/app/models/tasks/copy_image_task.rb
+++ b/app/models/tasks/copy_image_task.rb
@@ -16,7 +16,7 @@ class Tasks::CopyImageTask < ::Task
   def task_options
     super.merge({
       job_type: "image",
-      source: image_resource.original_url,
+      source: image_resource.href,
       destination: destination_url(image_resource)
     }).with_indifferent_access
   end

--- a/app/models/tasks/copy_media_task.rb
+++ b/app/models/tasks/copy_media_task.rb
@@ -22,7 +22,7 @@ class Tasks::CopyMediaTask < ::Task
   end
 
   def source_url(media_resource)
-    media_resource.original_url.sub(/\?.*$/, "")
+    media_resource.href.sub(/\?.*$/, "")
   end
 
   def destination_url(media_resource)

--- a/test/models/concerns/image_file_test.rb
+++ b/test/models/concerns/image_file_test.rb
@@ -56,8 +56,11 @@ describe ImageFile do
   end
 
   describe "#href" do
-    it "checks if processing is complete" do
+    it "checks if processing is complete or invalid" do
       assert_equal "complete", image.status
+      assert_equal image.url, image.href
+
+      image.status = "invalid"
       assert_equal image.url, image.href
 
       image.status = "processing"

--- a/test/models/tasks/copy_image_task_test.rb
+++ b/test/models/tasks/copy_image_task_test.rb
@@ -8,8 +8,16 @@ describe Tasks::CopyImageTask do
   it "has task options" do
     opts = task.task_options
     assert_equal opts[:job_type], "image"
-    assert_equal opts[:source], image.original_url
+    assert_equal opts[:source], image.href
     assert_match(/s3:\/\/test-prx-feed\/#{path}\/ba047dce-9df5-4132-a04b-31d24c7c55a(\d+)\/images\/4e745a8c-77ee-481c-a72b-fd868dfd1c9(\d+)\/image\.png/, opts[:destination])
+  end
+
+  it "uses the url as source when complete" do
+    assert_equal image.status, "complete"
+    assert_equal task.task_options[:source], image.url
+
+    image.status = "started"
+    assert_equal task.task_options[:source], image.original_url
   end
 
   it "gets the image path" do

--- a/test/models/tasks/copy_media_task_test.rb
+++ b/test/models/tasks/copy_media_task_test.rb
@@ -16,14 +16,14 @@ describe Tasks::CopyMediaTask do
     assert_equal options.keys, %w[callback job_type source destination]
     assert_match(/^sqs:\/\//, options[:callback])
     assert_equal options[:job_type], "audio"
-    assert_equal options[:source], "s3://prx-testing/test/audio.mp3"
+    assert_equal options[:source], task.media_resource.href
     assert_match(/^s3:\/\//, options[:destination])
   end
 
   it "remove query string from audio url" do
     refute_nil task.media_resource
-    original = task.media_resource.original_url
-    task.media_resource.original_url = "#{original}?remove=this"
+    original = task.media_resource.href
+    task.media_resource.href = "#{original}?remove=this"
     assert_equal task.task_options[:source], original
   end
 
@@ -45,8 +45,12 @@ describe Tasks::CopyMediaTask do
     assert_equal url, "s3://test-prx-feed/path/guid/audio.mp3"
   end
 
-  it "use original url as the source url" do
+  it "use original url as the source url until complete" do
+    task.media_resource.status = "started"
     assert_equal task.source_url(task.media_resource), task.media_resource.original_url
+
+    task.media_resource.status = "complete"
+    assert_equal task.source_url(task.media_resource), task.media_resource.url
   end
 
   it "updates status before save" do


### PR DESCRIPTION
Found a bunch of old files in prod, with `status: "complete"` but missing a bunch of metadata fields.  I'm guessing they just predate when we added the metadata to the DB, or something was missing in the Fixer callbacks?

Anyways, I need to fix them, but their original urls are long gone.

Generally, when re-copying media (for files that already succeeded) - we can and should use the `f.prxu.org` url as the source.  Instead of the `original_url`, which in many cases is long gone/broken.