### PR TITLE
Confirm when enter pressed

### DIFF
--- a/app/javascript/controllers/confirm_field_controller.js
+++ b/app/javascript/controllers/confirm_field_controller.js
@@ -1,10 +1,20 @@
 import { Controller } from "@hotwired/stimulus"
 
+const ACTION = "blur->confirm-field#confirm keydown.enter->confirm-field#enter"
+
 export default class extends Controller {
-  static targets = ["modal", "message"]
+  static targets = ["modal", "message", "field"]
 
   connect() {
     this.modal = new bootstrap.Modal(this.modalTarget, { backdrop: "static", keyboard: false })
+  }
+
+  fieldTargetConnected(field) {
+    if (!field.dataset.action) {
+      field.dataset.action = ACTION
+    } else {
+      field.dataset.action += ` ${ACTION}`
+    }
   }
 
   confirm(event) {
@@ -12,6 +22,14 @@ export default class extends Controller {
       this.field = event.target
       this.messageTarget.innerHTML = this.confirmMessage()
       this.modal.show()
+      return true
+    }
+  }
+
+  // prevent enter from submitting the form before we confirm the change
+  enter(event) {
+    if (this.confirm(event)) {
+      event.preventDefault()
     }
   }
 

--- a/app/views/episodes/_form_distribution.html.erb
+++ b/app/views/episodes/_form_distribution.html.erb
@@ -45,7 +45,8 @@
     <div class="col-12 mb-4">
       <div class="form-floating input-group">
         <% if episode.persisted? %>
-          <%= form.text_field :item_guid, data: {action: "blur->confirm-field#confirm", confirm_with: t(".confirm.item_guid")} %>
+          <% data = {confirm_field_target: "field", confirm_with: t(".confirm.item_guid")} %>
+          <%= form.text_field :item_guid, data: data %>
           <%= form.label :item_guid %>
           <%= field_copy episode.item_guid %>
         <% else %>

--- a/app/views/feeds/_form_main.html.erb
+++ b/app/views/feeds/_form_main.html.erb
@@ -17,8 +17,8 @@
 
   <div class="col-6 mb-4">
     <div class="form-floating input-group">
-      <% action = "keyup->feed-link#updateSlug blur->confirm-field#confirm" %>
-      <%= form.text_field :slug, data: {action: action, confirm_with: t(".confirm.slug")} %>
+      <% data = {action: "keyup->feed-link#updateSlug", confirm_field_target: "field", confirm_with: t(".confirm.slug")} %>
+      <%= form.text_field :slug, data: data %>
       <%= form.label :slug %>
       <%= field_help_text t(".help.slug") %>
     </div>
@@ -27,8 +27,8 @@
 
 <div class="<%= feed.default? ? "col-12" : "col-6" %> mb-4">
   <div class="form-floating input-group">
-    <% action = "keyup->feed-link#updateFileName blur->confirm-field#confirm" %>
-    <%= form.text_field :file_name, data: {action: action, confirm_with: t(".confirm.file_name")} %>
+    <% data = {action: "keyup->feed-link#updateFileName", confirm_field_target: "field", confirm_with: t(".confirm.file_name")} %>
+    <%= form.text_field :file_name, data: data %>
     <%= form.label :file_name %>
     <%= field_help_text t(".help.file_name") %>
   </div>
@@ -36,10 +36,10 @@
 
 <div class="col-12 mb-4">
   <div class="form-floating input-group">
-    <% action = feed.url_was.present? ? "blur->confirm-field#confirm" : "" %>
     <% with = t(".confirm.url") %>
     <% delete = t(".confirm.url_delete", published_url: feed.published_url) %>
-    <%= form.text_field :url, data: {action: action, confirm_with: with, confirm_delete: delete} %>
+    <% data = {confirm_field_target: "field", confirm_with: with, confirm_delete: delete} %>
+    <%= form.text_field :url, data: feed.url_was.present? ? data : {} %>
     <%= form.label :url %>
     <%= field_help_text t(".help.url") %>
   </div>
@@ -47,11 +47,11 @@
 
 <div class="col-12 mb-4">
   <div class="form-floating input-group">
-    <% action = "blur->confirm-field#confirm" %>
     <% with = t(".confirm.new_feed_url") %>
     <% create = t(".confirm.new_feed_url_create") %>
     <% delete = t(".confirm.new_feed_url_delete") %>
-    <%= form.text_field :new_feed_url, data: {action: action, confirm_with: with, confirm_create: create, confirm_delete: delete} %>
+    <% data = {confirm_field_target: "field", confirm_with: with, confirm_create: create, confirm_delete: delete} %>
+    <%= form.text_field :new_feed_url, data: data %>
     <%= form.label :new_feed_url %>
     <%= field_help_text t(".help.new_feed_url") %>
   </div>

--- a/app/views/layouts/_confirm_field.html.erb
+++ b/app/views/layouts/_confirm_field.html.erb
@@ -5,7 +5,7 @@
         <h5 class="modal-title" id="confirm-field-title"><%= t(".title") %></h5>
       </div>
       <div class="modal-body">
-        <p data-confirm-field-target="message">jello</p>
+        <p data-confirm-field-target="message"></p>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-light" data-action="confirm-field#confirmCancel"><%= t(".cancel") %></button>

--- a/app/views/layouts/_subnav.html.erb
+++ b/app/views/layouts/_subnav.html.erb
@@ -10,7 +10,7 @@
         <%= active_link_to "Podcast", main_app.podcast_path(@podcast), active: :exact, class: "nav-link" %>
         <%= active_link_to "Settings", main_app.edit_podcast_path(@podcast), active: podcast_settings_active?, class: "nav-link" %>
         <%= active_link_to "Episodes", main_app.podcast_episodes_path(@podcast), active: /\/episodes/, class: "nav-link" %>
-        <%= active_link_to "Feeds", main_app.podcast_feed_path(@podcast, @podcast.default_feed), class: "nav-link" %>
+        <%= active_link_to "Feeds", main_app.podcast_feed_path(@podcast, @podcast.default_feed), active: /\/feeds/, class: "nav-link" %>
       <% end %>
     </nav>
   <% end %>

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -8,9 +8,8 @@
 
 <div class="col-6 mb-4">
   <div class="form-floating">
-    <% action = podcast.persisted? ? "change->confirm-field#confirm" : "" %>
-    <% with = t(".confirm.owner") %>
-    <%= form.select :prx_account_uri, podcast_account_name_options(podcast), {}, data: {action: action, confirm_with: with} %>
+    <% data = {confirm_field_target: "field", confirm_with: t(".confirm.owner")} %>
+    <%= form.select :prx_account_uri, podcast_account_name_options(podcast), {}, data: podcast.persisted? ? data : {} %>
     <%= form.label :prx_account_uri %>
   </div>
 </div>
@@ -158,8 +157,8 @@
 
 <div class="col-6 mb-4 d-flex align-items-center">
   <div class="form-check">
-    <% action = podcast.complete? ? "" : "change->confirm-field#confirm" %>
-    <%= form.check_box :complete, data: {action: action, confirm_with: t(".confirm.complete")} %>
+    <% data = {confirm_field_target: "field", confirm_with: t(".confirm.complete")} %>
+    <%= form.check_box :complete, data: podcast.complete? ? {} : data %>
     <div class="d-flex align-items-center">
       <%= form.label :complete %>
       <%= help_text t(".help.complete") %>


### PR DESCRIPTION
Refactors the field-changed stimulus controller a bit.  So we can intercept "enter" keydown events, and prompt the user to confirm the change before the form submits.

(Previously, the form would submit, and _then_ you'd get prompted.  But the change was already saved, so not ideal)