### PR TITLE
Fixes Itunes Category & sub Category styling

### DIFF
--- a/app/assets/stylesheets/shared/bootstrap-variables.scss
+++ b/app/assets/stylesheets/shared/bootstrap-variables.scss
@@ -124,10 +124,9 @@ $form-floating-label-transform: scale(0.85) translateY(-1.75rem) translateX(0.15
 $form-select-indicator-color: $gray-800;
 $form-select-indicator: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>");
 
-$form-feedback-invalid-color:       $danger;
-$form-feedback-icon-invalid-color:  $form-feedback-invalid-color;
-$form-feedback-icon-invalid:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>");
-
+$form-feedback-invalid-color: $danger;
+$form-feedback-icon-invalid-color: $form-feedback-invalid-color;
+$form-feedback-icon-invalid: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>");
 
 $border-radius: 0.1875rem;
 

--- a/app/assets/stylesheets/shared/bootstrap-variables.scss
+++ b/app/assets/stylesheets/shared/bootstrap-variables.scss
@@ -121,6 +121,13 @@ $form-floating-input-padding-t: $input-btn-padding-y;
 $form-floating-input-padding-b: $input-btn-padding-y;
 $form-floating-label-opacity: 1;
 $form-floating-label-transform: scale(0.85) translateY(-1.75rem) translateX(0.15rem);
+$form-select-indicator-color: $gray-800;
+$form-select-indicator: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>");
+
+$form-feedback-invalid-color:       $danger;
+$form-feedback-icon-invalid-color:  $form-feedback-invalid-color;
+$form-feedback-icon-invalid:        url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>");
+
 
 $border-radius: 0.1875rem;
 

--- a/app/assets/stylesheets/shared/bootstrap-variables.scss
+++ b/app/assets/stylesheets/shared/bootstrap-variables.scss
@@ -122,11 +122,11 @@ $form-floating-input-padding-b: $input-btn-padding-y;
 $form-floating-label-opacity: 1;
 $form-floating-label-transform: scale(0.85) translateY(-1.75rem) translateX(0.15rem);
 $form-select-indicator-color: $gray-800;
-$form-select-indicator: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'><path fill='none' stroke='#{$form-select-indicator-color}' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/></svg>");
+$form-select-indicator: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23323233' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
 
 $form-feedback-invalid-color: $danger;
 $form-feedback-icon-invalid-color: $form-feedback-invalid-color;
-$form-feedback-icon-invalid: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='#{$form-feedback-icon-invalid-color}'><circle cx='6' cy='6' r='4.5'/><path stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/><circle cx='6' cy='8.2' r='.6' fill='#{$form-feedback-icon-invalid-color}' stroke='none'/></svg>");
+$form-feedback-icon-invalid: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
 
 $border-radius: 0.1875rem;
 

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -80,11 +80,16 @@
   > label::before {
     content: "";
     z-index: -1;
-    background: transparent;
+    background: $input-bg;
     position: absolute;
     inset: 35% 0.25rem 1rem;
     border-radius: $input-border-radius;
   }
+
+  .ss-disabled ~ label:before {
+    background: transparent;
+  }
+
 
   .form-control {
     color: #000;

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -240,8 +240,7 @@
 
 .ss-main.form-select.is-invalid:not([multiple]):not([size]) {
   padding-right: $form-select-feedback-icon-padding-end;
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23323233' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e"),
-    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
+  background-image: $form-select-indicator, $form-feedback-icon-invalid;
   background-position: $form-select-bg-position, $form-select-feedback-icon-position;
   background-size: $form-select-bg-size, $form-select-feedback-icon-size;
   border-color: $danger;

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -178,7 +178,6 @@
 
 // These styles work with Slim Select v2, not tested with v1
 .ss-main {
-
   &.form-select {
     padding: 0.75rem;
     min-height: $input-height;
@@ -237,8 +236,7 @@
 
 .ss-main.form-select.is-invalid:not([multiple]):not([size]) {
   padding-right: $form-select-feedback-icon-padding-end;
-  background-image: 
-    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23323233' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e"), 
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23323233' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e"),
     url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
   background-position: $form-select-bg-position, $form-select-feedback-icon-position;
   background-size: $form-select-bg-size, $form-select-feedback-icon-size;
@@ -248,7 +246,6 @@
 .form-select.is-invalid:not([multiple]):not([size]) {
   padding-right: 0;
   background-image: none;
-  
 }
 
 .ss-search input {
@@ -313,11 +310,6 @@
       background-color: $primary;
     }
   }
-}
-
-
-.form-control-blank.form-select.is-invalid:not([multiple]):not([size]) {
-
 }
 
 // undo bootstrap placeholder class

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -90,7 +90,6 @@
     background: transparent;
   }
 
-
   .form-control {
     color: #000;
     border: $input-border-width $border-style $input-border-color;

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -80,7 +80,7 @@
   > label::before {
     content: "";
     z-index: -1;
-    background: $input-bg;
+    background: transparent;
     position: absolute;
     inset: 35% 0.25rem 1rem;
     border-radius: $input-border-radius;
@@ -178,6 +178,7 @@
 
 // These styles work with Slim Select v2, not tested with v1
 .ss-main {
+
   &.form-select {
     padding: 0.75rem;
     min-height: $input-height;
@@ -235,7 +236,19 @@
 }
 
 .ss-main.form-select.is-invalid:not([multiple]):not([size]) {
+  padding-right: $form-select-feedback-icon-padding-end;
+  background-image: 
+    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23323233' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e"), 
+    url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' width='12' height='12' fill='none' stroke='%23dc3545'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
+  background-position: $form-select-bg-position, $form-select-feedback-icon-position;
+  background-size: $form-select-bg-size, $form-select-feedback-icon-size;
+  border-color: $danger;
+}
+
+.form-select.is-invalid:not([multiple]):not([size]) {
   padding-right: 0;
+  background-image: none;
+  
 }
 
 .ss-search input {
@@ -300,6 +313,11 @@
       background-color: $primary;
     }
   }
+}
+
+
+.form-control-blank.form-select.is-invalid:not([multiple]):not([size]) {
+
 }
 
 // undo bootstrap placeholder class


### PR DESCRIPTION
Woof. That was thorny, but once I realized that the .`ss-main` selector only applied to the selectbox and not the dropdown, I could make progress. 

A few notes in the code.


To replicate:
- Podcasts > Settings and remove the Itunes category and save, this should prompt validation. Ensure that the icons are present and not visible in the dropdown.