### PR TITLE
Temporarily extract RSS generation from pipeline

### DIFF
--- a/app/jobs/publish_feed_job.rb
+++ b/app/jobs/publish_feed_job.rb
@@ -13,7 +13,7 @@ class PublishFeedJob < ApplicationJob
     PublishingPipelineState.complete!(podcast)
   rescue => e
     PublishingPipelineState.error!(podcast)
-    Rails.logger.error("Error publishing podcast", {podcast_id: podcast.id, error: e.message, backtrace: e.backtrace})
+    Rails.logger.error("Error publishing podcast", {podcast_id: podcast.id, error: e.message, backtrace: e.backtrace.join("\n")})
     raise e
   ensure
     PublishingPipelineState.settle_remaining!(podcast)

--- a/app/jobs/publish_feed_job.rb
+++ b/app/jobs/publish_feed_job.rb
@@ -13,6 +13,7 @@ class PublishFeedJob < ApplicationJob
     PublishingPipelineState.complete!(podcast)
   rescue => e
     PublishingPipelineState.error!(podcast)
+    Rails.logger.error("Error publishing podcast", {podcast_id: podcast.id, error: e.message, backtrace: e.backtrace})
     raise e
   ensure
     PublishingPipelineState.settle_remaining!(podcast)

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -54,6 +54,7 @@ class Podcast < ApplicationRecord
   end
 
   def self.release!(options = {})
+    Rails.logger.info("Podcast.release! called")
     PublishingPipelineState.expire_pipelines!
     Episode.release_episodes!(options)
   end

--- a/app/models/publishing_pipeline_state.rb
+++ b/app/models/publishing_pipeline_state.rb
@@ -104,7 +104,7 @@ class PublishingPipelineState < ApplicationRecord
           Rails.logger.info("Unfinished items empty, nothing to do", podcast_id: podcast.id)
           next
         end
-        if curr_running_item = PublishingQueueItem.current_unfinished_item(podcast)
+        if (curr_running_item = PublishingQueueItem.current_unfinished_item(podcast))
           Rails.logger.info("Podcast's PublishingQueueItem already has running pipeline", podcast_id: podcast.id, running_queue_item: curr_running_item.id)
           next
         end

--- a/app/models/publishing_queue_item.rb
+++ b/app/models/publishing_queue_item.rb
@@ -18,6 +18,7 @@ class PublishingQueueItem < ApplicationRecord
   end
 
   def self.ensure_queued!(podcast)
+    Rails.logger.info("Creating new PublishingQueueItem", {podcast_id: podcast.id})
     create!(podcast: podcast)
   end
 


### PR DESCRIPTION
This PR extracts the RSS publishing out of the pipeline semantics for the moment, until something like #714 can land. The RSS pipeline state transitions stub the actual RSS generation (which happens first thing in the job) so we can still observe and test the podcast partitioned concurrency primitives.

This also adds some additional logging around the publishing pipeline and queue.

