### PR TITLE
Field change confirmations

### DIFF
--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -157,6 +157,25 @@
   }
 }
 
+// slightly different layout for checkboxes with help text
+.form-check {
+  .form-check-input.is-changed:not(.is-invalid) {
+    border-color: $orange;
+
+    &:focus {
+      box-shadow: 0 0 $input-btn-focus-blur $input-btn-focus-width rgba($orange, $input-btn-focus-color-opacity);
+    }
+
+    &:checked {
+      background-color: $orange;
+    }
+
+    ~ div > label {
+      color: $orange;
+    }
+  }
+}
+
 // These styles work with Slim Select v2, not tested with v1
 .ss-main {
   &.form-select {

--- a/app/helpers/feeder_form_builder.rb
+++ b/app/helpers/feeder_form_builder.rb
@@ -208,7 +208,7 @@ class FeederFormBuilder < ActionView::Helpers::FormBuilder
   def add_data(opts, key, val)
     opts ||= {}
     opts[:data] ||= {}
-    opts[:data][key] = [opts[:data][key], val].compact.join(" ").strip.html_safe
+    opts[:data][key] = [val, opts[:data][key]].compact.join(" ").strip.html_safe
     opts
   end
 end

--- a/app/javascript/controllers/click_controller.js
+++ b/app/javascript/controllers/click_controller.js
@@ -2,8 +2,19 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["submit"]
+  static values = { immediate: Boolean }
+
+  connect() {
+    if (this.immediateValue) {
+      this.submit()
+    }
+  }
 
   submit() {
-    this.submitTarget.click()
+    if (this.hasSubmitTarget) {
+      this.submitTarget.click()
+    } else {
+      this.element.click()
+    }
   }
 }

--- a/app/javascript/controllers/confirm_field_controller.js
+++ b/app/javascript/controllers/confirm_field_controller.js
@@ -20,14 +20,18 @@ export default class extends Controller {
   }
 
   confirmCancel() {
-    this.field.value = this.field.dataset.valueWas
+    if (this.field.type === "checkbox") {
+      this.field.checked = this.field.dataset.valueWas === "true"
+    } else {
+      this.field.value = this.field.dataset.valueWas
+    }
     this.field.dispatchEvent(new Event("change"))
     this.modal.hide()
   }
 
   confirmMessage() {
-    const oldValue = this.field.dataset.valueWas
-    const newValue = this.field.value
+    const oldValue = this.labelForValue(this.field, this.field.dataset.valueWas)
+    const newValue = this.labelForValue(this.field, this.field.value)
 
     const updateMsg = this.field.dataset.confirmWith
     const createMsg = this.field.dataset.confirmCreate
@@ -41,6 +45,19 @@ export default class extends Controller {
     } else {
       return this.templateMessage(oldValue, newValue, deleteMsg || updateMsg)
     }
+  }
+
+  // lookup labels for select options
+  labelForValue(field, value) {
+    if (field.options) {
+      for (const opt of field.options) {
+        if (opt.value === value) {
+          return opt.textContent
+        }
+      }
+    }
+
+    return value
   }
 
   templateMessage(oldValue, newValue, msg) {

--- a/app/javascript/controllers/confirm_field_controller.js
+++ b/app/javascript/controllers/confirm_field_controller.js
@@ -29,11 +29,21 @@ export default class extends Controller {
     const oldValue = this.field.dataset.valueWas
     const newValue = this.field.value
 
-    // optionally show a different message when deleting
     const updateMsg = this.field.dataset.confirmWith
-    const deleteMsg = this.field.dataset.confirmDelete || updateMsg
-    const msg = newValue ? updateMsg : deleteMsg
+    const createMsg = this.field.dataset.confirmCreate
+    const deleteMsg = this.field.dataset.confirmDelete
 
+    // optionally show a different message when creating/deleting
+    if (oldValue && newValue) {
+      return this.templateMessage(oldValue, newValue, updateMsg)
+    } else if (newValue) {
+      return this.templateMessage(oldValue, newValue, createMsg || updateMsg)
+    } else {
+      return this.templateMessage(oldValue, newValue, deleteMsg || updateMsg)
+    }
+  }
+
+  templateMessage(oldValue, newValue, msg) {
     return msg.replaceAll("{old}", oldValue).replaceAll("{new}", newValue)
   }
 }

--- a/app/javascript/controllers/confirm_field_controller.js
+++ b/app/javascript/controllers/confirm_field_controller.js
@@ -1,0 +1,39 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "message"]
+
+  connect() {
+    this.modal = new bootstrap.Modal(this.modalTarget, { backdrop: "static", keyboard: false })
+  }
+
+  confirm(event) {
+    if (event.target.classList.contains("is-changed")) {
+      this.field = event.target
+      this.messageTarget.innerHTML = this.confirmMessage()
+      this.modal.show()
+    }
+  }
+
+  confirmOkay() {
+    this.modal.hide()
+  }
+
+  confirmCancel() {
+    this.field.value = this.field.dataset.valueWas
+    this.field.dispatchEvent(new Event("change"))
+    this.modal.hide()
+  }
+
+  confirmMessage() {
+    const oldValue = this.field.dataset.valueWas
+    const newValue = this.field.value
+
+    // optionally show a different message when deleting
+    const updateMsg = this.field.dataset.confirmWith
+    const deleteMsg = this.field.dataset.confirmDelete || updateMsg
+    const msg = newValue ? updateMsg : deleteMsg
+
+    return msg.replaceAll("{old}", oldValue).replaceAll("{new}", newValue)
+  }
+}

