### PR TITLE
Pass in the private feed to get the enclosure filename

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -197,7 +197,7 @@ module Apple
     end
 
     def enclosure_filename
-      feeder_episode.enclosure_filename
+      feeder_episode.enclosure_filename(private_feed)
     end
 
     def sync_log

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -249,8 +249,8 @@ class Episode < ApplicationRecord
     EnclosureUrlBuilder.new.podcast_episode_url(podcast, self, feed)
   end
 
-  def enclosure_filename
-    uri = URI.parse(enclosure_url)
+  def enclosure_filename(feed = nil)
+    uri = URI.parse(enclosure_url(feed))
     File.basename(uri.path)
   end
 

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -148,4 +148,23 @@ describe Apple::Episode do
       end
     end
   end
+
+  describe "#enclosure_filename" do
+    let(:episode) { create(:episode_with_media, podcast: podcast) }
+
+    it "should return the filename from the enclosure url" do
+      assert_equal "audio.flac", apple_episode.enclosure_filename
+    end
+
+    it "calls into the episode with the private feed" do
+      expecter = ->(feed) do
+        assert_equal(feed, apple_episode.private_feed)
+      end
+
+      # make sure the episode is called with the private feed
+      apple_episode.feeder_episode.stub(:enclosure_filename, expecter) do
+        apple_episode.enclosure_filename
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes a bug where the enclosure filename was not being properly parameterized by the feed.  Handles the case where the file extensions of the main feed don't match the private feed in Apple publishing.