### PR TITLE
Fix thread pool logging

### DIFF
--- a/app/models/apple/upload_operation.rb
+++ b/app/models/apple/upload_operation.rb
@@ -51,8 +51,11 @@ module Apple
 
       chunked_slices = operation_bridge_params.each_slice(chunk_size).to_a
 
+      caller_log_tags = Rails.logger.formatter.current_tags.dup
       Parallel.map(chunked_slices, in_threads: num_threads) do |ops|
-        api.bridge_remote_and_retry!("executeUploadOperations", ops, batch_size: 1)
+        Rails.logger.tagged(caller_log_tags) do
+          api.bridge_remote_and_retry!("executeUploadOperations", ops, batch_size: 1)
+        end
       end
     end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ networks:
     driver: bridge
 services:
   feeder:
+    image: feederprxorg_feeder
     build: .
     volumes:
       - .:/app


### PR DESCRIPTION
Fixes the thread pool logging.

Currently, the publishing code tags the logs for easy searching. But since we're spawning threads, those are missing the thread-local tags. This PR makes sure that the thread local logging config has the right tags.