### PR TITLE
Fix case where the source metadata is not reset

### DIFF
--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -108,17 +108,14 @@ module Apple
           episode_id: episode.feeder_id,
           vendor_id: episode.audio_asset_vendor_id).first)
 
-          pc.update(enclosure_url: episode.enclosure_url,
-            source_filename: episode.enclosure_filename,
-            updated_at: Time.now.utc)
+          pc.touch
           [pc, :updated]
         else
           pc = create!(apple_episode_id: episode.apple_id,
             external_id: external_id,
-            source_filename: episode.enclosure_filename,
-            enclosure_url: episode.enclosure_url,
             vendor_id: episode.audio_asset_vendor_id,
             episode_id: episode.feeder_id)
+
           [pc, :created]
         end
 

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -20,7 +20,7 @@ module Apple
     FILE_ASSET_ROLE_PODCAST_AUDIO = "PodcastSourceAudio"
     SOURCE_URL_EXP_BUFFER = 10.minutes
 
-    def self.reset_source_urls(api, episodes)
+    def self.reset_source_file_metadata(episodes)
       episodes = episodes.select { |ep| ep.podcast_container.present? }
       episodes = episodes.select { |ep| ep.podcast_container.needs_delivery? }
 
@@ -40,7 +40,7 @@ module Apple
       end.compact
     end
 
-    def self.update_podcast_container_file_metadata(api, episodes)
+    def self.probe_source_file_metadata(api, episodes)
       containers = episodes.map(&:podcast_container)
       raise "Missing podcast container for episode" if containers.any?(&:nil?)
       containers = containers.filter(&:needs_file_metadata?)

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -33,7 +33,7 @@ module Apple
           source_url: container.source_url)
 
         # Back to DTR to pick up fresh arrangements:
-        container.reset_source_metadata!(episode.enclosure_url)
+        container.reset_source_metadata!(episode)
 
         # mark them for re-upload
         container.podcast_deliveries.destroy_all
@@ -268,12 +268,12 @@ module Apple
       podcast_deliveries.empty?
     end
 
-    def reset_source_metadata!(new_enclosure_url)
+    def reset_source_metadata!(apple_ep)
       update!(
         source_url: nil,
         source_size: nil,
-        source_filename: nil,
-        enclosure_url: new_enclosure_url
+        source_filename: apple_ep.enclosure_filename,
+        enclosure_url: apple_ep.enclosure_url
       )
     end
 

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -174,14 +174,14 @@ module Apple
         # The 'reset' in this case means fetching new CDN urls for the audio and
         # making sure that we will HEAD their file sizes for later upload.
         # Only reset if we need delivery.
-        reset = Apple::PodcastContainer.reset_source_file_metadata(eps)
-        Rails.logger.info("Reset podcast containers for expired source urls.", {reset_count: reset.length})
-
         res = Apple::PodcastContainer.create_podcast_containers(api, eps)
         Rails.logger.info("Created remote and local state for podcast containers.", {count: res.length})
 
         res = Apple::Episode.update_audio_container_reference(api, eps)
         Rails.logger.info("Updated remote container references for episodes.", {count: res.length})
+
+        reset = Apple::PodcastContainer.reset_source_file_metadata(eps)
+        Rails.logger.info("Reset podcast containers for expired source urls.", {reset_count: reset.length})
 
         res = Apple::PodcastContainer.probe_source_file_metadata(api, eps)
         Rails.logger.info("Updated remote file metadata on podcast containers.", {count: res.length})

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -174,7 +174,7 @@ module Apple
         # The 'reset' in this case means fetching new CDN urls for the audio and
         # making sure that we will HEAD their file sizes for later upload.
         # Only reset if we need delivery.
-        reset = Apple::PodcastContainer.reset_source_urls(api, eps)
+        reset = Apple::PodcastContainer.reset_source_file_metadata(eps)
         Rails.logger.info("Reset podcast containers for expired source urls.", {reset_count: reset.length})
 
         res = Apple::PodcastContainer.create_podcast_containers(api, eps)
@@ -183,7 +183,7 @@ module Apple
         res = Apple::Episode.update_audio_container_reference(api, eps)
         Rails.logger.info("Updated remote container references for episodes.", {count: res.length})
 
-        res = Apple::PodcastContainer.update_podcast_container_file_metadata(api, eps)
+        res = Apple::PodcastContainer.probe_source_file_metadata(api, eps)
         Rails.logger.info("Updated remote file metadata on podcast containers.", {count: res.length})
       end
     end

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -56,10 +56,10 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
       end
     end
 