--- a/app/javascript/controllers/slim_select_controller.js
+++ b/app/javascript/controllers/slim_select_controller.js
@@ -21,6 +21,7 @@ export default class extends Controller {
           } else {
             this.select.selectEl.classList.add("form-control-blank")
           }
+          this.element.dispatchEvent(new Event("blur"))
         },
       },
     })

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -59,6 +59,7 @@ class Episode < ApplicationRecord
   scope :draft, -> { where("episodes.published_at IS NULL") }
   scope :scheduled, -> { where("episodes.published_at IS NOT NULL AND episodes.published_at > now()") }
   scope :draft_or_scheduled, -> { draft.or(scheduled) }
+  scope :after, ->(time) { where("COALESCE(published_at, released_at) > ?", time) }
   scope :filter_by_title, ->(text) { where("episodes.title ILIKE ?", "%#{text}%") }
 
   enum :medium, [:audio, :uncut, :video], prefix: true

--- a/app/views/episodes/_form_distribution.html.erb
+++ b/app/views/episodes/_form_distribution.html.erb
@@ -45,7 +45,7 @@
     <div class="col-12 mb-4">
       <div class="form-floating input-group">
         <% if episode.persisted? %>
-          <%= form.text_field :item_guid %>
+          <%= form.text_field :item_guid, data: {action: "blur->confirm-field#confirm", confirm_with: t(".confirm.item_guid")} %>
           <%= form.label :item_guid %>
           <%= field_copy episode.item_guid %>
         <% else %>

--- a/app/views/episodes/_missing_drafts.html.erb
+++ b/app/views/episodes/_missing_drafts.html.erb
@@ -1,0 +1,18 @@
+<div class="modal hide" id="missing-drafts" tabindex="-1" aria-labelledby="missing-drafts-title" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="missing-drafts-title"><%= t(".title") %></h5>
+      </div>
+      <div class="modal-body">
+        <p><%= t(".message", href: podcast_planner_path(podcast)).html_safe %></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"><%= t(".okay") %></button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%# click hidden button to immediately show modal %>
+<button type="button" class="d-none" data-bs-toggle="modal" data-bs-target="#missing-drafts" data-controller="click" data-click-immediate-value="true"></button>

--- a/app/views/episodes/new.html.erb
+++ b/app/views/episodes/new.html.erb
@@ -3,3 +3,7 @@
 <%= render "tabs" %>
 
 <%= render "form", episode: @episode %>
+
+<% if !@podcast.complete && @podcast.episodes.after(Time.now).none? %>
+  <%= render "missing_drafts", podcast: @podcast %>
+<% end %>

--- a/app/views/feeds/_form_main.html.erb
+++ b/app/views/feeds/_form_main.html.erb
@@ -28,7 +28,7 @@
 
 <div class="<%= feed.default? ? "col-12" : "col-6" %> mb-4">
   <div class="form-floating input-group">
-    <%= form.text_field :file_name %>
+    <%= form.text_field :file_name, data: {action: "blur->confirm-field#confirm", confirm_with: t(".confirm.file_name")} %>
     <%= form.label :file_name %>
     <%= field_help_text t(".help.file_name") %>
   </div>
@@ -36,7 +36,8 @@
 
 <div class="col-12 mb-4">
   <div class="form-floating input-group">
-    <%= form.text_field :url %>
+    <% action = feed.url_was.present? ? "blur->confirm-field#confirm" : "" %>
+    <%= form.text_field :url, data: {action: action, confirm_with: t(".confirm.url"), confirm_delete: t(".confirm.url_delete")} %>
     <%= form.label :url %>
     <%= field_help_text t(".help.url") %>
   </div>

--- a/app/views/feeds/_form_main.html.erb
+++ b/app/views/feeds/_form_main.html.erb
@@ -17,7 +17,8 @@
 
   <div class="col-6 mb-4">
     <div class="form-floating input-group">
