### PR TITLE
Handle castle not found error

### DIFF
--- a/app/javascript/controllers/podcast_metrics_controller.js
+++ b/app/javascript/controllers/podcast_metrics_controller.js
@@ -29,6 +29,7 @@ export default class extends Controller {
     jwt: String,
     podcast: Number,
     titles: Array,
+    warning: String,
   }
 
   connect() {
@@ -76,6 +77,9 @@ export default class extends Controller {
       (res) => {
         if (res.status === 200) {
           return res.json()
+        } else if (res.status === 403 || res.status == 404) {
+          // takes a bit for Castle to hear about the new podcast
+          this.showNotReady()
         } else {
           const err = new Error(`Got ${res.status} from ${url}`)
           console.error(err.message, err)
@@ -93,6 +97,14 @@ export default class extends Controller {
         }
       }
     )
+  }
+
+  showNotReady() {
+    this.chartTarget.innerHTML = `
+      <div class="alert alert-primary" role="alert">
+        <p class="mb-0">${this.warningValue}</p>
+      </div>
+    `
   }
 
   showError(err) {

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -73,7 +73,8 @@
              data-podcast-metrics-guids-value="<%= @metrics_guids.to_json %>"
              data-podcast-metrics-jwt-value="<%= @metrics_jwt %>"
              data-podcast-metrics-podcast-value="<%= @podcast.id %>"
-             data-podcast-metrics-titles-value="<%= @metrics_titles.to_json %>">
+             data-podcast-metrics-titles-value="<%= @metrics_titles.to_json %>"
+             data-podcast-metrics-warning-value="<%= t(".metrics_not_ready") %>">
           <div class="card-header-light d-flex gap-4 align-items-center">
             <h2 class="h4 episode-card-title fw-bold flex-fill mb-0"><%= t(".last_30") %></h2>
             <%= link_to "#{current_user_app("metrics")}/#{@podcast.id}", class: "btn btn-primary btn-sm" do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -454,6 +454,7 @@ en:
       loading: Loading...
       manage_feeds: Manage Feeds
       manage_settings: Manage Settings
+      metrics_not_ready: Download metrics not available yet
       next_scheduled: Next Scheduled or Draft
       no_published: No Published Episodes
       no_scheduled: No Scheduled Episodes


### PR DESCRIPTION
For new podcasts (or in local dev, all new podcasts you create) ... Castle will for some time have no data.

Handle this, and display a nicer message:

![image](https://github.com/PRX/feeder.prx.org/assets/1410587/bf7ff787-20bd-4d3b-87bb-b6124aa4d0d7)