### PR TITLE
Revert "Last argument as keyword parameters is deprecated"

### DIFF
--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -109,7 +109,7 @@ module Apple
     def update_show!(sync)
       show_data_with_id = show_data
       show_data_with_id[:data][:id] = sync.external_id
-      resp = api.patch("shows/#{sync.external_id}", **show_data_with_id)
+      resp = api.patch("shows/#{sync.external_id}", show_data_with_id)
 
       api.response(resp)
     end


### PR DESCRIPTION
This reverts commit 3d006006285c5f31e07dae0d65e5fbbea9723d6f.

Removes a incorrectly added splat operator. 