### PR TITLE
Consider drafting episodes as not-synced

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -430,7 +430,7 @@ module Apple
     end
 
     def synced_with_apple?
-      audio_asset_state_success? && apple_upload_complete?
+      audio_asset_state_success? && apple_upload_complete? && !drafting?
     end
 
     def waiting_for_asset_state?

--- a/test/factories/apple_episode_api_response.rb
+++ b/test/factories/apple_episode_api_response.rb
@@ -1,0 +1,35 @@
+FactoryBot.define do
+  factory :apple_episode_api_response, class: OpenStruct do
+    transient do
+      apple_episode_id { "1234" }
+      item_guid { "item-guid" }
+      ok { true }
+      err { false }
+      api_url { "http://the-api-url.com/v1/episodes/123" }
+      apple_hosted_audio_asset_container_id { "456" }
+      publishing_state { "DRAFTING" }
+      apple_hosted_audio_state { "UNSPECIFIED" }
+    end
+
+    skip_create
+
+    after(:build) do |response_container, evaluator|
+      response_container["api_response"] =
+        {"request_metadata" => {"apple_episode_id" => evaluator.apple_episode_id, "item_guid" => evaluator.item_guid},
+         "api_url" => evaluator.api_url,
+         "api_parameters" => {},
+         "api_response" => {"ok" => evaluator.ok,
+                            "err" => evaluator.err,
+                            "val" => {"data" => {"id" => "123",
+                                                 "attributes" => {
+                                                   "appleHostedAudioAssetVendorId" => evaluator.apple_hosted_audio_asset_container_id,
+                                                   "publishingState" => evaluator.publishing_state,
+                                                   "guid" => evaluator.item_guid,
+                                                   "appleHostedAudioAssetState" => evaluator.apple_hosted_audio_state
+                                                 }}}}}.with_indifferent_access
+      response_container
+    end
+
+    initialize_with { attributes }
+  end
+end

--- a/test/factories/apple_episode_factory.rb
+++ b/test/factories/apple_episode_factory.rb
@@ -1,9 +1,37 @@
 FactoryBot.define do
   factory :apple_episode, class: Apple::Episode do
-    episode { build(:episode, apple_sync_log: SyncLog.new(feeder_type: :episodes, external_id: "123")) }
     show { build(:apple_show) }
     api { build(:apple_api) }
 
-    initialize_with { new(show: show, feeder_episode: episode, api: api) }
+    # set up transient api_response
+    transient do
+      feeder_episode { create(:episode) }
+      api_response { build(:apple_episode_api_response) }
+    end
+
+    # set a complete episode factory varient
+    factory :uploaded_apple_episode do
+      feeder_episode { create(:episode) }
+      transient do
+        api_response do
+          build(:apple_episode_api_response,
+            publishing_state: "PUBLISH",
+            apple_hosted_audio_state: Apple::Episode::AUDIO_ASSET_SUCCESS)
+        end
+      end
+      after(:build) do |apple_episode, evaluator|
+        container = create(:apple_podcast_container, episode: apple_episode.feeder_episode)
+        delivery = create(:apple_podcast_delivery, episode: apple_episode.feeder_episode, podcast_container: container)
+        _delivery_file = create(:apple_podcast_delivery_file, delivery: delivery, episode: apple_episode.feeder_episode)
+      end
+    end
+
+    after(:build) do |apple_episode, evaluator|
+      api_response = evaluator.api_response
+      external_id = api_response["api_response"]["api_response"]["val"]["data"]["id"]
+      apple_episode.feeder_episode.create_apple_sync_log!(external_id: external_id, **api_response) unless apple_episode.feeder_episode.apple_sync_log.present?
+    end
+
+    initialize_with { new(show: show, feeder_episode: feeder_episode, api: api) }
   end
 end

--- a/test/factories/apple_podcast_delivery_factory.rb
+++ b/test/factories/apple_podcast_delivery_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :apple_podcast_delivery, class: Apple::PodcastDelivery do
+    episode
+    sequence(:external_id) { |n| "vendor_id_#{n}" }
+  end
+end

--- a/test/factories/apple_podcast_delivery_file_factory.rb
+++ b/test/factories/apple_podcast_delivery_file_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :apple_podcast_delivery_file, class: Apple::PodcastDeliveryFile do
+    transient do
+      sequence(:external_id) { |n| "apple_pdf_id_#{n}" }
+    end
+
+    after(:build) do |delivery_file, evaluator|
+      api_response = build(:podcast_delivery_file_api_response, external_id: evaluator.external_id)
+      delivery_file.apple_sync_log = SyncLog.new(external_id: evaluator.external_id, feeder_type: :podcast_delivery_files, **api_response)
+    end
+  end
+end

--- a/test/factories/apple_show_factory.rb
+++ b/test/factories/apple_show_factory.rb
@@ -1,0 +1,24 @@
+FactoryBot.define do
+  factory :apple_show, class: Apple::Show do
+    api { build(:apple_api) }
+
+    transient do
+      podcast { nil }
+      public_feed { nil }
+      private_feed { nil }
+    end
+
+    after(:build) do |show, evaluator|
+      podcast =
+        if evaluator.podcast.nil?
+          create(:podcast)
+        else
+          evaluator.podcast
+        end
+
+      show["private_feed"] = evaluator.private_feed || create(:private_feed, podcast: podcast)
+      show["public_feed"] = evaluator.private_feed || podcast.default_feed
+    end
+    initialize_with { attributes }
+  end
+end

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -39,19 +39,19 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
     it "should create logs based on a returned row value" do
       apple_episode.stub(:apple_id, apple_episode_id) do
         apple_episode.stub(:audio_asset_vendor_id, apple_audio_asset_vendor_id) do
-          assert_equal SyncLog.count, 0
+          assert_equal SyncLog.podcast_containers.count, 0
           assert_equal Apple::PodcastContainer.count, 0
 
           Apple::PodcastContainer.upsert_podcast_container(apple_episode,
             podcast_container_json_row)
-          assert_equal SyncLog.count, 1
+          assert_equal SyncLog.podcast_containers.count, 1
           assert_equal Apple::PodcastContainer.count, 1
 
           Apple::PodcastContainer.upsert_podcast_container(apple_episode,
             podcast_container_json_row)
 
           # The second call should not create a new log or podcast container
-          assert_equal SyncLog.count, 1
+          assert_equal SyncLog.podcast_containers.count, 1
           assert_equal Apple::PodcastContainer.count, 1
         end
       end
@@ -127,7 +127,7 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
 
   describe ".poll_podcast_container_state(api, episodes)" do
     it "creates new records if they dont exist" do
-      assert_equal SyncLog.count, 0
+      assert_equal SyncLog.podcast_containers.count, 0
 
       Apple::PodcastContainer.stub(:get_podcast_containers_via_episodes, [podcast_container_json_row]) do
         apple_episode.stub(:apple_id, apple_episode_id) do
@@ -138,7 +138,7 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
           end
         end
       end
-      assert_equal SyncLog.count, 1
+      assert_equal SyncLog.podcast_containers.count, 1
     end
   end
 


### PR DESCRIPTION
Fixes a condition where the episode audio can be fully synced with apple and yet the episode in an unpublished state.  This PR makes insures that we include such an episode for the publishing process as well.  It will re-sync with the api, polling everything as usual (except the podcast container), and marked as published in Apple remote state.