### PR TITLE
Episode distributions card

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,10 @@ class ApplicationController < ActionController::Base
     redirect_to PrxAuth::Rails::Engine.routes.url_helpers.new_sessions_path
   end
 
+  def nilify(p)
+    p.transform_values { |v| v.present? ? v : nil }
+  end
+
   protected
 
   def user_not_authorized(exception)

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -112,7 +112,7 @@ class EpisodesController < ApplicationController
   end
 
   def episode_params
-    params.fetch(:episode, {}).permit(
+    nilify params.fetch(:episode, {}).permit(
       :title,
       :clean_title,
       :subtitle,
@@ -129,6 +129,9 @@ class EpisodesController < ApplicationController
       :ad_breaks,
       :released_at,
       :publishing_status,
+      :url,
+      :item_guid,
+      :original_guid,
       categories: [],
       contents_attributes: %i[id position original_url file_size _destroy _retry],
       images_attributes: %i[id original_url size alt_text caption credit _destroy _retry],

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,6 +55,14 @@ module ApplicationHelper
 
   def field_link(href)
     link_to href, class: "input-group-text prx-help", target: :_blank do
+      tag.span "open_in_new", class: "material-icons"
+    end
+  end
+
+  def field_copy(content)
+    data = {controller: "clipboard", clipboard_copy_value: content, clipboard_tooltip_value: t("helpers.application.field_copy_tooltip")}
+
+    tag.button class: "input-group-text prx-help", data: data do
       tag.span "link", class: "material-icons"
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
 
   def field_link(href)
     link_to href, class: "input-group-text prx-help", target: :_blank do
-      tag.span "open_in_new", class: "material-icons"
+      tag.span "open_in_new", class: "material-icons text-primary"
     end
   end
 
@@ -63,7 +63,7 @@ module ApplicationHelper
     data = {controller: "clipboard", clipboard_copy_value: content, clipboard_tooltip_value: t("helpers.application.field_copy_tooltip")}
 
     tag.button class: "input-group-text prx-help", data: data do
-      tag.span "link", class: "material-icons"
+      tag.span "link", class: "material-icons text-primary"
     end
   end
 end

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -1,0 +1,21 @@
+module EmbedPlayerHelper
+  include PrxAccess
+
+  EMBED_PLAYER_PATH = "/e"
+  EMBED_PLAYER_FEED = "uf"
+  EMBED_PLAYER_GUID = "ge"
+
+  def embed_player_episode_url(ep, preview = false)
+    if preview && !episode.published?
+      # TODO: private token auth url
+    else
+      embed_params(EMBED_PLAYER_FEED => ep.podcast_feed_url, EMBED_PLAYER_GUID => ep.item_guid)
+    end
+  end
+
+  private
+
+  def embed_params(params)
+    "#{play_root}#{EMBED_PLAYER_PATH}?#{params.to_query}"
+  end
+end

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -1,0 +1,28 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { copy: String, tooltip: String }
+
+  connect() {
+    this.element.dataset.action = "clipboard#copy"
+    this.tip = new bootstrap.Tooltip(this.element, { title: this.tooltipValue })
+    this.tip.disable()
+  }
+
+  disconnect() {
+    this.tip.dispose()
+  }
+
+  copy(event) {
+    event.preventDefault()
+    navigator.clipboard.writeText(this.copyValue)
+
+    // briefly show "copied" tooltip
+    this.tip.enable()
+    this.tip.show()
+    setTimeout(() => {
+      this.tip.hide()
+      this.tip.disable()
+    }, 1000)
+  }
+}

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -39,7 +39,8 @@ class Episode < ApplicationRecord
 
   validates :podcast_id, :guid, presence: true
   validates :title, presence: true
-  validates :original_guid, uniqueness: {scope: :podcast_id, allow_nil: true}
+  validates :original_guid, presence: true, uniqueness: {scope: :podcast_id}, allow_nil: true
+  alias_error_messages :item_guid, :original_guid
   validates :itunes_type, inclusion: {in: VALID_ITUNES_TYPES}
   validates :episode_number, numericality: {only_integer: true}, allow_nil: true
   validates :season_number, numericality: {only_integer: true}, allow_nil: true
@@ -180,7 +181,7 @@ class Episode < ApplicationRecord
   end
 
   def item_guid=(new_guid)
-    self.original_guid = new_guid
+    self.original_guid = new_guid.blank? ? nil : new_guid
   end
 
   def medium=(new_medium)
@@ -226,7 +227,7 @@ class Episode < ApplicationRecord
   end
 
   def podcast_feed_url
-    podcast&.url || podcast&.published_url
+    podcast&.public_url
   end
 
   def base_published_url

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -89,11 +89,7 @@ class Feed < ApplicationRecord
   end
 
   def public_url
-    if private? || url.blank?
-      published_url
-    else
-      url
-    end
+    url.present? ? url : published_url
   end
 
   def published_path

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -88,6 +88,14 @@ class Feed < ApplicationRecord
     end
   end
 
+  def public_url
+    if private? || url.blank?
+      published_url
+    else
+      url
+    end
+  end
+
   def published_path
     default? ? file_name : "#{slug}/#{file_name}"
   end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -1,7 +1,7 @@
 require "text_sanitizer"
 
 class Podcast < ApplicationRecord
-  FEED_ATTRS = %i[subtitle description summary url new_feed_url display_episodes_count display_full_episodes_count enclosure_prefix enclosure_template feed_image itunes_image ready_feed_image ready_itunes_image ready_image]
+  FEED_ATTRS = %i[subtitle description summary url public_url new_feed_url display_episodes_count display_full_episodes_count enclosure_prefix enclosure_template feed_image itunes_image ready_feed_image ready_itunes_image ready_image]
   FEED_GETTERS = FEED_ATTRS.map { |s| [s, "#{s}_was".to_sym, "#{s}_changed?".to_sym] }.flatten
   FEED_SETTERS = FEED_ATTRS.map { |s| "#{s}=".to_sym }
 

--- a/app/views/episodes/_form_distribution.html.erb
+++ b/app/views/episodes/_form_distribution.html.erb
@@ -30,12 +30,14 @@
 
     <div class="col-12 mb-4">
       <div class="form-floating input-group">
-        <% url = embed_player_episode_url(episode) %>
-        <%= form.text_field :embed_player_url, value: url, disabled: true %>
-        <%= form.label :embed_player_url %>
-        <% if url.present? %>
-          <%= field_link url %>
-          <%= field_copy url %>
+        <% if episode.persisted? %>
+          <%= form.text_field :embed_player_url, value: embed_player_episode_url(episode), disabled: true %>
+          <%= form.label :embed_player_url %>
+          <%= field_link embed_player_episode_url(episode) %>
+          <%= field_copy embed_player_episode_url(episode) %>
+        <% else %>
+          <%= form.text_field :embed_player_url, value: t(".embed_player_not_ready"), disabled: true %>
+          <%= form.label :embed_player_url %>
         <% end %>
       </div>
     </div>

--- a/app/views/episodes/_form_distribution.html.erb
+++ b/app/views/episodes/_form_distribution.html.erb
@@ -3,6 +3,55 @@
     <h5 class="card-title"><%= t(".title") %></h5>
   </div>
   <div class="card-body">
-    <p>tktktk</p>
+
+    <div class="col-12 mb-4">
+      <div class="form-floating input-group">
+        <% if episode.media_ready? %>
+          <%= form.text_field :enclosure_url, value: episode.enclosure_url, disabled: true %>
+          <%= form.label :enclosure_url %>
+          <%= field_copy episode.enclosure_url %>
+        <% else %>
+          <%= form.text_field :enclosure_url, value: t(".enclosure_not_ready"), disabled: true %>
+          <%= form.label :enclosure_url %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="col-12 mb-4">
+      <div class="form-floating input-group">
+        <%= form.text_field :url %>
+        <%= form.label :url %>
+        <% if episode.url.present? %>
+          <%= field_link episode.url %>
+          <%= field_copy episode.url %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="col-12 mb-4">
+      <div class="form-floating input-group">
+        <% url = embed_player_episode_url(episode) %>
+        <%= form.text_field :embed_player_url, value: url, disabled: true %>
+        <%= form.label :embed_player_url %>
+        <% if url.present? %>
+          <%= field_link url %>
+          <%= field_copy url %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="col-12 mb-4">
+      <div class="form-floating input-group">
+        <% if episode.persisted? %>
+          <%= form.text_field :item_guid %>
+          <%= form.label :item_guid %>
+          <%= field_copy episode.item_guid %>
+        <% else %>
+          <%= form.text_field :original_guid %>
+          <%= form.label :original_guid %>
+        <% end %>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/app/views/episodes/_form_status.html.erb
+++ b/app/views/episodes/_form_status.html.erb
@@ -1,4 +1,4 @@
-<div class="card shadow border-0">
+<div class="card shadow border-0 mb-2">
   <div class="card-header-<%= episode_status_class(episode) %>">
     <h5 class="card-title"><%= t(".title_#{episode.publishing_status_was}") %></h5>
   </div>

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -40,7 +40,7 @@ xml.rss "xmlns:atom" => "http://www.w3.org/2005/Atom",
       end
     end
 
-    xml.atom :link, href: (@feed.url || @feed.published_url), rel: "self", type: "application/rss+xml"
+    xml.atom :link, href: @feed.public_url, rel: "self", type: "application/rss+xml"
 
     unless @feed.new_feed_url.blank?
       xml.itunes :"new-feed-url", @feed.new_feed_url

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -160,6 +160,7 @@ en:
     form:
       confirm: Discard unsaved changes?
     form_distribution:
+      embed_player_not_ready: Episode Not Saved
       enclosure_not_ready: No Media Files Uploaded
       title: Distribution
     form_main:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,8 @@ en:
               less_than_or_equal_to: Enter a number less than %{count}
   # form/model helpers
   helpers:
+    application:
+      field_copy_tooltip: Copied!
     label:
       episode:
         ad_breaks: How many ad breaks are there in this episode?
@@ -57,11 +59,14 @@ en:
         categories: Categories
         clean_title: Clean Title
         description: Description
+        embed_player_url: Embeddable Player Link
+        enclosure_url: Media Link
         episode_number: Episode Number
         explicit: Explicit
         explicits:
           false: Clean
           true: Explicit
+        item_guid: GUID
         itunes_type: Episode Type
         itunes_types:
           full: Full
@@ -72,6 +77,7 @@ en:
           audio: Audio - upload multiple audio files
           uncut: Audio - upload a single file and then segment
           video: Video
+        original_guid: GUID
         released_at: Dropdate
         production_notes: Production Notes
         publishing_status: Status
@@ -83,6 +89,7 @@ en:
         segment_count: Number of Segments
         subtitle: Subtitle
         title: Title
+        url: Episode URL
       feed:
         audio_type: Format
         audio_bitrate: Bitrate
@@ -153,6 +160,7 @@ en:
     form:
       confirm: Discard unsaved changes?
     form_distribution:
+      enclosure_not_ready: No Media Files Uploaded
       title: Distribution
     form_main:
       help:

--- a/env-example
+++ b/env-example
@@ -47,6 +47,7 @@ FEEDER_HOST=feeder.staging.prx.tech
 FEEDER_CDN_HOST=f-staging.prxu.org
 FEEDER_CDN_PRIVATE_HOST=p.staging.prxu.org
 ID_HOST=id.staging.prx.tech
+PLAY_HOST=play.staging.prx.tech
 PRX_HOST=beta.staging.prx.tech
 
 # RSS settings

--- a/lib/prx_access.rb
+++ b/lib/prx_access.rb
@@ -114,6 +114,10 @@ module PrxAccess
     root_uri ENV["ID_HOST"]
   end
 
+  def play_root
+    root_uri ENV["PLAY_HOST"]
+  end
+
   private
 
   def method_missing(method, *args)


### PR DESCRIPTION
Fixes #633.  Fills in the Episode distribution card.

State of this form varies a bit based on episode state (new, is media uploaded, etc).

This _does not_ do the magic for "previewing" an embed-player before the episode publishes.  But I think that's the right call for this component.