### PR TITLE
Filter out video episodes for Apple episode sync

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -449,6 +449,10 @@ module Apple
       apple_id
     end
 
+    def video_content_type?
+      feeder_episode.video_content_type?
+    end
+
     def podcast_container
       feeder_episode.podcast_container
     end

--- a/app/models/concerns/episode_media.rb
+++ b/app/models/concerns/episode_media.rb
@@ -77,6 +77,10 @@ module EpisodeMedia
     end
   end
 
+  def video_content_type?(*args)
+    media_content_type(*args).starts_with?("video")
+  end
+
   def media_duration
     media.inject(0.0) { |s, c| s + c.duration.to_f } + podcast.try(:duration_padding).to_f
   end


### PR DESCRIPTION
Fixes a case in the subscription sync where a.video episode is in the podcast's feed. Since Apple Podcasts Subscriptions only supports audio content, we need to filter out video content.