### PR TITLE
Apple sync job

### DIFF
--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -1,5 +1,5 @@
 class PublishAppleJob < ApplicationJob
-  queue_as :feeder_default
+  queue_as :publish_apple
 
   def self.publish_to_apple(apple_config)
     apple_config.build_publisher.publish!

--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -1,0 +1,8 @@
+class PublishAppleJob < ApplicationJob
+  queue_as :feeder_default
+
+  def perform(apple_config)
+    publisher = apple_config.build_publisher
+    publisher.publish!
+  end
+end

--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -1,5 +1,5 @@
 class PublishAppleJob < ApplicationJob
-  queue_as :publish_podcast
+  queue_as :publishing
 
   def self.publish_to_apple(apple_config)
     apple_config.build_publisher.publish!

--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -1,5 +1,5 @@
 class PublishAppleJob < ApplicationJob
-  queue_as :publish
+  queue_as :publish_artifacts
 
   def self.publish_to_apple(apple_config)
     apple_config.build_publisher.publish!

--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -1,5 +1,5 @@
 class PublishAppleJob < ApplicationJob
-  queue_as :publish_apple
+  queue_as :publish
 
   def self.publish_to_apple(apple_config)
     apple_config.build_publisher.publish!

--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -1,5 +1,5 @@
 class PublishAppleJob < ApplicationJob
-  queue_as :publish_artifacts
+  queue_as :publish_podcast
 
   def self.publish_to_apple(apple_config)
     apple_config.build_publisher.publish!

--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -6,7 +6,9 @@ class PublishAppleJob < ApplicationJob
   end
 
   def perform(apple_config)
-    return unless apple_config.publish_to_apple?
+    if !apple_config.publish_to_apple?
+      logger.info "Skipping publish to apple for #{apple_config.class.name} #{apple_config.id}"
+    end
 
     self.class.publish_to_apple(apple_config)
   end

--- a/app/jobs/publish_apple_job.rb
+++ b/app/jobs/publish_apple_job.rb
@@ -1,8 +1,13 @@
 class PublishAppleJob < ApplicationJob
   queue_as :feeder_default
 
+  def self.publish_to_apple(apple_config)
+    apple_config.build_publisher.publish!
+  end
+
   def perform(apple_config)
-    publisher = apple_config.build_publisher
-    publisher.publish!
+    return unless apple_config.publish_to_apple?
+
+    self.class.publish_to_apple(apple_config)
   end
 end

--- a/app/jobs/publish_feed_job.rb
+++ b/app/jobs/publish_feed_job.rb
@@ -17,11 +17,15 @@ class PublishFeedJob < ApplicationJob
   end
 
   def publish_apple(feed)
-    feed.apple_configs.each do |config|
+    feed.apple_configs.map do |config|
       if feed.publish_to_apple?(config)
         PublishAppleJob.perform_later(config)
       end
     end
+  end
+
+  def schedule_publish_apple(config)
+    PublishAppleJob.perform_later(config)
   end
 
   def publish_rss(podcast, feed)

--- a/app/jobs/publish_feed_job.rb
+++ b/app/jobs/publish_feed_job.rb
@@ -19,8 +19,7 @@ class PublishFeedJob < ApplicationJob
   def publish_apple(feed)
     feed.apple_configs.each do |config|
       if feed.publish_to_apple?(config)
-        publisher = Apple::Publisher.from_apple_config(config)
-        publisher.publish!
+        PublishAppleJob.perform_later(config)
       end
     end
   end

--- a/app/jobs/publish_feed_job.rb
+++ b/app/jobs/publish_feed_job.rb
@@ -24,10 +24,6 @@ class PublishFeedJob < ApplicationJob
     end
   end
 
-  def schedule_publish_apple(config)
-    PublishAppleJob.perform_later(config)
-  end
-
   def publish_rss(podcast, feed)
     save_file(podcast, feed)
   end

--- a/app/models/apple/config.rb
+++ b/app/models/apple/config.rb
@@ -22,8 +22,18 @@ module Apple
                                          message: "can only have one credential per public and private feed"}
     validates :public_feed, exclusion: {in: ->(apple_credential) { [apple_credential.private_feed] }}
 
+    def publish_to_apple?
+      return false unless apple_credentials?
+
+      public_feed.publish_to_apple?(self)
+    end
+
     def build_publisher
       Apple::Publisher.from_apple_config(self)
+    end
+
+    def apple_credentials?
+      apple_provider_id.present? && apple_key_id.present? && apple_key_pem_b64.present?
     end
 
     def any_apple_credentials_exist?

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -209,7 +209,7 @@ class Episode < ApplicationRecord
   end
 
   def apple_mark_for_reupload!
-    podcast_deliveries.destroy_all
+    apple_podcast_deliveries.destroy_all
   end
 
   def publish!

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -208,7 +208,12 @@ class Episode < ApplicationRecord
     images.each { |i| i.copy_media(force) }
   end
 
+  def apple_mark_for_reupload!
+    podcast_deliveries.destroy_all
+  end
+
   def publish!
