### PR TITLE
Fix replaced media coming from CMS

### DIFF
--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -18,7 +18,6 @@ class MediaResource < ApplicationRecord
   validates :medium, inclusion: {in: %w[audio video]}, if: :status_complete?
 
   after_create :replace_resources!
-  after_destroy :mark_replaced!, if: :marked_for_replacement?
 
   scope :complete_or_replaced, -> do
     with_deleted
@@ -177,7 +176,9 @@ class MediaResource < ApplicationRecord
     @marked_for_replacement == true
   end
 
-  def mark_replaced!
-    update_column(:replaced_at, deleted_at)
+  def paranoia_destroy_attributes
+    super.tap do |attrs|
+      attrs[:replaced_at] = current_time_from_proper_timezone if marked_for_replacement?
+    end
   end
 end

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -18,6 +18,7 @@ class MediaResource < ApplicationRecord
   validates :medium, inclusion: {in: %w[audio video]}, if: :status_complete?
 
   after_create :replace_resources!
+  after_destroy :mark_replaced!, if: :marked_for_replacement?
 
   scope :complete_or_replaced, -> do
     with_deleted
@@ -169,10 +170,14 @@ class MediaResource < ApplicationRecord
 
   def mark_for_replacement
     mark_for_destruction
-    self.replaced_at = Time.now if status_complete?
+    @marked_for_replacement = true if status_complete?
   end
 
   def marked_for_replacement?
-    marked_for_destruction? && replaced_at.present?
+    @marked_for_replacement == true
+  end
+
+  def mark_replaced!
+    update_column(:replaced_at, deleted_at)
   end
 end

--- a/test/models/media_resource_test.rb
+++ b/test/models/media_resource_test.rb
@@ -128,16 +128,40 @@ describe MediaResource do
 
   it "marks completed resources for replacement" do
     mr = build_stubbed(:media_resource, status: "started")
+    refute mr.marked_for_destruction?
     refute mr.marked_for_replacement?
 
     mr.mark_for_replacement
+    assert mr.marked_for_destruction?
     refute mr.marked_for_replacement?
 
     mr.status = "complete"
     mr.mark_for_replacement
+    assert mr.marked_for_destruction?
     assert mr.marked_for_replacement?
+  end
 
-    mr.replaced_at = nil
-    refute mr.marked_for_replacement?
+  it "sets both deleted_at and replaced_at on save" do
+    ep = create(:episode_with_media)
+    mr = ep.contents.first
+
+    mr.mark_for_replacement
+    ep.save!
+
+    assert mr.deleted_at.present?
+    assert mr.replaced_at.present?
+  end
+
+  it "sets just deleted_at" do
+    ep = create(:episode_with_media)
+    mr = ep.contents.first
+
+    # invalid doesn't count as "replaced"
+    mr.status = "invalid"
+    mr.mark_for_replacement
+    ep.save!
+
+    assert mr.deleted_at.present?
+    assert_nil mr.replaced_at
   end
 end


### PR DESCRIPTION
Okay, so... I had written a [mark_for_replacement](https://github.com/PRX/feeder.prx.org/blob/main/app/models/media_resource.rb#L170) method to mimic how `mark_for_destruction` works.  But it would set both `deleted_at` and `replaced_at`.

This gets called from the [media=](https://github.com/PRX/feeder.prx.org/blob/main/app/models/concerns/episode_media.rb#L41) setter, which is called for API and Announced CMS updates.

But - apparently when you `.mark_for_destruction` something and then save its parent... it _ignores_ any other pending changes to that record.  So it was just setting `deleted_at` and ignoring the changed `replaced_at` field.

~Took a look at hacking/extending the `paranoia` gem to make it also set this field.  But that was complicated.  This takes an additional SQL statement, but it's fairly straightforward.   So... here we go!~

Just learned about `paranoia_destroy_attributes` ... and updated to that!  Should have done a better job reading the docs.