### PR TITLE
Fix destroy through relations

### DIFF
--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -34,9 +34,7 @@ module Apple
 
         # Back to DTR to pick up fresh arrangements:
         container.reset_source_metadata!(episode)
-
-        # mark them for re-upload
-        container.podcast_deliveries.destroy_all
+        episode.feeder_episode.apple_mark_for_reupload!
       end.compact
     end
 

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -222,7 +222,7 @@ class Episode < ApplicationRecord
   end
 
   def publish!
-    # apple_mark_for_reupload!
+    apple_mark_for_reupload!
     podcast&.publish!
   end
 

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -218,7 +218,9 @@ class Episode < ApplicationRecord
   end
 
   def apple_mark_for_reupload!
-    apple_podcast_deliveries.destroy_all
+    apple_podcast_deliveries.map(&:destroy)
+    apple_podcast_deliveries.reset
+    apple_podcast_container&.podcast_deliveries&.reset
   end
 
   def publish!

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -377,4 +377,22 @@ describe Episode do
       assert_equal "", episode.description_with_default
     end
   end
+
+  describe "#publish!" do
+    let(:episode) { create(:episode) }
+    let(:container) { create(:apple_podcast_container, episode: episode) }
+    let(:delivery) { create(:apple_podcast_delivery, episode: episode, podcast_container: container) }
+
+    before do
+      assert_equal [delivery], episode.apple_podcast_deliveries
+    end
+
+    it "destroys any existing apple podcast deliveries" do
+      refute_empty container.podcast_deliveries
+      refute_empty episode.apple_podcast_deliveries
+      episode.publish!
+      assert_empty episode.apple_podcast_deliveries
+      assert_empty container.podcast_deliveries
+    end
+  end
 end

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -394,5 +394,15 @@ describe Episode do
       assert_empty episode.apple_podcast_deliveries
       assert_empty container.podcast_deliveries
     end
+
+    it "can be called for an episode without a container" do
+      delivery.destroy!
+      container.destroy!
+      episode.reload
+
+      assert_empty episode.apple_podcast_deliveries
+      episode.publish!
+      assert_empty episode.apple_podcast_deliveries
+    end
   end
 end


### PR DESCRIPTION
Fixes a bug where the call to `delete_all` via a `has_many through: ..` throws an ORM exception.

This unifies the code paths in the episode publish method with the metadata reset in the Apple::PodcastContainer class method.

Touches on https://github.com/PRX/feeder.prx.org/issues/685 where the assumption is that if we have _missing_ local copies of the podcast delivery apple data, we intend to re-upload.  The presence of the local podcast deliveries metadata indicates that _we_ have records of doing the uploads, even if [Apple discards them](https://github.com/PRX/feeder.prx.org/issues/680)