+    apple_mark_for_reupload!
     podcast&.publish!
   end
 

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -22,4 +22,4 @@ groups:
   single_threaded:
     concurrency: 1
     queues:
-      - ["<%= prefix %>_feeder_publish_artifacts", 1]
+      - ["<%= prefix %>_feeder_publish_podcast", 1]

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -19,7 +19,7 @@ queues:
   - ["<%= prefix %>_announce_feeder_story_publish", 1]
   - ["<%= prefix %>_announce_feeder_story_unpublish", 1]
 groups:
-  singlethreaded:
+  single_threaded:
     concurrency: 1
     queues:
-      - ["<%= prefix %>_publish_apple", 1]
+      - ["<%= prefix %>_publish", 1]

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -18,3 +18,8 @@ queues:
   - ["<%= prefix %>_announce_feeder_story_delete", 1]
   - ["<%= prefix %>_announce_feeder_story_publish", 1]
   - ["<%= prefix %>_announce_feeder_story_unpublish", 1]
+groups:
+  singlethreaded:
+    concurrency: 1
+    queues:
+      - ["<%= prefix %>_publish_apple", 1]

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -22,4 +22,4 @@ groups:
   single_threaded:
     concurrency: 1
     queues:
-      - ["<%= prefix %>_feeder_publish_podcast", 1]
+      - ["<%= prefix %>_feeder_publishing", 1]

--- a/config/shoryuken.yml
+++ b/config/shoryuken.yml
@@ -22,4 +22,4 @@ groups:
   single_threaded:
     concurrency: 1
     queues:
-      - ["<%= prefix %>_publish", 1]
+      - ["<%= prefix %>_feeder_publish_artifacts", 1]

--- a/lib/tasks/sqs.rake
+++ b/lib/tasks/sqs.rake
@@ -5,6 +5,8 @@ namespace :sqs do
   task :create, [:env] do
     sqs = Aws::SQS::Client.new
     names = Rails.application.config_for(:shoryuken, env: :queues).map(&:first)
+    group_names = Rails.application.config_for(:shoryuken, env: :groups).values.map { |v| v[:queues] }.map { |config| config.map(&:first) }.flatten
+    names += group_names
 
     # only allow creating queues in dev, with non-default names
     abort "Can only create queues in development" unless Rails.env.development?

--- a/test/factories/apple_config_factory.rb
+++ b/test/factories/apple_config_factory.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     apple_key_id { "some_key_id" }
     apple_key_pem_b64 { Base64.encode64(test_file("/fixtures/apple_podcasts_connect_keyfile.pem")) }
     apple_provider_id { SecureRandom.uuid }
+    publish_enabled { true }
 
     transient do
       podcast { build(:podcast) }

--- a/test/jobs/publish_apple_job_test.rb
+++ b/test/jobs/publish_apple_job_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+describe PublishAppleJob do
+  let(:episode) { create(:episode, prx_uri: "/api/v1/stories/87683") }
+  let(:podcast) { episode.podcast }
+  let(:feed) { create(:feed, podcast: podcast, slug: "adfree") }
+  let(:apple_config) { create(:apple_config, public_feed: feed) }
+
+  describe "publishing to apple" do
+    it "does not publish to apple unless publish_enabled?" do
+      apple_config.update(publish_enabled: false)
+
+      # test that the `publish_to_apple` method is not called
+      PublishAppleJob.stub(:publish_to_apple, ->(x) { raise "should not be called" }) do
+        assert_nil PublishAppleJob.perform_now(apple_config)
+      end
+    end
+
+    it "does publish to apple if publish_enabled?" do
+      apple_config.update(publish_enabled: true)
+
+      PublishAppleJob.stub(:publish_to_apple, :it_published!) do
+        assert_equal :it_published!, PublishAppleJob.perform_now(apple_config)
+      end
+    end
+  end
+end

--- a/test/jobs/publish_feed_job_test.rb
+++ b/test/jobs/publish_feed_job_test.rb
@@ -38,4 +38,23 @@ describe PublishFeedJob do
       end
     end
   end
+
+  describe "publishing to apple" do
+    it "does not schedule publishing to apple if there is no apple config" do
+      assert_equal [], feed.apple_configs
+      assert_equal [], job.publish_apple(feed)
+    end
+
+    it "does not schedule publishing to apple if the config is marked as not publishable" do
+      apple_config = create(:apple_config, public_feed: feed, publish_enabled: false)
+      assert_equal [apple_config], feed.apple_configs.reload
+      assert_equal [nil], job.publish_apple(feed)
+    end
+
+    it "does schedule publishing if the config is present and marked as publishable" do
+      apple_config = create(:apple_config, public_feed: feed, publish_enabled: true)
+      assert_equal [apple_config], feed.apple_configs.reload
+      assert_equal [PublishAppleJob], job.publish_apple(feed).map(&:class)
+    end
+  end
 end


### PR DESCRIPTION
Sets up a new Apple sync/publish job as part of a testing strategy. This will kick off apple publishing with rss publishing. Once this has settled down, then we can merge this back into the PublishFeedJob to get the blocking semantics (Apple publishing is blocking RSS publishing).