### PR TITLE
Set default description for publishing

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -240,7 +240,7 @@ module Apple
             guid: guid,
             title: feeder_episode.title,
             originalReleaseDate: feeder_episode.published_at.utc.iso8601,
-            description: feeder_episode.description || feeder_episode.subtitle,
+            description: feeder_episode.description_with_default,
             websiteUrl: feeder_episode.url,
             explicit: explicit,
             episodeNumber: feeder_episode.episode_number,

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -281,6 +281,10 @@ class Episode < ApplicationRecord
     self.keywords = keywords.map { |kw| sanitize_keyword(kw, kw.length) }
   end
 
+  def description_with_default
+    description || subtitle || title || ""
+  end
+
   def feeder_cdn_host
     ENV["FEEDER_CDN_HOST"]
   end

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -115,7 +115,7 @@ xml.rss "xmlns:atom" => "http://www.w3.org/2005/Atom",
         xml.title(ep.title)
         xml.pubDate ep.published_at.utc.rfc2822
         xml.link ep.url || ep.enclosure_url(@feed)
-        xml.description { xml.cdata!(ep.description || "") }
+        xml.description { xml.cdata!(ep.description_with_default) }
         # TODO: may not reflect the content_type/file_size of replaced media
         xml.enclosure(url: ep.enclosure_url(@feed), type: ep.media_content_type(@feed), length: ep.media_file_size) if ep.media?
 

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -351,4 +351,30 @@ describe Episode do
       assert e.valid?
     end
   end
+
+  describe "#description_with_default" do
+    let(:episode) { build_stubbed(:episode, description: "description", subtitle: "subtitle", title: "title") }
+
+    it "returns the description if present" do
+      assert_equal "description", episode.description_with_default
+    end
+
+    it "returns the subtitle if description is blank" do
+      episode.description = nil
+      assert_equal "subtitle", episode.description_with_default
+    end
+
+    it "returns the title if description and subtitle are blank" do
+      episode.description = nil
+      episode.subtitle = nil
+      assert_equal "title", episode.description_with_default
+    end
+
+    it "returns an empty string if description, subtitle, and title are blank" do
+      episode.description = nil
+      episode.subtitle = nil
+      episode.title = nil
+      assert_equal "", episode.description_with_default
+    end
+  end
 end


### PR DESCRIPTION
Partially solves https://github.com/PRX/feeder.prx.org/issues/589 by setting up a default.

Sets up a helper method which wraps the subtitle and title as fallback defaults. This is so that the description is not left blank in the RSS feed.  The motivation here is that Apple validates the presence of the description via interactions to their API. So if the feed is consumed by the RSS poller with a blank description, then unrelated API operations can fail with validation errors.