-    describe ".reset_source_urls" do
+    describe ".reset_source_file_metadata" do
       it "needs delivery in order to be reset" do
         apple_episode.podcast_container.stub(:needs_delivery?, false) do
-          Apple::PodcastContainer.reset_source_urls(api, [apple_episode])
+          Apple::PodcastContainer.reset_source_file_metadata(api, [apple_episode])
         end
 
         apple_episode.podcast_container.reload
@@ -69,7 +69,7 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
 
         apple_episode.stub(:enclosure_url, "http://this-is-new") do
           apple_episode.podcast_container.stub(:needs_delivery?, true) do
-            Apple::PodcastContainer.reset_source_urls(api, [apple_episode])
+            Apple::PodcastContainer.reset_source_file_metadata(api, [apple_episode])
           end
         end
 
@@ -82,11 +82,11 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
     end
   end
 
-  describe ".update_podcast_container_file_metadata" do
+  describe ".probe_source_file_metadata" do
     it "should raise if any of the episodes lack a container" do
       apple_episode.stub(:podcast_container, nil) do
         assert_raises(RuntimeError, "missing podcast container") do
-          Apple::PodcastContainer.update_podcast_container_file_metadata(api, [apple_episode])
+          Apple::PodcastContainer.probe_source_file_metadata(api, [apple_episode])
         end
       end
     end

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -156,33 +156,24 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
       end
     end
 
-    it "should update the source_url and source_file_name" do
+    it "should not update the source_url and source_file_name" do
       apple_episode.stub(:apple_id, apple_episode_id) do
         apple_episode.stub(:audio_asset_vendor_id, apple_audio_asset_vendor_id) do
-          pc1 = nil
-          apple_episode.stub(:enclosure_url, "https://podcast.source/1234") do
-            apple_episode.stub(:enclosure_filename, "1234") do
-              pc1 = Apple::PodcastContainer.upsert_podcast_container(apple_episode,
-                podcast_container_json_row)
-              assert_equal pc1.enclosure_url, "https://podcast.source/1234"
-              assert_nil pc1.source_url
-              assert_equal pc1.source_filename, "1234"
-            end
-          end
+          # It does not touch the source_url or source_filename on create
+          pc1 = Apple::PodcastContainer.upsert_podcast_container(apple_episode,
+            podcast_container_json_row)
+          assert_nil pc1.enclosure_url
+          assert_nil pc1.source_url
+          assert_nil pc1.source_filename
 
-          pc2 = nil
-          apple_episode.stub(:enclosure_url, "https://another.source/5678") do
-            apple_episode.stub(:enclosure_filename, "5678") do
-              pc2 = Apple::PodcastContainer.upsert_podcast_container(apple_episode,
-                podcast_container_json_row)
-            end
-          end
+          pc2 = Apple::PodcastContainer.upsert_podcast_container(apple_episode,
+            podcast_container_json_row)
 
           assert pc1 == pc2
-
-          assert_equal pc2.enclosure_url, "https://another.source/5678"
-          assert_nil pc2.source_url
-          assert_equal pc2.source_filename, "5678"
+          # It does not touch the source_url or source_filename on update
+          assert_nil pc1.enclosure_url
+          assert_nil pc1.source_url
+          assert_nil pc1.source_filename
         end
       end
     end

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -59,7 +59,7 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
     describe ".reset_source_file_metadata" do
       it "needs delivery in order to be reset" do
         apple_episode.podcast_container.stub(:needs_delivery?, false) do
-          Apple::PodcastContainer.reset_source_file_metadata(api, [apple_episode])
+          Apple::PodcastContainer.reset_source_file_metadata([apple_episode])
         end
 
         apple_episode.podcast_container.reload
@@ -69,7 +69,7 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
 
         apple_episode.stub(:enclosure_url, "http://this-is-new") do
           apple_episode.podcast_container.stub(:needs_delivery?, true) do
-            Apple::PodcastContainer.reset_source_file_metadata(api, [apple_episode])
+            Apple::PodcastContainer.reset_source_file_metadata([apple_episode])
           end
         end
 


### PR DESCRIPTION
Fixes a bug where an old (finished) upload was polling for metadata on an expired CDN url.   This sets up a guard, and will only reset and refresh "source" file metadata if needed.