-      <%= form.text_field :slug, data: {action: "keyup->feed-link#updateSlug"} %>
+      <% action = "keyup->feed-link#updateSlug blur->confirm-field#confirm" %>
+      <%= form.text_field :slug, data: {action: action, confirm_with: t(".confirm.slug")} %>
       <%= form.label :slug %>
       <%= field_help_text t(".help.slug") %>
     </div>
@@ -36,7 +37,9 @@
 <div class="col-12 mb-4">
   <div class="form-floating input-group">
     <% action = feed.url_was.present? ? "blur->confirm-field#confirm" : "" %>
-    <%= form.text_field :url, data: {action: action, confirm_with: t(".confirm.url"), confirm_delete: t(".confirm.url_delete")} %>
+    <% with = t(".confirm.url") %>
+    <% delete = t(".confirm.url_delete", published_url: feed.published_url) %>
+    <%= form.text_field :url, data: {action: action, confirm_with: with, confirm_delete: delete} %>
     <%= form.label :url %>
     <%= field_help_text t(".help.url") %>
   </div>
@@ -44,7 +47,11 @@
 
 <div class="col-12 mb-4">
   <div class="form-floating input-group">
-    <%= form.text_field :new_feed_url %>
+    <% action = "blur->confirm-field#confirm" %>
+    <% with = t(".confirm.new_feed_url") %>
+    <% create = t(".confirm.new_feed_url_create") %>
+    <% delete = t(".confirm.new_feed_url_delete") %>
+    <%= form.text_field :new_feed_url, data: {action: action, confirm_with: with, confirm_create: create, confirm_delete: delete} %>
     <%= form.label :new_feed_url %>
     <%= field_help_text t(".help.new_feed_url") %>
   </div>

--- a/app/views/layouts/_confirm_field.html.erb
+++ b/app/views/layouts/_confirm_field.html.erb
@@ -1,0 +1,16 @@
+<div class="modal fade" id="confirm-field" tabindex="-1" aria-labelledby="confirm-field-title" aria-hidden="true" data-confirm-field-target="modal">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="confirm-field-title"><%= t(".title") %></h5>
+      </div>
+      <div class="modal-body">
+        <p data-confirm-field-target="message">jello</p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-light" data-action="confirm-field#confirmCancel"><%= t(".cancel") %></button>
+        <button type="button" class="btn btn-primary" data-action="confirm-field#confirmOkay"><%= t(".okay") %></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,11 +15,11 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body data-controller="blank-field popover">
+  <body data-controller="blank-field confirm-field popover">
     <%= render "layouts/nav" %>
     <%= render "layouts/subnav" if current_user %>
-
     <%= render "layouts/alerts" %>
+    <%= render "layouts/confirm_field" %>
 
     <% if content_for? :tabs %>
       <div class="prx-main | container-fluid d-grid">

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -8,7 +8,9 @@
 
 <div class="col-6 mb-4">
   <div class="form-floating">
-    <%= form.select :prx_account_uri, podcast_account_name_options(podcast) %>
+    <% action = podcast.persisted? ? "change->confirm-field#confirm" : "" %>
+    <% with = t(".confirm.owner") %>
+    <%= form.select :prx_account_uri, podcast_account_name_options(podcast), {}, data: {action: action, confirm_with: with} %>
     <%= form.label :prx_account_uri %>
   </div>
 </div>
@@ -156,7 +158,8 @@
 
 <div class="col-6 mb-4 d-flex align-items-center">
   <div class="form-check">
-    <%= form.check_box :complete, class: "form-check-input" %>
+    <% action = podcast.complete? ? "" : "change->confirm-field#confirm" %>
+    <%= form.check_box :complete, data: {action: action, confirm_with: t(".confirm.complete")} %>
     <div class="d-flex align-items-center">
       <%= form.label :complete %>
       <%= help_text t(".help.complete") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -271,6 +271,10 @@ en:
         auth_tokens: Auth tokens help ensure your feed stays private. They must be appended to the feed URL for the audio to work. Remove them to revoke access to your feed.
         private: Your feed can be public or private. Leave unchecked to keep it a Public Feed. If you check this box this feed becomes Private and you'll need to generate an authorization token. Be careful who you share your private link with - <strong>anyone who has access to the link will be able to use it</strong>.
     form_main:
