### PR TITLE
Consistent card groupings

### DIFF
--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -58,7 +58,7 @@
 
 .input-group {
   .invalid-feedback {
-    order: 4;
+    order: 10;
   }
 }
 

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -56,6 +56,12 @@
   }
 }
 
+.input-group {
+  .invalid-feedback {
+    order: 4;
+  }
+}
+
 // material style floating form labels
 .form-floating {
   > label {

--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -24,7 +24,7 @@
 
 <div class="col-12 mb-4">
   <div class="card shadow border-0">
-    <div class="card-header card-header-light d-flex justify-content-between">
+    <div class="card-header card-header-secondary d-flex justify-content-between">
       <h5 class="card-title flex-grow-1"><%= t("helpers.label.episode.description") %></h5>
       <%= help_text t(".help.description") %>
     </div>
@@ -62,7 +62,7 @@
   <div class="form-floating input-group">
     <%= form.number_field :season_number %>
     <%= form.label :season_number %>
-    <%= field_help_text t(".help.season_number") %>>
+    <%= field_help_text t(".help.season_number") %>
   </div>
 </div>
 

--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -24,7 +24,7 @@
 
 <div class="col-12 mb-4">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title flex-grow-1"><%= t("helpers.label.episode.description") %></h5>
       <%= help_text t(".help.description") %>
     </div>

--- a/app/views/episodes/_form_tags.html.erb
+++ b/app/views/episodes/_form_tags.html.erb
@@ -1,6 +1,6 @@
 <div class="col-12 mb-4">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title"><%= t(".title") %></h5>
     </div>
 

--- a/app/views/fake/index.html.erb
+++ b/app/views/fake/index.html.erb
@@ -14,7 +14,7 @@
   <div class="row mt-4 gy-sm-3">
 
     <div class="col-lg-8 d-grid gap-3">
-      <section class="card shadow">
+      <section class="card shadow border-0">
         <header class="card-header position-sticky top-0 d-flex justify-content-between align-items-center bg-white">
           <h2 class="card-title fs-5 fw-bold">Look a card</h2>
           <a href="#" class="btn btn-primary d-flex gap-1 align-items-center">Action <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span></a>
@@ -28,7 +28,7 @@
         </footer>
       </section>
 
-      <section class="card shadow">
+      <section class="card shadow border-0">
         <header class="card-header d-flex justify-content-between align-items-center">
           <h2 class="card-title fs-5 fw-bold">Look another card</h2>
           <a href="#" class="btn btn-icon"><span class="material-icons">delete</span></a>
@@ -44,7 +44,7 @@
     </div>
 
     <div class="col-lg-4 d-grid gap-3">
-      <section class="card shadow">
+      <section class="card shadow border-0">
         <div class="card-header-info">
           <h5 class="card-title fw-bold">Card Title</h5>
         </div>
@@ -79,7 +79,7 @@
         </div>
       </section>
 
-      <div class="card shadow">
+      <div class="card shadow border-0">
         <div class="card-header-success">
           <h5 class="card-title fw-bold">Look a card</h5>
         </div>

--- a/app/views/feeds/_form_ad_zones.html.erb
+++ b/app/views/feeds/_form_ad_zones.html.erb
@@ -1,6 +1,6 @@
 <div class="col-12 mb-4">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title flex-grow-1"><%= t(".title") %></h5>
       <%= help_text t(".help.ad_zones") %>
     </div>

--- a/app/views/feeds/_form_audio_format.html.erb
+++ b/app/views/feeds/_form_audio_format.html.erb
@@ -1,6 +1,6 @@
 <div class="col-12 mb-4" data-controller="toggle-field">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title flex-grow-1"><%= t(".title") %></h5>
       <%= help_text t(".help.audio_format") %>
     </div>

--- a/app/views/feeds/_form_auth.html.erb
+++ b/app/views/feeds/_form_auth.html.erb
@@ -1,6 +1,6 @@
 <div class="col-12 mb-4" data-controller="toggle-field">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title flex-grow-1"><%= t(".title") %></h5>
       <%= help_text t(".help.auth_tokens") %>
     </div>

--- a/app/views/feeds/_form_overrides.html.erb
+++ b/app/views/feeds/_form_overrides.html.erb
@@ -1,6 +1,6 @@
 <div class="col-12 mb-4">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title"><%= t(".title") %></h5>
     </div>
 

--- a/app/views/feeds/_form_status.html.erb
+++ b/app/views/feeds/_form_status.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card shadow border-0">
   <div class="card-header-primary">
     <h5 class="card-title"><%= t(".title") %></h5>
   </div>

--- a/app/views/images/_complete.html.erb
+++ b/app/views/images/_complete.html.erb
@@ -1,4 +1,4 @@
-<div class="card shadow prx-uploads">
+<div class="card shadow border-0 prx-uploads">
   <div class="card-header-info d-flex align-items-center">
     <h5 class="card-title flex-grow-1"><%= t("images.title.#{image.model_name.singular}") %></h5>
 

--- a/app/views/images/_new.html.erb
+++ b/app/views/images/_new.html.erb
@@ -1,4 +1,4 @@
-<div class="card shadow prx-uploads" data-controller="upload" data-upload-disable-outlet="form">
+<div class="card shadow border-0 prx-uploads" data-controller="upload" data-upload-disable-outlet="form">
 
   <div class="card-header-info d-flex align-items-center">
     <h5 class="card-title flex-grow-1"><%= t("images.title.#{image.model_name.singular}") %></h5>

--- a/app/views/images/_processing.html.erb
+++ b/app/views/images/_processing.html.erb
@@ -1,4 +1,4 @@
-<div class="card shadow prx-uploads">
+<div class="card shadow border-0 prx-uploads">
   <div class="card-header-info d-flex justify-content-between align-items-center">
     <h5 class="card-title"><%= t("images.title.#{image.model_name.singular}") %></h5>
 

--- a/app/views/podcast_engagement/show.html.erb
+++ b/app/views/podcast_engagement/show.html.erb
@@ -6,39 +6,45 @@
     <div class="row">
       <div class="col-lg-8">
         <div class="row">
-          <div class="col-12 mb-4 input-group">
-            <div class="form-floating">
-              <%= form.text_field :donation_url %>
-              <%= form.label :donation_url %>
+          <div class="col-12">
+            <div class="input-group mb-4">
+              <div class="form-floating">
+                <%= form.text_field :donation_url %>
+                <%= form.label :donation_url %>
+              </div>
+              <div class="input-group-text">
+                <span class="material-icons">link</span>
+              </div>
             </div>
-            <div class="input-group-text">
-              <span class="material-icons">link</span>
+            
+            <div class="input-group mb-4">
+              <div class="form-floating">
+                <%= form.text_field :payment_pointer %>
+                <%= form.label :payment_pointer %>
+              </div>
+              <div class="input-group-text">
+                <span class="material-icons">link</span>
+              </div>
             </div>
           </div>
         </div>
 
-        <div class="mb-4">
-          <div class="input-group">
-            <div class="form-floating">
-              <%= form.text_field :payment_pointer %>
-              <%= form.label :payment_pointer %>
-            </div>
-            <div class="input-group-text">
-              <span class="material-icons">link</span>
-            </div>
-          </div>
-        </div>
+
       </div>
       <div class="col-lg-4">
-        <div class="card row">
-          <div class="card-header-primary">
-            <h5 class="card-title"><%= t(".status") %></h5>
+        <div class="row">
+          <div class="col-12">
+            <div class="card shadow border-0">
+              <div class="card-header-primary">
+                <h5 class="card-title"><%= t(".status") %></h5>
+              </div>
+              <div class="card-footer">
+                <p class="status-text mb-2"><strong><%= t(".last_saved") %></strong> <br><%= l(@podcast.updated_at) %></p>
+                <%= form.submit t(".save"), class: "btn btn-primary" %>
+              </div>
+            </div>
           </div>
-          <div class="card-footer">
-            <p class="status-text mb-2"><strong><%= t(".last_saved") %></strong> <br><%= l(@podcast.updated_at) %></p>
-            <%= form.submit t(".save"), class: "btn btn-primary" %>
-          </div>
-        </div>
+        </div>  
       </div>
     </div>
   </div>

--- a/app/views/podcast_engagement/show.html.erb
+++ b/app/views/podcast_engagement/show.html.erb
@@ -16,7 +16,7 @@
                 <span class="material-icons">link</span>
               </div>
             </div>
-            
+
             <div class="input-group mb-4">
               <div class="form-floating">
                 <%= form.text_field :payment_pointer %>
@@ -28,7 +28,6 @@
             </div>
           </div>
         </div>
-
 
       </div>
       <div class="col-lg-4">
@@ -44,7 +43,7 @@
               </div>
             </div>
           </div>
-        </div>  
+        </div>
       </div>
     </div>
   </div>

--- a/app/views/podcast_planner/_form_date_calculator.html.erb
+++ b/app/views/podcast_planner/_form_date_calculator.html.erb
@@ -2,7 +2,7 @@
   <div class="card border-light shadow mb-4">
     <div class="card-header-light">
       <%= t(".header.day_select") %>
-    </div>  
+    </div>
     <div class="card-body">
       <div class="form-floating">
         <%= form.select :selected_days, day_options, {include_blank: true}, data: {action: "click#submit"}, multiple: true %>
@@ -80,6 +80,6 @@
           </div>
         </div>
       </div>
-    </div>  
+    </div>
   </div>
 </section>

--- a/app/views/podcast_planner/_form_date_calculator.html.erb
+++ b/app/views/podcast_planner/_form_date_calculator.html.erb
@@ -1,7 +1,9 @@
 <section>
-  <div class="mb-4">
-    <h3 class="mb-3"><%= t(".header.day_select") %></h3>
-    <div class="col-lg-12">
+  <div class="card border-light shadow mb-4">
+    <div class="card-header-light">
+      <%= t(".header.day_select") %>
+    </div>  
+    <div class="card-body">
       <div class="form-floating">
         <%= form.select :selected_days, day_options, {include_blank: true}, data: {action: "click#submit"}, multiple: true %>
         <%= form.label :selected_days %>
@@ -9,66 +11,75 @@
     </div>
   </div>
 
-  <div class="mb-4" data-controller="toggle-field">
-    <h3 class="mb-3"><%= t(".header.week_select") %></h3>
-    <div class="row">
-      <div class="col-lg-6">
-        <div class="form-floating">
-          <%= form.select :week_condition, week_condition_options, {}, data: {action: "toggle-field#displayOnlyThisField click#submit"} %>
-          <%= form.label t(".label.week_condition") %>
-        </div>
-      </div>
-      <div class="col-lg-6">
-        <div class="" data-toggle-field-target="field" field="monthly">
+  <div class="card border-light shadow mb-4">
+    <div class="card-header-light">
+      <%= t(".header.week_select") %>
+    </div>
+
+    <div class="card-body">
+      <div class="row">
+        <div class="col-lg-6">
           <div class="form-floating">
-            <%= form.select :monthly_weeks, monthly_weeks_options, {include_blank: true}, data: {action: "click#submit"}, multiple: true %>
-            <%= form.label t(".label.week_of_month") %>
+            <%= form.select :week_condition, week_condition_options, {}, data: {action: "toggle-field#displayOnlyThisField click#submit"} %>
+            <%= form.label t(".label.week_condition") %>
           </div>
         </div>
-        <div class="d-none" data-toggle-field-target="field" field="periodic">
-          <div class="form-floating">
-            <%= form.select :period, periodic_weeks_options, {}, data: {action: "click#submit"} %>
-            <%= form.label t(".label.period") %>
+        <div class="col-lg-6">
+          <div class="" data-toggle-field-target="field" field="monthly">
+            <div class="form-floating">
+              <%= form.select :monthly_weeks, monthly_weeks_options, {include_blank: true}, data: {action: "click#submit"}, multiple: true %>
+              <%= form.label t(".label.week_of_month") %>
+            </div>
+          </div>
+          <div class="d-none" data-toggle-field-target="field" field="periodic">
+            <div class="form-floating">
+              <%= form.select :period, periodic_weeks_options, {}, data: {action: "click#submit"} %>
+              <%= form.label t(".label.period") %>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="mb-4" data-controller="toggle-field">
-    <h3 class="mb-3"><%= t(".header.range_select") %></h3>
-    <div class="row mb-4">
-      <div class="col-12">
-        <div>
-          <div class="form-floating">
-            <%= form.select :date_range_condition, end_condition_options, {}, data: {action: "toggle-field#displayOnlyThisField click#submit"} %>
-            <%= form.label t(".label.date_range_condition") %>
+  <div class="card border-light shadow mb-4">
+    <div class="card-header-light">
+      <%= t(".header.range_select") %>
+    </div>
+    <div class="card-body">
+      <div class="row mb-4">
+        <div class="col-12">
+          <div>
+            <div class="form-floating">
+              <%= form.select :date_range_condition, end_condition_options, {}, data: {action: "toggle-field#displayOnlyThisField click#submit"} %>
+              <%= form.label t(".label.date_range_condition") %>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-    <div class="row mb-4">
-      <div class="col-lg-6">
-        <div class="form-floating mb-2">
-          <%= form.date_field :start_date, min: DateTime.tomorrow, max: DateTime.tomorrow + 1.years, value: DateTime.tomorrow, data: {action: "click#submit"} %>
-          <%= form.label :start_date %>
+      <div class="row">
+        <div class="col-lg-6">
+          <div class="form-floating mb-2">
+            <%= form.date_field :start_date, min: DateTime.tomorrow, max: DateTime.tomorrow + 1.years, value: DateTime.tomorrow, data: {action: "click#submit"} %>
+            <%= form.label :start_date %>
+          </div>
         </div>
-      </div>
 
-      <div class="col-lg-6">
-        <div data-toggle-field-target="field" field="episodes">
-          <div class="form-floating">
-            <%= form.number_field :number_of_episodes, {min: 1, max: 100, step: 1, value: 10, data: {action: "click#submit"}} %>
-            <%= form.label :number_of_episodes %>
+        <div class="col-lg-6">
+          <div data-toggle-field-target="field" field="episodes">
+            <div class="form-floating">
+              <%= form.number_field :number_of_episodes, {min: 1, max: 100, step: 1, value: 10, data: {action: "click#submit"}} %>
+              <%= form.label :number_of_episodes %>
+            </div>
           </div>
-        </div>
-        <div class="d-none" data-toggle-field-target="field" field="date">
-          <div class="form-floating">
-            <%= form.date_field :end_date, min: DateTime.tomorrow + 1.day, max: DateTime.tomorrow + 2.years, data: {action: "click#submit"} %>
-            <%= form.label :end_date %>
+          <div class="d-none" data-toggle-field-target="field" field="date">
+            <div class="form-floating">
+              <%= form.date_field :end_date, min: DateTime.tomorrow + 1.day, max: DateTime.tomorrow + 2.years, data: {action: "click#submit"} %>
+              <%= form.label :end_date %>
+            </div>
           </div>
         </div>
       </div>
-    </div>
+    </div>  
   </div>
 </section>

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -51,7 +51,7 @@
             <% end %>
           </div>
           <p class="mb-0 fs-6">Key: <span class="badge bg-warning text-dark">Existing Episode Draft</span> <span class="badge bg-primary">New Episode Draft</span></p>
-        </div>  
+        </div>
       </div>
     <% end %>
 

--- a/app/views/podcast_planner/_form_side.html.erb
+++ b/app/views/podcast_planner/_form_side.html.erb
@@ -2,9 +2,11 @@
       url: podcast_planner_path(@podcast),
       method: :post
     ) do |form| %>
-  <div class="mb-4">
-    <h3 class="mb-3"><%= t(".header.publish_time") %></h3>
-    <div class="col-lg-12">
+  <div class="card border-light shadow mb-4">
+    <div class="card-header-light">
+      <%= t(".header.publish_time") %>
+    </div>
+    <div class="card-body">
       <div class="form-floating">
         <%= form.select :publish_time, time_options %>
         <%= form.label :publish_time %>
@@ -12,9 +14,11 @@
     </div>
   </div>
 
-  <div class="mb-4">
-    <h3 class="mb-3"><%= t(".header.audio_segments") %></h3>
-    <div class="col-lg-12">
+  <div class="card border-light shadow mb-4">
+    <div class="card-header-light">
+      <%= t(".header.audio_segments") %>
+    </div>
+    <div class="card-body">
       <div class="form-floating">
         <%= form.number_field :segment_count, {min: 1, max: 10, step: 1, value: 2} %>
         <%= form.label :segment_count %>
@@ -22,13 +26,13 @@
     </div>
   </div>
 
-  <div class="card p-4 mt-4mb-4">
+  <div class="card shadow border-0 mb-4">
     <%= turbo_frame_tag "preview", target: "_top" do %>
       <div data-controller="pager count" data-pager-range-value="6">
-        <div class="d-flex justify-content-between">
-          <h3 class="mb-3"><%= t(".header.number_of_drafts") %>
+        <div class="card-header-light d-flex justify-content-between align-items-center">
+          <span><%= t(".header.number_of_drafts") %>
             <span data-count-target="display"><%= @planner.dates.present? ? @planner.dates.count : "0" %></span>
-          </h3>
+          </span>
           <div class="mb-2">
             <%= button_tag type: "button", class: "btn btn-primary btn-sm", data: {action: "click->pager#pageBackward", pager_target: "prev"}, disabled: true do %>
               <span class="material-icons">arrow_left</span>
@@ -40,13 +44,14 @@
             <% end %>
           </div>
         </div>
+        <div class="card-body">
           <div class="row d-flex flex-wrap gx-4">
             <% 24.times do |i| %>
               <%= render "calendar", form: form, start_date: Date.today.beginning_of_month + i.months, planner: @planner, index: i, range: 6 %>
             <% end %>
           </div>
-        </div>
-        <p class="mb-0 fs-6">Key: <span class="badge bg-warning text-dark">Existing Episode Draft</span> <span class="badge bg-primary">New Episode Draft</span></p>
+          <p class="mb-0 fs-6">Key: <span class="badge bg-warning text-dark">Existing Episode Draft</span> <span class="badge bg-primary">New Episode Draft</span></p>
+        </div>  
       </div>
     <% end %>
 

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -30,7 +30,7 @@
 
 <div class="col-12 mb-4">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title flex-grow-1"><%= t("helpers.label.podcast.description") %></h5>
       <%= help_text t(".help.description") %>
     </div>

--- a/app/views/podcasts/_form_status.html.erb
+++ b/app/views/podcasts/_form_status.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card shadow border-0">
   <div class="card-header-primary">
     <h5 class="card-title"><%= t(".title") %></h5>
   </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -15,7 +15,7 @@
 
   <div class="row my-4">
     <div class="col-lg-4 mb-4 mb-lg-0">
-      <div class="card shadow mb-4">
+      <div class="card shadow border-0 mb-4">
         <div class="card-header d-flex gap-4 align-items-center">
           <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".latest_published" %></h1>
           <%= link_to podcast_episodes_path(@podcast), class: "btn btn-primary btn-sm" do %>
@@ -35,7 +35,7 @@
         </div>
       </div>
 
-      <div class="card shadow">
+      <div class="card shadow border-0">
         <div class="card-header d-flex align-items-center">
           <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".next_scheduled" %></h1>
         </div>
@@ -57,7 +57,7 @@
     </div>
 
     <div class="col-lg-8 d-grid">
-      <div class="card shadow">
+      <div class="card shadow border-0">
         <div class="card-body">
           <p>Metrics Placeholder</p>
         </div>
@@ -68,7 +68,7 @@
 
   <div class="row">
     <div class="col-lg-6 d-grid mb-4 mb-lg-0">
-      <div class="card shadow">
+      <div class="card shadow border-0">
         <div class="card-header d-flex align-items-center">
           <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".feeds" %></h1>
           <%= link_to podcast_feeds_path(@podcast), class: "btn btn-primary btn-sm" do %>
@@ -85,7 +85,7 @@
     </div>
 
     <div class="col-lg-6 d-grid">
-      <div class="card shadow">
+      <div class="card shadow border-0">
         <div class="card-header d-flex align-items-center">
           <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".settings" %></h1>
           <%= link_to edit_podcast_path(@podcast), class: "btn btn-primary btn-sm" do %>


### PR DESCRIPTION
- Uses card headers with no border and a shadow for base cards
- `card-shadow-light` to replace the black (I though the black was too stark), light blue still available for other card headers too.
- Adds cards to the episode planner
- fixes a bug where the `invalid-feedback` message was added before the help text.

In review:
- [ ] Save a blank episode and ensure error state messaging is inline.
