### PR TITLE
HOTFIX: style clean up for only one podcast

### DIFF
--- a/app/assets/stylesheets/shared/episode-card.scss
+++ b/app/assets/stylesheets/shared/episode-card.scss
@@ -2,6 +2,8 @@
 // Episode card styles.
 //
 
+prx-episode-s
+
 .episode-card {
   border-top: none;
   border-left: 5px solid $primary;
@@ -37,7 +39,6 @@
     .episode-card-inner {
       display: flex;
       flex-direction: column;
-      overflow: hidden;
     }
 
     .episode-card-title {

--- a/app/assets/stylesheets/shared/episode-card.scss
+++ b/app/assets/stylesheets/shared/episode-card.scss
@@ -2,8 +2,6 @@
 // Episode card styles.
 //
 
-prx-episode-s
-
 .episode-card {
   border-top: none;
   border-left: 5px solid $primary;

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -88,7 +88,6 @@
 
   [disabled="disabled"],
   .ss-disabled {
-    
     ~ label:before {
       background: $input-disabled-bg;
     }

--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -86,8 +86,12 @@
     border-radius: $input-border-radius;
   }
 
-  .ss-disabled ~ label:before {
-    background: transparent;
+  [disabled="disabled"],
+  .ss-disabled {
+    
+    ~ label:before {
+      background: $input-disabled-bg;
+    }
   }
 
   .form-control {
@@ -194,6 +198,10 @@
     height: auto;
     border-color: $input-border-color;
     // border: none;
+  }
+
+  &.ss-disabled {
+    background-color: $input-disabled-bg;
   }
 
   .ss-values .ss-single {

--- a/app/assets/stylesheets/shared/layout.scss
+++ b/app/assets/stylesheets/shared/layout.scss
@@ -24,5 +24,4 @@ h3 {
 .prx-main {
   position: relative;
   display: grid;
-  flex-grow: 1;
 }

--- a/app/views/episodes/index.html.erb
+++ b/app/views/episodes/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, t(".title") %>
 
-<div class="container my-4 mx-2">
-  <div class="d-grid d-sm-flex align-items-center w-auto">
+<div class="my-4">
+  <div class="d-grid d-sm-flex align-items-center w-auto mb-2">
     <h1 class="text-black fw-bold d-flex flex-fill my-4"><%= t(".episodes") %></h1>
-    <div class="d-grid d-lg-flex gap-2 align-items-center">
+    <div class="d-flex gap-2 align-items-center">
       <% if @podcast.present? %>
           <%= link_to new_podcast_episode_path(@podcast), class: "btn btn-primary btn-sm" do %>
             <%= t ".create_episode" %>

--- a/app/views/episodes/media/_complete.html.erb
+++ b/app/views/episodes/media/_complete.html.erb
@@ -9,7 +9,7 @@
     </button>
 
     <div class="form-control d-flex align-items-center">
-      <div class="text-secondary me-2"><%= media.file_name %></div>
+      <div class="text-secondary me-2 flex-grow-1 overflow-hidden text-truncate"><%= media.file_name %></div>
 
       <small class="text-danger flex-grow-1 me-2"><%= t(".unable") %></small>
 

--- a/app/views/episodes/media/_error.html.erb
+++ b/app/views/episodes/media/_error.html.erb
@@ -2,7 +2,7 @@
   <div class="form-floating input-group">
     <div class="form-control d-flex align-items-center is-invalid">
       <span class="material-icons text-primary mx-2"><%= episode.medium_video? ? "video_file" : "audio_file" %></span>
-      <div class="text-secondary mx-2 flex-grow-1"><%= media.file_name %></div>
+      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate"><%= media.file_name %></div>
       <small class="text-muted">(<%= number_to_human_size(media.file_size) %>)</small>
     </div>
 

--- a/app/views/episodes/media/_new.html.erb
+++ b/app/views/episodes/media/_new.html.erb
@@ -24,7 +24,7 @@
     <% fake_cls += " is-invalid" if invalid_msg %>
     <div class="<%= fake_cls %>">
       <span class="material-icons text-primary">upload</span>
-      <div class="text-secondary mx-2"><%= t(".hint") %></div>
+      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate"><%= t(".hint") %></div>
     </div>
 
     <% if invalid_msg %>
@@ -38,7 +38,7 @@
   <div class="form-floating d-none input-group input-group" data-upload-target="progress">
     <div class="form-control d-flex align-items-center is-changed if-visible">
       <span class="material-icons text-primary">upload</span>
-      <div class="text-secondary mx-2" data-upload-target="fileName"></div>
+      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate" data-upload-target="fileName"></div>
 
       <div class="progress flex-grow-1 me-2">
         <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-upload-target="progressBar">
@@ -62,7 +62,7 @@
 
     <div class="form-control d-flex align-items-center is-changed if-visible">
       <span class="material-icons text-primary ms-2"><%= episode.medium_video? ? "video_file" : "audio_file" %></span>
-      <div class="text-secondary mx-2 flex-grow-1" data-upload-target="fileName"></div>
+      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate" data-upload-target="fileName"></div>
       <small class="text-muted">(<span data-upload-target="fileSize"></span>)</small>
     </div>
 
@@ -77,7 +77,7 @@
   <div class="form-floating d-none" data-upload-target="error">
     <div class="form-control d-flex align-items-center is-invalid">
       <span class="material-icons text-primary mx-2"><%= episode.medium_video? ? "video_file" : "audio_file" %></span>
-      <div class="text-secondary mx-2 flex-grow-1" data-upload-target="fileName"></div>
+      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate" data-upload-target="fileName"></div>
       <small class="text-muted">(<span data-upload-target="fileSize"></span>)</small>
 
       <button class="btn" data-action="upload#cancelUpload">

--- a/app/views/episodes/media/_processing.html.erb
+++ b/app/views/episodes/media/_processing.html.erb
@@ -5,7 +5,7 @@
         <span class="visually-hidden"><%= t(".hint") %>...</span>
       </div>
 
-      <div class="text-secondary mx-2"><%= media.file_name %></div>
+      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate"><%= media.file_name %></div>
 
       <% if media.retryable? %>
         <div class="flex-grow-1">

--- a/app/views/fake/audio_segmenter.html.erb
+++ b/app/views/fake/audio_segmenter.html.erb
@@ -12,7 +12,7 @@
   data-waveform-inspector-audio-url-value="/audio/TOL_6min_720p_download.mp3"
   data-waveform-inspector-waveform-url-value="/audio/TOL_6min_720p_download.json"
   data-action="resize@window->waveform-inspector#updateLayout audio-breakpoints:markers.update->waveform-inspector#updateMarkers waveform-inspector:marker.update->audio-breakpoints#updateBreakpointMarker audio-breakpoint:marker.update->audio-breakpoints#updateBreakpointMarker audio-breakpoint:play->waveform-inspector#playMarker audio-breakpoint:seekTo->waveform-inspector#seekToMarker">
-  <header class="prx-content-header | d-flex justify-content-end mx-4 px-2 py-3">
+  <header class="prx-content-header d-flex justify-content-end mx-4 px-2 py-3">
     <h2 class="h1 fw-bold visually-hidden">Audio Segmenter</h2>
     <div class="">
       <button class="btn btn-primary">Save</button>
@@ -21,7 +21,7 @@
 
   <input type="hidden" data-audio-breakpoints-target="markersInput">
 
-  <div class="prx-waveform-inspector | d-grid gap-2 m-4">
+  <div class="prx-waveform-inspector d-grid gap-2 m-4">
     <div class="prx-waveform-inspector-container">
       <div class="prx-waveform-inspector-view-container" data-waveform-inspector-target="overview"></div>
       <div class="prx-waveform-inspector-scrollbar-wrapper">
@@ -29,8 +29,8 @@
       </div>
       <div class="prx-waveform-inspector-view-container" data-waveform-inspector-target="zoom"></div>
     </div>
-    <div class="prx-waveform-inspector-footer | d-flex justify-content-between align-items-start">
-      <div class="prx-waveform-inspector-player-controls | d-flex gap-3 align-items-center">
+    <div class="prx-waveform-inspector-footer d-flex justify-content-between align-items-start">
+      <div class="prx-waveform-inspector-player-controls d-flex gap-3 align-items-center">
         <button class="btn btn-icon btn-icon-lg btn-icon-round btn-primary" data-action="click->waveform-inspector#togglePlaying">
           <span class="material-icons playing-hide" aria-label="Play">play_arrow</span>
           <span class="material-icons playing-show" aria-label="Pause">pause</span>
@@ -76,43 +76,43 @@
   <template data-audio-breakpoints-target="controlTemplate">
     <tr data-controller="audio-breakpoint tooltip" data-audio-breakpoint-completed-class="status--completed">
       <td>
-        <span class="completed-show | material-icons text-success">check_circle</span>
-        <span class="completed-hide | material-icons text-danger">error</span>
+        <span class="completed-show material-icons text-success">check_circle</span>
+        <span class="completed-hide material-icons text-danger">error</span>
       </td>
       <td>
         <span data-audio-breakpoint-target="label">Label Text</span>
       </td>
       <td>
-        <button class="has-start-time-hide | btn btn-sm btn-primary text-nowrap" data-action="audio-breakpoint#updateStartTimeToPlayhead">
+        <button class="has-start-time-hide btn btn-sm btn-primary text-nowrap" data-action="audio-breakpoint#updateStartTimeToPlayhead">
           Insert At Playhead <span class="material-icons" aria-hidden="true">my_location</span>
         </button>
-        <div class="has-start-time-show | prx-input-group input-group-sm">
+        <div class="has-start-time-show prx-input-group input-group-sm">
           <input class="form-control" placeholder="00:00"
             data-audio-breakpoint-target="startTime"
             data-action="keypress.enter->audio-breakpoint#changeStartTime"
             data-bs-toggle="tooltip"
             data-bs-title="Edit Start Time">
-          <button class="prx-input-confirm | btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Confirm Change" data-action="audio-breakpoint#changeStartTime">
+          <button class="prx-input-confirm btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Confirm Change" data-action="audio-breakpoint#changeStartTime">
             <span class="material-icons">done</span>
           </button>
-          <button class="prx-input-confirm-hidden | btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Set To Playhead" data-action="audio-breakpoint#updateStartTimeToPlayhead">
+          <button class="prx-input-confirm-hidden btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Set To Playhead" data-action="audio-breakpoint#updateStartTimeToPlayhead">
             <span class="material-icons">my_location</span>
           </button>
-          <button class="has-end-time-hide | btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Add End Time" data-action="audio-breakpoint#addEndTime">
+          <button class="has-end-time-hide btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Add End Time" data-action="audio-breakpoint#addEndTime">
             <span class="material-icons rotate-90">expand</span>
           </button>
         </div>
-        <span class="has-end-time-show | material-icons rotate-90">expand</span>
-        <div class="has-end-time-show | prx-input-group input-group-sm">
+        <span class="has-end-time-show material-icons rotate-90">expand</span>
+        <div class="has-end-time-show prx-input-group input-group-sm">
           <input class="form-control" placeholder="00:00"
             data-audio-breakpoint-target="endTime"
             data-action="keypress.enter->audio-breakpoint#changeEndTime"
             data-bs-toggle="tooltip"
             data-bs-title="Edit End Time">
-          <button class="prx-input-confirm | btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Confirm Change" data-action="audio-breakpoint#changeEndTime">
+          <button class="prx-input-confirm btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Confirm Change" data-action="audio-breakpoint#changeEndTime">
             <span class="material-icons">done</span>
           </button>
-          <button class="prx-input-confirm-hidden | btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Set To Playhead" data-action="audio-breakpoint#updateEndTimeToPlayhead">
+          <button class="prx-input-confirm-hidden btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Set To Playhead" data-action="audio-breakpoint#updateEndTimeToPlayhead">
             <span class="material-icons">my_location</span>
           </button>
           <button class="btn btn-icon btn-icon-borderless btn-primary" data-bs-toggle="tooltip" data-bs-title="Remove End Time" data-action="audio-breakpoint#removeEndTime">
@@ -121,10 +121,10 @@
         </div>
       </td>
       <td class="justify-content-end">
-        <button class="has-end-time-show | btn btn-icon btn-icon-round btn-primary" data-action="audio-breakpoint#play">
+        <button class="has-end-time-show btn btn-icon btn-icon-round btn-primary" data-action="audio-breakpoint#play">
           <span class="material-icons">play_arrow</span>
         </button>
-        <button class="has-start-time-show | btn btn-icon btn-icon-round btn-primary" data-action="audio-breakpoint#seekTo">
+        <button class="has-start-time-show btn btn-icon btn-icon-round btn-primary" data-action="audio-breakpoint#seekTo">
           <span class="material-icons">skip_next</span>
         </button>
       </td>

--- a/app/views/fake/index.html.erb
+++ b/app/views/fake/index.html.erb
@@ -118,7 +118,7 @@
         </div>
       </div>
       <div class="dashboard-list mb-4 shadow">
-        <div class="prx-podcast | card">
+        <div class="prx-podcast card">
           <div class="d-flex g-2 p-3 align-items-center">
             <div class="card-image">
               <%= image_tag "fake-podcast.png", width: 80 %>
@@ -135,7 +135,7 @@
           </div>
         </div>
 
-        <div class="prx-podcast | card">
+        <div class="prx-podcast card">
           <div class="d-flex g-2 p-3 align-items-center">
             <div class="card-image">
               <%= image_tag "fake-podcast.png", width: 80 %>

--- a/app/views/fake/index.html.erb
+++ b/app/views/fake/index.html.erb
@@ -117,7 +117,7 @@
           <label for="episode_itunes_type">Filter Podcasts</label>
         </div>
       </div>
-      <div class="dashboard-list mb-4 shadow">
+      <div class="dashboard-list mb-4 shadow d-flex align-items-start">
         <div class="prx-podcast | card">
           <div class="d-flex g-2 p-3 align-items-center">
             <div class="card-image">

--- a/app/views/fake/index.html.erb
+++ b/app/views/fake/index.html.erb
@@ -117,7 +117,7 @@
           <label for="episode_itunes_type">Filter Podcasts</label>
         </div>
       </div>
-      <div class="dashboard-list mb-4 shadow d-flex align-items-start">
+      <div class="dashboard-list mb-4 shadow">
         <div class="prx-podcast | card">
           <div class="d-flex g-2 p-3 align-items-center">
             <div class="card-image">

--- a/app/views/images/_error.html.erb
+++ b/app/views/images/_error.html.erb
@@ -11,7 +11,7 @@
     <div class="form-floating mb-4">
       <div class="form-control d-flex align-items-center is-invalid">
         <span class="material-icons text-primary mx-2">image</span>
-        <div class="text-secondary mx-2 flex-grow-1"><%= image.file_name %></div>
+        <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate"><%= image.file_name %></div>
         <small class="text-muted">(<%= number_to_human_size(image.size) %>)</small>
       </div>
 

--- a/app/views/images/_new.html.erb
+++ b/app/views/images/_new.html.erb
@@ -31,7 +31,7 @@
       <%# fake display field; real text area is opacity-0 on top of it %>
       <div class="form-control d-flex align-items-center <%= "is-changed" if image.marked_for_destruction? %>">
         <span class="material-icons text-primary">upload</span>
-        <div class="text-secondary mx-2">Upload a file</div>
+        <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate">Upload a file</div>
       </div>
 
       <%= form.label :image_file, "Image File" %>
@@ -41,7 +41,7 @@
     <div class="form-floating d-none" data-upload-target="progress">
       <div class="form-control d-flex align-items-center is-changed if-visible">
         <span class="material-icons text-primary">upload</span>
-        <div class="text-secondary mx-2" data-upload-target="fileName"></div>
+        <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate" data-upload-target="fileName"></div>
 
         <div class="progress flex-grow-1 me-2">
           <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-upload-target="progressBar"></div>
@@ -62,7 +62,7 @@
 
       <div class="form-control d-flex align-items-center is-changed if-visible">
         <span class="material-icons text-primary ms-2">image</span>
-        <div class="text-secondary mx-2 flex-grow-1" data-upload-target="fileName"></div>
+        <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate overflow-hidden text-truncate" data-upload-target="fileName"></div>
         <small class="text-muted">(<span data-upload-target="fileSize"></span>)</small>
       </div>
 
@@ -76,7 +76,7 @@
     <div class="form-floating d-none" data-upload-target="error">
       <div class="form-control d-flex align-items-center is-invalid">
         <span class="material-icons text-primary mx-2">image</span>
-        <div class="text-secondary mx-2 flex-grow-1" data-upload-target="fileName"></div>
+        <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate overflow-hidden text-truncate " data-upload-target="fileName"></div>
         <small class="text-muted">(<span data-upload-target="fileSize"></span>)</small>
       </div>
 

--- a/app/views/images/_processing.html.erb
+++ b/app/views/images/_processing.html.erb
@@ -14,7 +14,7 @@
           <span class="visually-hidden">Loading...</span>
         </div>
 
-        <div class="text-secondary mx-2"><%= image.file_name %></div>
+        <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate"><%= image.file_name %></div>
 
         <% if image.retryable? %>
           <div class="flex-grow-1">

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -1,4 +1,4 @@
-<div class="prx-header-bar | navbar navbar-dark align-items-stretch p-0 bg-primary-dark">
+<div class="prx-header-bar navbar navbar-dark align-items-stretch p-0 bg-primary-dark">
   <div class="container-fluid align-items-stretch pe-0">
     <header class="flex-grow-1 d-flex align-items-center">
       <%= link_to image_tag("dovetail_logo.svg", width: 152, height: 30, alt: "Dovetail from PRX"), main_app.podcasts_path, class: "navbar-brand d-inline-flex" %>

--- a/app/views/layouts/_subnav.html.erb
+++ b/app/views/layouts/_subnav.html.erb
@@ -1,9 +1,9 @@
-<div class="prx-app-bar | navbar justify-content-start align-items-stretch p-0 bg-white">
+<div class="prx-app-bar navbar justify-content-start align-items-stretch p-0 bg-white">
 
   <%= render "podcast_switcher/dropdown" %>
 
   <% if @podcast %>
-    <nav class="prx-app-nav | navbar-nav flex-row justifty-content-start">
+    <nav class="prx-app-nav navbar-nav flex-row justifty-content-start">
       <% if @podcast.new_record? %>
         <%= active_link_to "Settings", main_app.new_podcast_path, class: "nav-link" %>
       <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
     <%= render "layouts/confirm_field" %>
 
     <% if content_for? :tabs %>
-      <div class="prx-main | container-fluid d-grid">
+      <div class="prx-main | container-fluid flex-grow-1">
         <div class="row">
           <aside class="prx-tabs | d-flex flex-column justify-content-between col-sm-12 col-md-3 col-xl-2">
             <nav class="prx-tabs-nav | nav nav-tabs flex-column bg-white">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,23 +22,23 @@
     <%= render "layouts/confirm_field" %>
 
     <% if content_for? :tabs %>
-      <div class="prx-main | container-fluid flex-grow-1">
+      <div class="prx-main container-fluid flex-grow-1">
         <div class="row">
-          <aside class="prx-tabs | d-flex flex-column justify-content-between col-sm-12 col-md-3 col-xl-2">
-            <nav class="prx-tabs-nav | nav nav-tabs flex-column bg-white">
+          <aside class="prx-tabs d-flex flex-column justify-content-between col-sm-12 col-md-3 col-xl-2">
+            <nav class="prx-tabs-nav nav nav-tabs flex-column bg-white">
               <%= yield :tabs %>
             </nav>
             <% if content_for? :actions %>
-              <nav class="prx-tabs-actions | d-grid gap-3 px-2 py-3">
+              <nav class="prx-tabs-actions d-grid gap-3 px-2 py-3">
                 <%= yield :actions %>
               </nav>
             <% end %>
           </aside>
-          <main class="prx-tab-content | col-sm-12 col-md-9 col-xl-10 bg-white"><%= yield %></main>
+          <main class="prx-tab-content col-sm-12 col-md-9 col-xl-10 bg-white"><%= yield %></main>
         </div>
       </div>
     <% else %>
-      <main class="prx-main | container-xl">
+      <main class="prx-main container-xl">
         <%= yield %>
       </main>
     <% end %>

--- a/app/views/podcast_switcher/_dropdown.html.erb
+++ b/app/views/podcast_switcher/_dropdown.html.erb
@@ -1,4 +1,4 @@
-<div class="prx-podcast-switcher | dropdown" data-controller="focus">
+<div class="prx-podcast-switcher dropdown" data-controller="focus">
 
   <button class="btn btn-white dropdown-toggle" type="button" id="podcast-switcher" data-bs-toggle="dropdown" aria-expanded="false" data-action="focus#focus">
     <% if @podcast %>

--- a/app/views/podcasts/_podcast_page.html.erb
+++ b/app/views/podcasts/_podcast_page.html.erb
@@ -1,4 +1,4 @@
-<div class="prx-podcast | card">
+<div class="prx-podcast card">
   <div class="d-flex g-2 p-3 align-items-center">
     <div class="card-image">
       <% if podcast.ready_image %>

--- a/app/views/podcasts/index.html.erb
+++ b/app/views/podcasts/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "My Podcasts" %>
 
-<div class="container p-0">
+<div class="mt-4 mb-2">
   <div class="d-flex align-items-center justify-content-between">
     <div class="dashboard header">
       <div class="d-flex gap-2 align-items-center">

--- a/app/views/podcasts/index.html.erb
+++ b/app/views/podcasts/index.html.erb
@@ -1,9 +1,9 @@
 <% content_for :title, "My Podcasts" %>
 
-<div class="container p-0">
+<div class="">
   <div class="d-flex align-items-center justify-content-between">
     <div class="dashboard header">
-      <div class="d-grid d-lg-flex gap-2 align-items-center">
+      <div class="d-flex gap-2 align-items-center">
         <h1 class="text-black fw-bold d-flex flex-fill my-4"><%= t(".my_podcasts") %></h1>
 
         <button class="btn btn-outline-light btn-sm dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">

--- a/app/views/podcasts/index.html.erb
+++ b/app/views/podcasts/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "My Podcasts" %>
 
-<div class="">
+<div class="container p-0">
   <div class="d-flex align-items-center justify-content-between">
     <div class="dashboard header">
       <div class="d-flex gap-2 align-items-center">

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -34,7 +34,7 @@
               </div>
             <% end %>
           <% else %>
-            <h2 class="text-muted text-center m-2"><%= t(".no_published") %></h2>
+            <p class="text-muted text-center m-2"><%= t(".no_published") %></p>
           <% end %>
         </div>
       </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -1,7 +1,7 @@
-<div class="container my-4 mx-2">
+<div class="my-4">
   <div class="d-grid d-sm-flex align-items-center">
     <%= render @podcast %>
-    <div class="d-grid d-lg-flex gap-2 align-items-center">
+    <div class="d-flex gap-2 align-items-center">
       <%= link_to new_podcast_episode_path(@podcast), class: "btn btn-primary btn-sm" do %>
         <%= t ".create_episode" %>
         <span class="material-icons ms-2" aria-hidden="true">mic</span>


### PR DESCRIPTION
will comment inline.
 
Review:
In podcasts controller, change this to:
`@podcasts = add_sorting(filtered_podcasts).where(id: 815)`

To Do:
- [ ] When a new podcast is created, Metrics (obviously) aren't available yet, right now there's a big pink warning box that could be changed to a friendlier message. 