### PR TITLE
Ruby 3.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.8
+ruby 3.2.2
 nodejs 18.13.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.8-alpine
+FROM ruby:3.2.2-alpine
 
 LABEL org.prx.app="yes"
 LABEL org.prx.spire.publish.ecr="RAILS_APP"

--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem "say_when", "~> 2.2.1"
 gem "shoryuken"
 
 # podcast import
-gem "feedjira", "2.1.0"
+gem "feedjira"
 gem "loofah"
 
 # utilities

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.7.8"
+ruby "3.2.2"
 
 # core
 gem "activerecord-session_store"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,7 +293,7 @@ GEM
     parallel (1.22.1)
     paranoia (2.6.1)
       activerecord (>= 5.1, < 7.1)
-    parser (3.2.1.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     pg (1.4.5)
     popper_js (2.11.6)
@@ -541,7 +541,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.7.8p225
+   ruby 3.2.2p53
 
 BUNDLED WITH
-   2.1.4
+   2.4.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,12 +181,8 @@ GEM
       railties (>= 5.0.0)
     faraday (0.17.6)
       multipart-post (>= 1.2, < 3)
-    faraday_middleware (0.14.0)
-      faraday (>= 0.7.4, < 1.0)
-    feedjira (2.1.0)
-      faraday (>= 0.9)
-      faraday_middleware (>= 0.9)
-      loofah (>= 2.0)
+    feedjira (3.2.2)
+      loofah (>= 2.3.1)
       sax-machine (>= 1.0)
     ffi (1.15.5)
     fuzzyurl (0.2.2)
@@ -239,7 +235,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.21.2)
+    loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -262,7 +258,7 @@ GEM
     msgpack (1.6.0)
     multi_json (1.15.0)
     multi_xml (0.6.0)
-    multipart-post (2.2.3)
+    multipart-post (2.3.0)
     net-http (0.3.1)
       uri
     net-imap (0.3.4)
@@ -276,8 +272,8 @@ GEM
       net-protocol
     newrelic_rpm (8.13.1)
     nio4r (2.5.9)
-    nokogiri (1.14.4)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.2)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (1.4.11)
       faraday (>= 0.17.3, < 3.0)
@@ -494,7 +490,7 @@ DEPENDENCIES
   excon
   factory_bot_rails
   faraday (~> 0.17.4)
-  feedjira (= 2.1.0)
+  feedjira
   hal_api-rails (~> 1.2.0)
   hyperresource
   importmap-rails

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -175,7 +175,7 @@ class PodcastImport < ActiveRecord::Base
   def get_feed
     response = connection.get(uri.path, uri.query_values)
     self.feed_raw_doc = response.body
-    podcast_feed = Feedjira::Feed.parse(feed_raw_doc)
+    podcast_feed = Feedjira.parse(feed_raw_doc)
     validate_feed(podcast_feed)
     self.feed = podcast_feed
   end

--- a/config/initializers/feedjira.rb
+++ b/config/initializers/feedjira.rb
@@ -1,3 +1,5 @@
 load "#{Rails.root}/lib/feedjira/parser/podcast.rb"
 
-Feedjira::Feed.add_feed_class Feedjira::Parser::Podcast
+Feedjira.configure do |config|
+  config.parsers.unshift(Feedjira::Parser::Podcast)
+end

--- a/test/models/episode_import_test.rb
+++ b/test/models/episode_import_test.rb
@@ -8,7 +8,7 @@ describe EpisodeImport do
 
   let(:importer) { create(:podcast_import, account_id: account_id, podcast: podcast) }
 
-  let(:feed) { Feedjira::Feed.parse(test_file("/fixtures/transistor_two.xml")) }
+  let(:feed) { Feedjira.parse(test_file("/fixtures/transistor_two.xml")) }
   let(:entry) { feed.entries.first }
   let(:entry_libsyn) { feed.entries.last }
 

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -24,7 +24,7 @@ describe PodcastImport do
     stub_requests
   end
 
-  let(:feed) { Feedjira::Feed.parse(test_file("/fixtures/transistor_two.xml")) }
+  let(:feed) { Feedjira.parse(test_file("/fixtures/transistor_two.xml")) }
 
   it "retrieves a valid feed" do
     importer.get_feed
@@ -201,7 +201,7 @@ describe PodcastImport do
   end
 
   describe("#parse_feed_entries_for_dupe_guids") do
-    let(:rss_feed) { Feedjira::Feed.parse(test_file("/fixtures/transistor_dupped_guids.xml")) }
+    let(:rss_feed) { Feedjira.parse(test_file("/fixtures/transistor_dupped_guids.xml")) }
 
     it "will parse feed entries for good and duped entries" do
       importer.feed = rss_feed


### PR DESCRIPTION
Closes #564.

Had to upgrade Feedjira to fix a bunch of date parsing errors (fixed in [feedjira 3.2.2](https://github.com/feedjira/feedjira/blob/main/CHANGELOG.md#322).  Couple of API changes there, but not bad.