+      confirm:
+        file_name: Woh there! Changing your PRX feed url could break things for your subscribers - are you sure?
+        url: Are you sure you want to change your public feed URL from <b>{old}</b> to <b>{new}</b>? This will point your subscribers to a new feed location.<br/>If you have existing subscribers at <b>{old}</b>, make sure to set the <a href="https://help.apple.com/itc/podcasts_connect/#/itcb54353390" target="_blank">New Feed URL</a> as well to avoid losing subscribers.
+        url_delete: Are you sure you want to delete your public feed URL? This will point your subscribers back at your PRX feed location. If you have existing subscribers at <b>{old}</b>, make sure to set the New Feed URL as well to avoid losing subscribers.
       help:
         display_episodes_count: You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will disappear as you publish newer ones. Leave this field blank to include all.
         display_full_episodes_count: You can optionally reduce the size of your RSS feed by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and older episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.
@@ -339,6 +343,10 @@ en:
       feed_image: Thumbnail Image
       itunes_image: Profile Image
   layouts:
+    confirm_field:
+      cancel: Cancel
+      okay: Okay
+      title: Really Change?
     nav:
       account: PRX Account
       attribution: Attribution

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -162,6 +162,8 @@ en:
     form:
       confirm: Discard unsaved changes?
     form_distribution:
+      confirm:
+        item_guid: Are you sure you want to change the permanent GUID for this episode from <b>{old}</b> to <b>{new}</b>? This should only be done in special cases.
       embed_player_not_ready: Episode Not Saved
       enclosure_not_ready: No Media Files Uploaded
       title: Distribution
@@ -234,6 +236,10 @@ en:
         hint: Processing
       segment_count:
         help: Enter the number of ad breaks in this episode.
+    missing_drafts:
+      message: The more drafts you add, the better we can support your podcast. Please add <a href="%{href}">all of your known upcoming episodes</a> to the Production Calendar.
+      okay: Okay
+      title: Missing Episode Drafts
     update:
       error: Unable to save
       media_not_ready: Audio not ready

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -275,8 +275,12 @@ en:
     form_main:
       confirm:
         file_name: Woh there! Changing your PRX feed url could break things for your subscribers - are you sure?
-        url: Are you sure you want to change your public feed URL from <b>{old}</b> to <b>{new}</b>? This will point your subscribers to a new feed location.<br/>If you have existing subscribers at <b>{old}</b>, make sure to set the <a href="https://help.apple.com/itc/podcasts_connect/#/itcb54353390" target="_blank">New Feed URL</a> as well to avoid losing subscribers.
-        url_delete: Are you sure you want to delete your public feed URL? This will point your subscribers back at your PRX feed location. If you have existing subscribers at <b>{old}</b>, make sure to set the New Feed URL as well to avoid losing subscribers.
+        new_feed_url: Are you sure you want to change your feed URL from <b>{old}</b> to <b>{new}</b>? This will point your subscribers to a new feed location.
+        new_feed_url_create: Are you sure you want to change your feed URL to <b>{new}</b>? This will point your subscribers to a new feed location.
+        new_feed_url_delete: Are you sure you want to delete your New Feed URL? Generally you should just leave this alone after setting it to something.
+        slug: Woh there! Changing your PRX feed url could break things for your subscribers - are you sure?
+        url: Are you sure you want to change your public feed URL from <b>{old}</b> to <b>{new}</b>? This will point your subscribers to a new feed location.<br/><br/>If you have existing subscribers at <b>{old}</b>, make sure to set the <a href="https://help.apple.com/itc/podcasts_connect/#/itcb54353390" target="_blank">New Feed URL</a> as well to avoid losing subscribers.
+        url_delete: Are you sure you want to delete your public feed URL? This will point your subscribers back at your PRX feed location <b>%{published_url}</b>.<br/><br/>If you have existing subscribers at <b>{old}</b>, make sure to set the <a href="https://help.apple.com/itc/podcasts_connect/#/itcb54353390" target="_blank">New Feed URL</a> as well to avoid losing subscribers.
       help:
         display_episodes_count: You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will disappear as you publish newer ones. Leave this field blank to include all.
         display_full_episodes_count: You can optionally reduce the size of your RSS feed by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and older episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -376,6 +376,9 @@ en:
     form:
       confirm: Discard unsaved changes?
     form_main:
+      confirm:
+        complete: Are you sure this podcast is complete? Apps will assume this show is over, and won't look for new episodes.
+        owner: Are you sure you want to change the owner of this podcast from <b>{old}</b> to <b>{new}</b>? This will affect who can access the podcast
       help:
         author_email: Set the author email for this podcast.
         author_name: Set the author name for this podcast.


### PR DESCRIPTION
Confirms when a bunch of fields are changed, as Publish does.

- Podcast Settings -> Owner
- Podcast Settings -> Complete (only when changing to "complete")
- Feed -> File Name
- Feed -> Slug (non default feeds)
- Feed -> Public Feed URL (different text depending if you're creating/deleting/changing)
- Feed -> New Feed URL (different text depending if you're creating/deleting/changing)
- Episode -> GUID
- Episode -> New (when you have 0 future-drafts planned)