### PR TITLE
Podcast metrics

### DIFF
--- a/app/assets/stylesheets/shared/bootstrap-variables.scss
+++ b/app/assets/stylesheets/shared/bootstrap-variables.scss
@@ -36,7 +36,7 @@ $success: $green;
 $info: $cyan;
 $warning: $yellow;
 $danger: $red;
-$light: $gray-100;
+$light: $gray-200;
 $dark: $gray-900;
 
 $theme-colors: (

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -34,8 +34,8 @@ class PodcastsController < ApplicationController
   def show
     authorize @podcast
 
-    @recently_published = @podcast.episodes.published.first
-    @next_scheduled = @podcast.episodes.draft_or_scheduled.order(:released_at).first
+    @recently_published = @podcast.episodes.published.order(published_at: :desc).limit(3)
+    @next_scheduled = @podcast.episodes.draft_or_scheduled.order(released_at: :asc).limit(3)
 
     @metrics_jwt = prx_jwt
     @metrics_castle_root = castle_root

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -42,7 +42,7 @@ class PodcastsController < ApplicationController
     @metrics_dates = 30.days.ago.utc.to_date..Time.now.utc.to_date
     @metrics_guids, @metrics_titles = published_episodes(@metrics_dates)
 
-    @feeds = @podcast.feeds.order(Arel.sql("slug IS NULL DESC, updated_at DESC")).limit(3)
+    @feeds = @podcast.feeds.order(Arel.sql("slug IS NULL DESC, updated_at DESC"))
   end
 
   # GET /podcasts/new

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -41,6 +41,8 @@ class PodcastsController < ApplicationController
     @metrics_castle_root = castle_root
     @metrics_dates = 30.days.ago.utc.to_date..Time.now.utc.to_date
     @metrics_guids, @metrics_titles = published_episodes(@metrics_dates)
+
+    @feeds = @podcast.feeds.order(Arel.sql("slug IS NULL DESC, updated_at DESC")).limit(3)
   end
 
   # GET /podcasts/new

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -39,7 +39,7 @@ class PodcastsController < ApplicationController
 
     @metrics_jwt = prx_jwt
     @metrics_castle_root = castle_root
-    @metrics_dates = 30.days.ago.utc.to_date..1.day.from_now.utc.to_date
+    @metrics_dates = 30.days.ago.utc.to_date..Time.now.utc.to_date
     @metrics_guids, @metrics_titles = published_episodes(@metrics_dates)
   end
 
@@ -114,8 +114,8 @@ class PodcastsController < ApplicationController
   end
 
   def published_episodes(date_range)
-    data = @podcast.episodes.published.where(published_at: date_range).order(published_at: :asc).pluck(:guid, :title)
-    [data.transpose[0], data.transpose[1]]
+    data = @podcast.episodes.published.where(published_at: date_range.first..).order(published_at: :asc).pluck(:guid, :title)
+    [data.transpose[0] || [], data.transpose[1] || []]
   end
 
   def podcast_params

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -42,7 +42,7 @@ class PodcastsController < ApplicationController
     @metrics_dates = 30.days.ago.utc.to_date..Time.now.utc.to_date
     @metrics_guids, @metrics_titles = published_episodes(@metrics_dates)
 
-    @feeds = @podcast.feeds.order(Arel.sql("slug IS NULL DESC, updated_at DESC"))
+    @feeds = @podcast.feeds.order(Arel.sql("slug IS NULL DESC, created_at ASC"))
   end
 
   # GET /podcasts/new

--- a/app/javascript/controllers/podcast_metrics_controller.js
+++ b/app/javascript/controllers/podcast_metrics_controller.js
@@ -1,6 +1,25 @@
 import { Controller } from "@hotwired/stimulus"
 import Highcharts from "highcharts"
 
+const CONFIG = {
+  chart: { type: "line" },
+  legend: { enabled: false },
+  title: { text: null },
+  yAxis: { title: "Downloads", min: 0, max: 100 },
+  xAxis: {
+    type: "datetime",
+    dateTimeLabelFormats: {
+      day: "%Y-%m-%d",
+      week: "%Y-%m-%d",
+      month: "%Y-%m-%d",
+      year: "%Y-%m-%d",
+    },
+    labels: {
+      rotation: -45,
+    },
+  },
+}
+
 export default class extends Controller {
   static targets = ["chart", "total"]
   static values = {
@@ -13,15 +32,36 @@ export default class extends Controller {
   }
 
   connect() {
-    // Highcharts.chart(this.element, this.configValue)
+    const data = this.datesValue.map((d) => ({ x: new Date(d).getTime(), y: 0 }))
+    const empty = { type: "line", data }
 
-    const from = this.datesValue[0]
-    this.chart(`podcasts/${this.podcastValue}?interval=DAY&from=${from}`)
+    // setup initial/blank series for episodes and podcast
+    CONFIG.series = this.titlesValue.map((name) => ({ ...empty, name }))
+    CONFIG.series.push({ ...empty, name: "Total Downloads" })
+    this.chart = Highcharts.chart(this.chartTarget, CONFIG)
+
+    // load podcast/episode downloads from castle
+    const query = `interval=DAY&from=${this.datesValue[0]}`
+    this.load(`podcasts/${this.podcastValue}/downloads?${query}`, this.chart.series.length - 1, true)
+    this.guidsValue.forEach((guid, index) => {
+      this.load(`episodes/${guid}/downloads?${query}`, index)
+    })
   }
 
-  async chart(path) {
-    console.log("charting", path)
+  async load(path, seriesIndex, isTotal = false) {
     const json = await this.fetchJSON(path)
+    const data = json.downloads.map((d) => [new Date(d[0]).getTime(), d[1]])
+
+    // clear out yAxis max and update series
+    this.chart.yAxis[0].update({ max: null }, false)
+    this.chart.series[seriesIndex].setData(data, false)
+    this.chart.redraw()
+
+    // set total element
+    if (isTotal) {
+      const total = data.map((d) => d[1]).reduce((a, b) => a + b, 0)
+      this.totalTarget.innerHTML = total.toLocaleString()
+    }
   }
 
   fetchJSON(path, token = null) {
@@ -29,13 +69,31 @@ export default class extends Controller {
     const headers = new Headers()
     headers.append("Accept", "application/json")
     headers.append("Authorization", `Bearer ${this.jwtValue}`)
-    return fetch(url, { headers }).then((res) => {
-      if (res.status === 200) {
-        return res.json()
-      } else {
-        console.error(`Failed to load ${url}`, res)
-        return null
+    return fetch(url, { headers }).then(
+      (res) => {
+        if (res.status === 200) {
+          return res.json()
+        } else {
+          const err = new Error(`Got ${res.status} from ${url}`)
+          console.error(err.message, err)
+          this.showError(err)
+          return null
+        }
+      },
+      (err) => {
+        console.error(`Fetch error for ${url}`, err)
+        this.showError(err)
       }
-    })
+    )
+  }
+
+  showError(err) {
+    this.chartTarget.innerHTML = `
+      <div class="alert alert-danger" role="alert">
+        <h3 class="alert-heading">Error</h3>
+        <hr>
+        <p class="mb-0">${err.message}</p>
+      </div>
+    `
   }
 }

--- a/app/javascript/controllers/podcast_metrics_controller.js
+++ b/app/javascript/controllers/podcast_metrics_controller.js
@@ -50,6 +50,9 @@ export default class extends Controller {
 
   async load(path, seriesIndex, isTotal = false) {
     const json = await this.fetchJSON(path)
+    if (!json) {
+      return
+    }
     const data = json.downloads.map((d) => [new Date(d[0]).getTime(), d[1]])
 
     // clear out yAxis max and update series
@@ -77,12 +80,17 @@ export default class extends Controller {
           const err = new Error(`Got ${res.status} from ${url}`)
           console.error(err.message, err)
           this.showError(err)
-          return null
         }
       },
       (err) => {
         console.error(`Fetch error for ${url}`, err)
-        this.showError(err)
+        if (window.location.href.includes("localhost") || window.location.href.includes("127.0.0.1")) {
+          this.showError(
+            new Error("CORS error - you cannot load metrics data using localhost. Switch to https://feeder.prx.test!")
+          )
+        } else {
+          this.showError(err)
+        }
       }
     )
   }

--- a/app/javascript/controllers/podcast_metrics_controller.js
+++ b/app/javascript/controllers/podcast_metrics_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+import Highcharts from "highcharts"
+
+export default class extends Controller {
+  static targets = ["chart", "total"]
+  static values = {
+    castle: String,
+    dates: Array,
+    guids: Array,
+    jwt: String,
+    podcast: Number,
+    titles: Array,
+  }
+
+  connect() {
+    // Highcharts.chart(this.element, this.configValue)
+
+    const from = this.datesValue[0]
+    this.chart(`podcasts/${this.podcastValue}?interval=DAY&from=${from}`)
+  }
+
+  async chart(path) {
+    console.log("charting", path)
+    const json = await this.fetchJSON(path)
+  }
+
+  fetchJSON(path, token = null) {
+    const url = `${this.castleValue}/${path}`
+    const headers = new Headers()
+    headers.append("Accept", "application/json")
+    headers.append("Authorization", `Bearer ${this.jwtValue}`)
+    return fetch(url, { headers }).then((res) => {
+      if (res.status === 200) {
+        return res.json()
+      } else {
+        console.error(`Failed to load ${url}`, res)
+        return null
+      }
+    })
+  }
+}

--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -24,7 +24,7 @@
 
 <div class="col-12 mb-4">
   <div class="card shadow border-0">
-    <div class="card-header card-header-secondary d-flex justify-content-between">
+    <div class="card-header card-header-light d-flex justify-content-between">
       <h5 class="card-title flex-grow-1"><%= t("helpers.label.episode.description") %></h5>
       <%= help_text t(".help.description") %>
     </div>

--- a/app/views/feeds/_tabs.html.erb
+++ b/app/views/feeds/_tabs.html.erb
@@ -3,7 +3,7 @@
     <%= tab_link_to "Default Feed", podcast_feed_path(podcast, podcast.default_feed) %>
 
     <% if @custom_feeds.present? %>
-      <% @custom_feeds.each do |feed| %>
+      <% @custom_feeds.order(created_at: :asc).each do |feed| %>
         <%= tab_link_to feed.title.to_s, podcast_feed_path(@podcast, feed) %>
       <% end %>
     <% end %>

--- a/app/views/podcasts/_podcast.html.erb
+++ b/app/views/podcasts/_podcast.html.erb
@@ -1,4 +1,4 @@
-<div id="<%= dom_id podcast %>" class="d-flex align-items-center flex-fill my-4">
+<div id="<%= dom_id podcast %>" class="d-flex align-items-center flex-fill">
   <div>
     <% if podcast.ready_image %>
       <%= image_tag(podcast.ready_image.url, width: 135, alt: podcast.ready_image.alt_text, class: "d-flex me-4") %>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -25,12 +25,16 @@
         </div>
         <div class="card-body episode-card h-auto border-start-0">
           <% if @recently_published.present? %>
-            <div class="episode-card-info">
-              <p class="episode-card-date"><%= l(@recently_published.published_at, format: :short) %></p>
-              <div class="episode-card-inner">
-                <h2 class="h5 episode-card-title m-0"><%= link_to @recently_published.title, episode_path(@recently_published) %></h2>
+            <% @recently_published.each do |ep| %>
+              <div class="episode-card-info">
+                <p class="episode-card-date"><%= l(ep.published_at, format: :short) %></p>
+                <div class="episode-card-inner">
+                  <h2 class="h5 episode-card-title m-0"><%= link_to ep.title, episode_path(ep) %></h2>
+                </div>
               </div>
-            </div>
+            <% end %>
+          <% else %>
+            <h2 class="text-muted"><%= t(".no_published") %></h2>
           <% end %>
         </div>
       </div>
@@ -41,16 +45,20 @@
         </div>
         <div class="card-body episode-card h-auto border-start-0">
           <% if @next_scheduled.present? %>
-            <div class="episode-card-info">
-              <p class="episode-card-date">
-                <% if @next_scheduled.published_or_released_date.present? %>
-                  <%= l(@next_scheduled.published_or_released_date, format: :short) %>
-                <% end %>
-              </p>
-              <div class="episode-card-inner">
-                <h2 class="h5 episode-card-title"><%= link_to @next_scheduled.title, episode_path(@next_scheduled) %></h2>
+            <% @next_scheduled.each do |ep| %>
+              <div class="episode-card-info">
+                <p class="episode-card-date">
+                  <% if ep.published_or_released_date.present? %>
+                    <%= l(ep.published_or_released_date, format: :short) %>
+                  <% end %>
+                </p>
+                <div class="episode-card-inner">
+                  <h2 class="h5 episode-card-title"><%= link_to ep.title, episode_path(ep) %></h2>
+                </div>
               </div>
-            </div>
+            <% end %>
+          <% else %>
+            <h2 class="text-muted"><%= t(".no_scheduled") %></h2>
           <% end %>
         </div>
       </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -115,7 +115,9 @@
         </div>
         <div class="card-body">
           <ul class="list-group list-group-flush">
-            <li class="list-group-item p-0"><%= link_to (t ".default_feed"), podcast_feed_path(@podcast, @podcast.default_feed) %></li>
+            <% @feeds.each do |feed| %>
+              <li class="list-group-item border-bottom-0 p-0"><%= link_to feed.default? ? t(".default_feed") : feed.title, podcast_feed_path(@podcast, feed) %></li>
+            <% end %>
           </ul>
         </div>
       </div>
@@ -126,14 +128,15 @@
         <div class="card-header d-flex align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".settings" %></h2>
           <%= link_to edit_podcast_path(@podcast), class: "btn btn-primary btn-sm" do %>
-            <%= t ".manage_settings" %>
+            <%= t(".manage_settings") %>
             <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>
           <% end %>
         </div>
         <div class="card-body">
           <ul class="list-group list-group-flush">
-            <li class="list-group-item border-bottom-0 p-0"><%= link_to (t ".engagement_settings"), podcast_engagement_path(@podcast) %></li>
-            <li class="list-group-item p-0"><%= link_to (t ".import"), podcast_imports_path(@podcast) %></li>
+            <li class="list-group-item border-bottom-0 p-0"><%= link_to t(".engagement_settings"), podcast_engagement_path(@podcast) %></li>
+            <li class="list-group-item border-bottom-0 p-0"><%= link_to t(".player"), podcast_player_path(@podcast) %></li>
+            <li class="list-group-item border-bottom-0 p-0"><%= link_to t(".import"), podcast_imports_path(@podcast) %></li>
           </ul>
         </div>
       </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -81,7 +81,7 @@
               </h3>
               <h3 class="text-center flex-fill border-start border-bottom py-2">
                 <span class="h1"><%= @metrics_guids.size %></span><br>
-                <span class="text-uppercase h6"><%= pluralize @metrics_guids.size, t(".published_episodes") %>
+                <span class="text-uppercase h6"><%= t(".published_episodes").pluralize(@metrics_guids.size) %>
                 </span>
               </h3>
             </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -35,7 +35,6 @@
         </div>
       </div>
 
-
       <div class="card shadow border-0 flex-fill">
         <div class="card-header d-flex align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".next_scheduled" %></h2>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -17,7 +17,7 @@
     <div class="col-lg-4 mb-4 mb-lg-0">
       <div class="card shadow mb-4">
         <div class="card-header d-flex gap-4 align-items-center">
-          <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".latest_published" %></h1>
+          <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".latest_published" %></h2>
           <%= link_to podcast_episodes_path(@podcast), class: "btn btn-primary btn-sm" do %>
             <%= t ".all_episodes" %>
             <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>
@@ -37,7 +37,7 @@
 
       <div class="card shadow">
         <div class="card-header d-flex align-items-center">
-          <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".next_scheduled" %></h1>
+          <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".next_scheduled" %></h2>
         </div>
         <div class="card-body episode-card h-auto border-start-0">
           <% if @next_scheduled.present? %>
@@ -58,7 +58,7 @@
 
     <% if current_user_app?("metrics") %>
       <div class="col-lg-8 d-grid">
-        <div class="card shadow mb-4"
+        <div class="card shadow"
              data-controller="podcast-metrics"
              data-podcast-metrics-castle-value="<%= @metrics_castle_root %>"
              data-podcast-metrics-dates-value="<%= @metrics_dates.to_a.to_json %>"
@@ -67,7 +67,7 @@
              data-podcast-metrics-podcast-value="<%= @podcast.id %>"
              data-podcast-metrics-titles-value="<%= @metrics_titles.to_json %>">
           <div class="card-header d-flex gap-4 align-items-center">
-            <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t(".last_30") %></h1>
+            <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t(".last_30") %></h2>
             <%= link_to "#{current_user_app("metrics")}/#{@podcast.id}", class: "btn btn-primary btn-sm" do %>
               <%= t(".view_metrics") %>
               <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>
@@ -98,7 +98,7 @@
     <div class="col-lg-6 d-grid mb-4 mb-lg-0">
       <div class="card shadow">
         <div class="card-header d-flex align-items-center">
-          <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".feeds" %></h1>
+          <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".feeds" %></h2>
           <%= link_to podcast_feeds_path(@podcast), class: "btn btn-primary btn-sm" do %>
             <%= t ".manage_feeds" %>
             <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>
@@ -115,7 +115,7 @@
     <div class="col-lg-6 d-grid">
       <div class="card shadow">
         <div class="card-header d-flex align-items-center">
-          <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t ".settings" %></h1>
+          <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".settings" %></h2>
           <%= link_to edit_podcast_path(@podcast), class: "btn btn-primary btn-sm" do %>
             <%= t ".manage_settings" %>
             <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -83,11 +83,9 @@
                 <%= pluralize @metrics_guids.size, t(".published_episodes") %>
               </h1>
             </div>
-            <div class="d-flex justify-content-center" data-podcast-metrics-target="chart">
-              <div class="m-4">
-                <div class="spinner-border text-primary ms-2" role="status">
-                  <span class="visually-hidden"><%= t(".loading") %></span>
-                </div>
+            <div class="d-flex justify-content-center align-items-center" data-podcast-metrics-target="chart" style="min-height: 400px">
+              <div class="spinner-border text-primary ms-2" role="status">
+                <span class="visually-hidden"><%= t(".loading") %></span>
               </div>
             </div>
           </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -56,14 +56,44 @@
       </div>
     </div>
 
-    <div class="col-lg-8 d-grid">
-      <div class="card shadow">
-        <div class="card-body">
-          <p>Metrics Placeholder</p>
+    <% if current_user_app?("metrics") %>
+      <div class="col-lg-8 d-grid">
+        <div class="card shadow mb-4"
+             data-controller="podcast-metrics"
+             data-podcast-metrics-castle-value="<%= @metrics_castle_root %>"
+             data-podcast-metrics-dates-value="<%= @metrics_dates.to_a.to_json %>"
+             data-podcast-metrics-guids-value="<%= @metrics_guids.to_json %>"
+             data-podcast-metrics-jwt-value="<%= @metrics_jwt %>"
+             data-podcast-metrics-podcast-value="<%= @podcast.id %>"
+             data-podcast-metrics-titles-value="<%= @metrics_titles.to_json %>">
+          <div class="card-header d-flex gap-4 align-items-center">
+            <h1 class="h5 episode-card-title fw-bold flex-fill"><%= t(".last_30") %></h1>
+            <%= link_to "#{current_user_app("metrics")}/#{@podcast.id}", class: "btn btn-primary btn-sm" do %>
+              <%= t(".view_metrics") %>
+              <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>
+            <% end %>
+          </div>
+          <div class="card-body episode-card h-auto border-start-0">
+            <div class="d-flex justify-content-evenly">
+              <h1>
+                <span data-podcast-metrics-target="total">&mdash;</span>
+                <%= t(".total_downloads") %>
+              </h1>
+              <h1>
+                <%= pluralize @metrics_guids.size, t(".published_episodes") %>
+              </h1>
+            </div>
+            <div class="d-flex justify-content-center" data-podcast-metrics-target="chart">
+              <div class="m-4">
+                <div class="spinner-border text-primary ms-2" role="status">
+                  <span class="visually-hidden"><%= t(".loading") %></span>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
-
-    </div>
+    <% end %>
   </div>
 
   <div class="row">

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -14,8 +14,8 @@
   </div>
 
   <div class="row my-4">
-    <div class="col-lg-4 mb-4 mb-lg-0">
-      <div class="card shadow mb-4">
+    <div class="d-flex flex-column col-lg-4 mb-4 mb-lg-0">
+      <div class="card shadow mb-4 flex-fill">
         <div class="card-header d-flex gap-4 align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".latest_published" %></h2>
           <%= link_to podcast_episodes_path(@podcast), class: "btn btn-primary btn-sm" do %>
@@ -35,7 +35,7 @@
         </div>
       </div>
 
-      <div class="card shadow">
+      <div class="card shadow flex-fill">
         <div class="card-header d-flex align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".next_scheduled" %></h2>
         </div>
@@ -73,17 +73,19 @@
               <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>
             <% end %>
           </div>
-          <div class="card-body episode-card h-auto border-start-0">
+          <div class="card-body p-0 episode-card h-auto border-start-0">
             <div class="d-flex justify-content-evenly">
-              <h1>
-                <span data-podcast-metrics-target="total">&mdash;</span>
-                <%= t(".total_downloads") %>
-              </h1>
-              <h1>
-                <%= pluralize @metrics_guids.size, t(".published_episodes") %>
-              </h1>
+              <h3 class="text-center flex-fill border-bottom py-2">
+                <span class="h1" data-podcast-metrics-target="total">&mdash;</span><br>
+                <span class="text-uppercase h6"><%= t(".total_downloads") %></span>
+              </h3>
+              <h3 class="text-center flex-fill border-start border-bottom py-2">
+                <span class="h1"><%= @metrics_guids.size %></span><br>
+                <span class="text-uppercase h6"><%= pluralize @metrics_guids.size, t(".published_episodes") %>
+                </span>
+              </h3>
             </div>
-            <div class="d-flex justify-content-center align-items-center" data-podcast-metrics-target="chart" style="min-height: 400px">
+            <div class="d-flex justify-content-center align-items-center p-4" data-podcast-metrics-target="chart" style="min-height: 300px">
               <div class="spinner-border text-primary ms-2" role="status">
                 <span class="visually-hidden"><%= t(".loading") %></span>
               </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -16,17 +16,17 @@
   <div class="row my-4">
     <div class="d-flex flex-column col-lg-4 mb-4 mb-lg-0">
       <div class="card shadow border-0 mb-4 flex-fill">
-        <div class="card-header d-flex gap-4 align-items-center">
+        <div class="card-header-primary d-flex gap-4 align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".latest_published" %></h2>
-          <%= link_to podcast_episodes_path(@podcast), class: "btn btn-primary btn-sm" do %>
+          <%= link_to podcast_episodes_path(@podcast), class: "btn btn-light btn-sm" do %>
             <%= t ".all_episodes" %>
             <span class="material-icons" aria-label="hidden">keyboard_arrow_right</span>
           <% end %>
         </div>
-        <div class="card-body episode-card h-auto border-start-0">
+        <div class="card-body episode-card mb-0 h-auto border-start-0 p-0 d-flex flex-column">
           <% if @recently_published.present? %>
             <% @recently_published.each do |ep| %>
-              <div class="episode-card-info">
+              <div class="episode-card-info flex-fill px-3 py-2 border-bottom">
                 <p class="episode-card-date"><%= l(ep.published_at, format: :short) %></p>
                 <div class="episode-card-inner">
                   <h2 class="h5 episode-card-title m-0"><%= link_to ep.title, episode_path(ep) %></h2>
@@ -34,19 +34,19 @@
               </div>
             <% end %>
           <% else %>
-            <h2 class="text-muted"><%= t(".no_published") %></h2>
+            <h2 class="text-muted text-center m-2"><%= t(".no_published") %></h2>
           <% end %>
         </div>
       </div>
 
       <div class="card shadow border-0 flex-fill">
-        <div class="card-header d-flex align-items-center">
+        <div class="card-header-warning d-flex align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".next_scheduled" %></h2>
         </div>
-        <div class="card-body episode-card h-auto border-start-0">
+        <div class="card-body episode-card mb-0 h-auto border-start-0 p-0 d-flex flex-column">
           <% if @next_scheduled.present? %>
             <% @next_scheduled.each do |ep| %>
-              <div class="episode-card-info">
+              <div class="episode-card-info flex-fill px-3 py-2 border-bottom">
                 <p class="episode-card-date">
                   <% if ep.published_or_released_date.present? %>
                     <%= l(ep.published_or_released_date, format: :short) %>
@@ -58,7 +58,7 @@
               </div>
             <% end %>
           <% else %>
-            <h2 class="text-muted"><%= t(".no_scheduled") %></h2>
+            <p class="text-muted text-center m-2"><%= t(".no_scheduled") %></p>
           <% end %>
         </div>
       </div>
@@ -74,7 +74,7 @@
              data-podcast-metrics-jwt-value="<%= @metrics_jwt %>"
              data-podcast-metrics-podcast-value="<%= @podcast.id %>"
              data-podcast-metrics-titles-value="<%= @metrics_titles.to_json %>">
-          <div class="card-header d-flex gap-4 align-items-center">
+          <div class="card-header-light d-flex gap-4 align-items-center">
             <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t(".last_30") %></h2>
             <%= link_to "#{current_user_app("metrics")}/#{@podcast.id}", class: "btn btn-primary btn-sm" do %>
               <%= t(".view_metrics") %>
@@ -106,7 +106,7 @@
   <div class="row">
     <div class="col-lg-6 d-grid mb-4 mb-lg-0">
       <div class="card shadow border-0">
-        <div class="card-header d-flex align-items-center">
+        <div class="card-header-light d-flex align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".feeds" %></h2>
           <%= link_to podcast_feeds_path(@podcast), class: "btn btn-primary btn-sm" do %>
             <%= t ".manage_feeds" %>
@@ -125,7 +125,7 @@
 
     <div class="col-lg-6 d-grid">
       <div class="card shadow border-0">
-        <div class="card-header d-flex align-items-center">
+        <div class="card-header-light d-flex align-items-center">
           <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t ".settings" %></h2>
           <%= link_to edit_podcast_path(@podcast), class: "btn btn-primary btn-sm" do %>
             <%= t(".manage_settings") %>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -81,8 +81,7 @@
               </h3>
               <h3 class="text-center flex-fill border-start border-bottom py-2">
                 <span class="h1"><%= @metrics_guids.size %></span><br>
-                <span class="text-uppercase h6"><%= t(".published_episodes").pluralize(@metrics_guids.size) %>
-                </span>
+                <span class="text-uppercase h6"><%= t(".published_episodes").pluralize(@metrics_guids.size) %></span>
               </h3>
             </div>
             <div class="d-flex justify-content-center align-items-center p-4" data-podcast-metrics-target="chart" style="min-height: 300px">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -36,3 +36,4 @@ pin "convert-string" # @0.1.0
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin_all_from "app/javascript/custom", under: "custom"
 pin_all_from "app/javascript/util", under: "util"
+pin "highcharts", to: "https://ga.jspm.io/npm:highcharts@11.1.0/highcharts.js"

--- a/config/initializers/prx_auth.rb
+++ b/config/initializers/prx_auth.rb
@@ -5,5 +5,5 @@ PrxAuth::Rails.configure do |config|
   config.namespace = :feeder
   config.id_host = ENV["ID_HOST"]
   config.prx_client_id = ENV["PRX_CLIENT_ID"]
-  config.prx_scope = "feeder:*"
+  config.prx_scope = "feeder:* castle:*"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,6 +385,8 @@ en:
       manage_feeds: Manage Feeds
       manage_settings: Manage Settings
       next_scheduled: Next Scheduled or Draft
+      no_published: No Published Episodes
+      no_scheduled: No Scheduled Episodes
       published_episodes: Published Episode
       settings: Settings
       total_downloads: Total Downloads

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,16 +374,21 @@ en:
       error: Unable to save
       notice: Podcast updated
     show:
-      latest_published: Latest Published
       all_episodes: All Episodes
-      next_scheduled: Next Scheduled or Draft
-      feeds: Feeds
-      manage_feeds: Manage Feeds
       default_feed: Default RSS Feed
-      settings: Settings
-      manage_settings: Manage Settings
       engagement_settings: Engagement Settings
+      feeds: Feeds
       import: Import
+      last_30: Last 30 Days
+      latest_published: Latest Published
+      loading: Loading...
+      manage_feeds: Manage Feeds
+      manage_settings: Manage Settings
+      next_scheduled: Next Scheduled or Draft
+      published_episodes: Published Episodes
+      settings: Settings
+      total_downloads: Total Downloads
+      view_metrics: View Metrics
     podcast_page:
       my_podcasts: My Podcasts
       drafted_episodes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -387,6 +387,7 @@ en:
       next_scheduled: Next Scheduled or Draft
       no_published: No Published Episodes
       no_scheduled: No Scheduled Episodes
+      player: Embeddable Player
       published_episodes: Published Episode
       settings: Settings
       total_downloads: Total Downloads

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -385,7 +385,7 @@ en:
       manage_feeds: Manage Feeds
       manage_settings: Manage Settings
       next_scheduled: Next Scheduled or Draft
-      published_episodes: Published Episodes
+      published_episodes: Published Episode
       settings: Settings
       total_downloads: Total Downloads
       view_metrics: View Metrics

--- a/env-example
+++ b/env-example
@@ -40,6 +40,7 @@ PRX_CLIENT_ID=
 PRX_SECRET=
 
 # prx hosts
+CASTLE_HOST=castle.staging.prx.tech
 CMS_HOST=cms.staging.prx.tech
 DOVETAIL_HOST=dovetail.staging.prxu.org
 FEEDER_HOST=feeder.staging.prx.tech


### PR DESCRIPTION
Adds highcharts to display Castle data on `podcasts#show`.

![image](https://github.com/PRX/feeder.prx.org/assets/1410587/4fad6552-7b4f-4ddf-a951-08fa208243e8)

To make this work locally, you need to:

- Add the new `CASTLE_HOST=castle.staging.prx.tech` to your `.env`
- Have [puma-dev installed/running](https://github.com/PRX/internal/wiki/Guide%3A-Local-Development-Environment#install-puma-dev)
- `echo 3002 > ~/.puma-dev/feeder.prx`
- Change your `PRX_CLIENT_ID` and `PRX_CLIENT_SECRET` to a client app for `.test` (`x55P20kzJzy4xnZjm4J5wxRnhJWtG0tpgUwo71EA` is setup for `https://feeder.prx.test` in ID staging)
- Open your browser to `https://feeder.prx.test/podcasts`