### PR TITLE
Wait for timeouts raise exception

### DIFF
--- a/app/models/apple/api_waiting.rb
+++ b/app/models/apple/api_waiting.rb
@@ -8,6 +8,8 @@ module Apple
       def self.wait_for(remaining_records)
         t_beg = Time.now.utc
         loop do
+          Rails.logger.info(".wait_for", {remaining_records: remaining_records, have_waited: Time.now.utc - t_beg})
+
           # Return `timeout == true` if we've waited too long
           break [true, remaining_records] if Time.now.utc - t_beg > self::API_WAIT_TIMEOUT
 

--- a/app/models/apple/api_waiting.rb
+++ b/app/models/apple/api_waiting.rb
@@ -8,12 +8,13 @@ module Apple
       def self.wait_for(remaining_records)
         t_beg = Time.now.utc
         loop do
-          # TODO: handle timeout
-          break [false, remaining_records] if Time.now.utc - t_beg > self::API_WAIT_TIMEOUT
+          # Return `timeout == true` if we've waited too long
+          break [true, remaining_records] if Time.now.utc - t_beg > self::API_WAIT_TIMEOUT
 
           remaining_records = yield(remaining_records)
 
-          break [true, []] if remaining_records.empty?
+          # All done, return `timeout == false`
+          break [false, []] if remaining_records.empty?
 
           sleep(self::API_WAIT_INTERVAL)
         end

--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -25,13 +25,13 @@ module Apple
 
         remaining_eps.each do |ep|
           Rails.logger.info("Waiting for audio asset state?", {episode_id: ep.feeder_id,
-                                                                  delivery_file_count: ep.podcast_delivery_files.count,
-                                                                  delivery_files_processed_errors: ep.podcast_delivery_files.all?(&:processed_errors?),
-                                                                  delivery_files_processed: ep.podcast_delivery_files.all?(&:processed?),
-                                                                  delivery_files_delivered: ep.podcast_delivery_files.all?(&:delivered?),
-                                                                  asset_state: ep.audio_asset_state,
-                                                                  has_podcast_audio: ep&.podcast_container&.has_podcast_audio?,
-                                                                  waiting_for_asset_state: ep.waiting_for_asset_state?})
+                                                               delivery_file_count: ep.podcast_delivery_files.count,
+                                                               delivery_files_processed_errors: ep.podcast_delivery_files.all?(&:processed_errors?),
+                                                               delivery_files_processed: ep.podcast_delivery_files.all?(&:processed?),
+                                                               delivery_files_delivered: ep.podcast_delivery_files.all?(&:delivered?),
+                                                               asset_state: ep.audio_asset_state,
+                                                               has_podcast_audio: ep&.podcast_container&.has_podcast_audio?,
+                                                               waiting_for_asset_state: ep.waiting_for_asset_state?})
         end
 
         rem =

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -113,14 +113,20 @@ module Apple
       Rails.logger.tagged("##{__method__}") do
         pdfs = eps.map(&:podcast_delivery_files).flatten
 
-        Apple::PodcastDeliveryFile.wait_for_delivery_files(api, pdfs)
+        (waiting_timed_out, _) = Apple::PodcastDeliveryFile.wait_for_delivery(api, pdfs)
+        raise "Timed out waiting for delivery" if waiting_timed_out
+
+        (waiting_timed_out, _) = Apple::PodcastDeliveryFile.wait_for_processing(api, pdfs)
+        raise "Timed out waiting for processing" if waiting_timed_out
       end
     end
 
     def wait_for_asset_state(eps)
       Rails.logger.tagged("##{__method__}") do
         eps = eps.filter { |e| e.podcast_delivery_files.any?(&:api_marked_as_uploaded?) }
-        Apple::Episode.wait_for_asset_state(api, eps)
+
+        (waiting_timed_out, _) = Apple::Episode.wait_for_asset_state(api, eps)
+        raise "Timed out waiting for asset state" if waiting_timed_out
       end
     end
 

--- a/test/models/apple/api_waiting_test.rb
+++ b/test/models/apple/api_waiting_test.rb
@@ -25,7 +25,7 @@ describe Apple::ApiWaiting do
 
       step = 0
 
-      (finished_waiting, remaining) = TestWait.wait_for(records) do |remaining|
+      (timed_out, remaining) = TestWait.wait_for(records) do |remaining|
         rem = remaining.dup
 
         assert_equal intervals[step], rem
@@ -37,16 +37,17 @@ describe Apple::ApiWaiting do
         rem
       end
 
-      assert_equal finished_waiting, true
+      assert_equal timed_out, false
       assert_equal remaining, []
     end
 
     it "times out" do
-      (finished_waiting, remaining) = TestTimeout.wait_for(["a", "b", "c"]) do |remaining|
+      (timed_out, remaining) = TestTimeout.wait_for(["a", "b", "c"]) do |remaining|
         remaining
       end
+      binding.pry
 
-      assert_equal finished_waiting, false
+      assert_equal timed_out, true
       assert_equal remaining, ["a", "b", "c"]
     end
   end


### PR DESCRIPTION
Bug/TODO fix.  This makes sure that if the remote apple state polling _times out_, then an exception is raised and the publishing flow halts.