### PR TITLE
Backfill validations

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -89,7 +89,7 @@ class FeedsController < ApplicationController
 
   # Only allow a list of trusted parameters through.
   def feed_params
-    params.fetch(:feed, {}).permit(
+    nilify params.fetch(:feed, {}).permit(
       :file_name,
       :slug,
       :title,

--- a/app/controllers/podcast_engagement_controller.rb
+++ b/app/controllers/podcast_engagement_controller.rb
@@ -30,7 +30,7 @@ class PodcastEngagementController < ApplicationController
 
   ### TODO include params for socmed and podcast apps
   def podcast_engagement_params
-    params.fetch(:podcast, {}).permit(
+    nilify params.fetch(:podcast, {}).permit(
       :donation_url,
       :payment_pointer
     )

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -121,7 +121,7 @@ class PodcastsController < ApplicationController
   end
 
   def podcast_params
-    params.fetch(:podcast, {}).permit(
+    nilify params.fetch(:podcast, {}).permit(
       :title,
       :prx_account_uri,
       :subtitle,

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -39,11 +39,12 @@ class Episode < ApplicationRecord
 
   validates :podcast_id, :guid, presence: true
   validates :title, presence: true
+  validates :url, http_url: true
   validates :original_guid, presence: true, uniqueness: {scope: :podcast_id}, allow_nil: true
   alias_error_messages :item_guid, :original_guid
   validates :itunes_type, inclusion: {in: VALID_ITUNES_TYPES}
-  validates :episode_number, numericality: {only_integer: true}, allow_nil: true
-  validates :season_number, numericality: {only_integer: true}, allow_nil: true
+  validates :episode_number, numericality: {only_integer: true, greater_than: 0}, allow_nil: true
+  validates :season_number, numericality: {only_integer: true, greater_than: 0}, allow_nil: true
   validates :explicit, inclusion: {in: %w[true false]}, allow_nil: true
   validates :segment_count, presence: true, if: :strict_validations
   validates :segment_count, numericality: {only_integer: true, greater_than: 0, less_than_or_equal_to: MAX_SEGMENT_COUNT}, allow_nil: true

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -45,6 +45,11 @@ class Feed < ApplicationRecord
   validates :include_tags, tag_list: true
   validates :audio_format, audio_format: true
   validates :title, presence: true, unless: :default?
+  validates :url, http_url: true
+  validates :new_feed_url, http_url: true
+  validates :enclosure_prefix, http_url: true
+  validates :display_episodes_count, numericality: {only_integer: true, greater_than: 0}, allow_nil: true
+  validates :display_full_episodes_count, numericality: {only_integer: true, greater_than: 0}, allow_nil: true
 
   after_initialize :set_defaults
   before_validation :sanitize_text

--- a/app/models/validators/http_url_validator.rb
+++ b/app/models/validators/http_url_validator.rb
@@ -8,7 +8,7 @@ class HttpUrlValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     if value.present? && !self.class.http_url?(value)
-      record.errors.add(attribute, "is not a valid HTTP URL")
+      record.errors.add(attribute, :not_http_url)
     end
   end
 end

--- a/app/views/episodes/_form_distribution.html.erb
+++ b/app/views/episodes/_form_distribution.html.erb
@@ -19,17 +19,6 @@
 
     <div class="col-12 mb-4">
       <div class="form-floating input-group">
-        <%= form.text_field :url %>
-        <%= form.label :url %>
-        <% if episode.url.present? %>
-          <%= field_link episode.url %>
-          <%= field_copy episode.url %>
-        <% end %>
-      </div>
-    </div>
-
-    <div class="col-12 mb-4">
-      <div class="form-floating input-group">
         <% if episode.persisted? %>
           <%= form.text_field :embed_player_url, value: embed_player_episode_url(episode), disabled: true %>
           <%= form.label :embed_player_url %>
@@ -44,13 +33,27 @@
 
     <div class="col-12 mb-4">
       <div class="form-floating input-group">
+        <%= form.text_field :url %>
+        <%= form.label :url %>
+        <% if episode.url.present? %>
+          <%= field_link episode.url %>
+          <%= field_copy episode.url %>
+        <% end %>
+        <%= field_help_text t(".help.url") %>
+      </div>
+    </div>
+
+    <div class="col-12 mb-4">
+      <div class="form-floating input-group">
         <% if episode.persisted? %>
           <%= form.text_field :item_guid, data: {action: "blur->confirm-field#confirm", confirm_with: t(".confirm.item_guid")} %>
           <%= form.label :item_guid %>
           <%= field_copy episode.item_guid %>
+          <%= field_help_text t(".help.item_guid") %>
         <% else %>
           <%= form.text_field :original_guid %>
           <%= form.label :original_guid %>
+          <%= field_help_text t(".help.original_guid") %>
         <% end %>
       </div>
     </div>

--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -46,7 +46,7 @@
   <div class="form-floating input-group">
     <%= form.select :explicit, podcast_explicit_options, {include_blank: true} %>
     <%= form.label :explicit %>
-    <%= field_help_text t(".help.explicit") %>
+    <%= field_help_text t(".help.explicit", podcast_value: t("helpers.label.podcast.explicits.#{episode.podcast.explicit}")) %>
   </div>
 </div>
 

--- a/app/views/feeds/_form_main.html.erb
+++ b/app/views/feeds/_form_main.html.erb
@@ -41,7 +41,7 @@
     <% delete = t(".confirm.url_delete", published_url: feed.published_url) %>
     <%= form.text_field :url, data: {action: action, confirm_with: with, confirm_delete: delete} %>
     <%= form.label :url %>
-    <%= field_help_text t(".help.url") %>
+    <%= field_help_text t(".help.url", published_url: feed.published_url) %>
   </div>
 </div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -171,6 +171,10 @@ en:
     form_distribution:
       confirm:
         item_guid: Are you sure you want to change the permanent GUID for this episode from <b>{old}</b> to <b>{new}</b>? This should only be done in special cases.
+      help:
+        item_guid: Every podcast episode on iTunes should have a permanent, case-sensitive globally unique identifier (GUID). When an episode is added to a podcast's RSS feed, the episode is deemed "new" if no episode with that GUID exists yet in the feed. In certain rare cases, it can make sense to give an existing episode a new GUID. If you'd like to change the GUID for this episode, you may do so here.
+        original_guid: In most cases, you should leave this blank and let us auto-generate a globally unique identifier for you. But if you'd like to manually set your episode GUID, enter it here.
+        url: If you have a public URL for this podcast episode, enter it here. If not, we'll auto generate one for you.
       embed_player_not_ready: Episode Not Saved
       enclosure_not_ready: No Media Files Uploaded
       title: Distribution
@@ -182,7 +186,7 @@ en:
         description: Write a full description of your episode, including keywords, names of interviewees, places and topics. Feel free to incorporate links, images, and any of the other provided rich text formatting options.
         episode_number: If your episode is part of has a specific number add it here.
         episode_url: If you have a public URL for this podcast episode, enter it here.
-        explicit: In accordance with <a href="https://help.apple.com/itc/podcasts_connect/#/itc1723472cb" target="_blank">the requirements for iTunes podcast content</a>, does this episode contain explicit material?
+        explicit: In accordance with <a href="https://help.apple.com/itc/podcasts_connect/#/itc1723472cb" target="_blank">the requirements for iTunes podcast content</a>, does this episode contain explicit material?<br/><br/>Setting this field will override your <b>%{podcast_value}</b> podcast global value.
         itunes_type: <p>Select the type of episode.</p> <p><strong>Full</strong> default and most common;</p> <p><strong>Trailer</strong> a short, promotional piece of content that represents a preview of a show;</p> <p><strong>Bonus</strong> extra content like behind-the-scenes information or interviews.</p>
         production_notes: Helpful information for the production and/or ad sales teams. Example 'Descriptions of violence in segment 2.'
         season_number: If your episode is part of a season add it here.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,15 +38,22 @@ en:
       short: "%m/%d"
       time_12_hour: "%l:%M %p %Z"
       day_and_date: "%A, %m/%d"
-  # validation error messages
+  # validation error messages https://guides.rubyonrails.org/i18n.html#error-message-interpolation
   activerecord:
     errors:
+      messages:
+        blank: Can't be blank
+        not_http_url: Not a valid URL
       models:
         episode:
           attributes:
             segment_count:
               greater_than: Can't be negative
               less_than_or_equal_to: Enter a number less than %{count}
+        podcast:
+          attributes:
+            payment_pointer:
+              invalid: Payment pointers must have the format $prx.wallet.example/abcd1234
   # form/model helpers
   helpers:
     application:
@@ -175,7 +182,7 @@ en:
         description: Write a full description of your episode, including keywords, names of interviewees, places and topics. Feel free to incorporate links, images, and any of the other provided rich text formatting options.
         episode_number: If your episode is part of has a specific number add it here.
         episode_url: If you have a public URL for this podcast episode, enter it here.
-        explicit: In accordance with <a href='https://help.apple.com/itc/podcasts_connect/#/itc1723472cb'>the requirements for iTunes podcast content</a>, does this episode contain explicit material?
+        explicit: In accordance with <a href="https://help.apple.com/itc/podcasts_connect/#/itc1723472cb" target="_blank">the requirements for iTunes podcast content</a>, does this episode contain explicit material?
         itunes_type: <p>Select the type of episode.</p> <p><strong>Full</strong> default and most common;</p> <p><strong>Trailer</strong> a short, promotional piece of content that represents a preview of a show;</p> <p><strong>Bonus</strong> extra content like behind-the-scenes information or interviews.</p>
         production_notes: Helpful information for the production and/or ad sales teams. Example 'Descriptions of violence in segment 2.'
         season_number: If your episode is part of a season add it here.
@@ -289,14 +296,14 @@ en:
         url_delete: Are you sure you want to delete your public feed URL? This will point your subscribers back at your PRX feed location <b>%{published_url}</b>.<br/><br/>If you have existing subscribers at <b>{old}</b>, make sure to set the <a href="https://help.apple.com/itc/podcasts_connect/#/itcb54353390" target="_blank">New Feed URL</a> as well to avoid losing subscribers.
       help:
         display_episodes_count: You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will disappear as you publish newer ones. Leave this field blank to include all.
-        display_full_episodes_count: You can optionally reduce the size of your RSS feed by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and older episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.
+        display_full_episodes_count: You can optionally <a href="https://help.prx.org/hc/en-us/articles/360055869313-Limiting-Episode-Metadata" target="_blank">reduce the size of your RSS feed</a> by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and older episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.
         enclosure_prefix: If you have an enclosure prefix URL to set a redirect on audio requests for your podcast feed (e.g., podtrac or blubrry), enter it here.
         episode_offset_seconds: Instead of episodes immediately showing up in this feed when published, delay their appearance. AKA Windowing.
         file_name: The file name used for your private RSS feed.
         new_feed_url: If your podcast feed is moving, use this field to point to the new URL where your podcast is located. The current feed should be maintained until all of your subscribers have migrated.
         slug: An alphanumeric slug used to identify your feed. Also used in the private feed RSS url.
         title: An alternate title for your feed, to distinguish it from the Default Feed
-        url: If you already have a public URL for your podcast feed (e.g., feedburner), enter it here. It should point to your private feed URL.
+        url: If you already have a public URL for your podcast feed (e.g., <a href="https://support.google.com/feedburner/answer/78475?hl=en" target="_blank">feedburner</a>), enter it here. It should point to your <a href="%{published_url}" target="_blank">private feed URL</a>.
     form_overrides:
       title: Overrides
       help:
@@ -391,8 +398,8 @@ en:
         complete: Checking the box indicates that the podcast is complete and you will not post any more episodes in the future.
         copyright: Copyright notice for content in the podcast.
         description: A full description of this podcast.
-        explicit: In accordance with <a href='https://help.apple.com/itc/podcasts_connect/#/itc1723472cb'>the requirements for iTunes podcast content</a>, do any of your podcast episodes contain explicit material?
-        itunes_category: Select the <a href='https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12'>iTunes category and subcategory</a>, if applicable, that best describe this podcast.
+        explicit: In accordance with <a href="https://help.apple.com/itc/podcasts_connect/#/itc1723472cb" target="_blank">the requirements for iTunes podcast content</a>, do any of your podcast episodes contain explicit material?
+        itunes_category: Select the <a href="https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12" target="_blank">iTunes category and subcategory</a>, if applicable, that best describe this podcast.
         language: Select which language your podcast is in.
         link: A link to the homepage for your podcast.
         managing_editor_email: Set the managing editor email for this podcast.

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -4,7 +4,7 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
   let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/123") }
   let(:feed) { create(:feed, podcast: podcast, private: false) }
   let(:private_feed) { create(:private_feed, podcast: podcast) }
-  let(:update_params) { {url: "/a_public_url", display_episodes_count: 5} }
+  let(:update_params) { {url: "https://prx.org/a_public_url", display_episodes_count: 5} }
   let(:create_params) { {podcast: podcast, slug: "new_feed", title: "new title", private: false} }
 
   setup_current_user { build(:user, account_id: 123) }


### PR DESCRIPTION
Adds a bunch of validations that existed in Publish/CMS.  I fixed all prod data that didn't adhere to these, so shouldn't cause any issues with CMS -> Feeder data syncing.

See [the parity check spreadsheet](https://docs.google.com/spreadsheets/d/1ZidmwH3JUM4ag2eb1i5YWkbMqx2PsUrSAQ8Te6LdoPM/edit#gid=0) for a list of things I've added here.