### PR TITLE
Podcast.publish! on change

### DIFF
--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -48,7 +48,7 @@ class EpisodesController < ApplicationController
     respond_to do |format|
       if @episode.save
         @episode.copy_media
-        @episode.podcast.publish!
+        @episode.podcast&.publish!
         format.html { redirect_to edit_episode_url(@episode), notice: t(".notice") }
       elsif @episode.errors.added?(:base, :media_not_ready)
         @episode.build_contents.each(&:valid?)
@@ -69,7 +69,7 @@ class EpisodesController < ApplicationController
     respond_to do |format|
       if @episode.save
         @episode.copy_media
-        @episode.podcast.publish!
+        @episode.podcast&.publish!
         format.html { redirect_to edit_episode_url(@episode), notice: t(".notice") }
       elsif @episode.errors.added?(:base, :media_not_ready)
         @episode.build_contents.each(&:valid?)
@@ -88,7 +88,7 @@ class EpisodesController < ApplicationController
 
     respond_to do |format|
       if @episode.destroy
-        @episode.podcast.publish!
+        @episode.podcast&.publish!
         format.html { redirect_to podcast_episodes_url(@episode.podcast_id), notice: t(".notice") }
       else
         format.html do

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -48,6 +48,7 @@ class EpisodesController < ApplicationController
     respond_to do |format|
       if @episode.save
         @episode.copy_media
+        @episode.podcast.publish!
         format.html { redirect_to edit_episode_url(@episode), notice: t(".notice") }
       elsif @episode.errors.added?(:base, :media_not_ready)
         @episode.build_contents.each(&:valid?)
@@ -68,6 +69,7 @@ class EpisodesController < ApplicationController
     respond_to do |format|
       if @episode.save
         @episode.copy_media
+        @episode.podcast.publish!
         format.html { redirect_to edit_episode_url(@episode), notice: t(".notice") }
       elsif @episode.errors.added?(:base, :media_not_ready)
         @episode.build_contents.each(&:valid?)
@@ -86,6 +88,7 @@ class EpisodesController < ApplicationController
 
     respond_to do |format|
       if @episode.destroy
+        @episode.podcast.publish!
         format.html { redirect_to podcast_episodes_url(@episode.podcast_id), notice: t(".notice") }
       else
         format.html do

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -26,6 +26,7 @@ class FeedsController < ApplicationController
     respond_to do |format|
       if @feed.save
         @feed.copy_media
+        @feed.podcast.publish!
         format.html { redirect_to podcast_feed_path(@podcast, @feed), notice: t(".success", model: "Feed") }
       else
         format.html do
@@ -44,6 +45,7 @@ class FeedsController < ApplicationController
     respond_to do |format|
       if @feed.save
         @feed.copy_media
+        @feed.podcast.publish!
         format.html { redirect_to podcast_feed_path(@podcast, @feed), notice: t(".success", model: "Feed") }
       else
         format.html do

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -26,7 +26,7 @@ class FeedsController < ApplicationController
     respond_to do |format|
       if @feed.save
         @feed.copy_media
-        @feed.podcast.publish!
+        @feed.podcast&.publish!
         format.html { redirect_to podcast_feed_path(@podcast, @feed), notice: t(".success", model: "Feed") }
       else
         format.html do
@@ -45,7 +45,7 @@ class FeedsController < ApplicationController
     respond_to do |format|
       if @feed.save
         @feed.copy_media
-        @feed.podcast.publish!
+        @feed.podcast&.publish!
         format.html { redirect_to podcast_feed_path(@podcast, @feed), notice: t(".success", model: "Feed") }
       else
         format.html do
@@ -60,6 +60,7 @@ class FeedsController < ApplicationController
   def destroy
     respond_to do |format|
       if @feed.destroy
+        @feed.podcast&.publish!
         format.html { redirect_to podcast_feed_path(@podcast, @podcast.default_feed), notice: t(".success", model: "Feed") }
       else
         format.html do

--- a/app/controllers/podcast_engagement_controller.rb
+++ b/app/controllers/podcast_engagement_controller.rb
@@ -10,6 +10,7 @@ class PodcastEngagementController < ApplicationController
 
     respond_to do |format|
       if @podcast.save
+        @podcast.publish!
         format.html { redirect_to podcast_engagement_path(@podcast), notice: t(".notice") }
       else
         flash.now[:error] = t(".error")

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -69,6 +69,7 @@ class PodcastsController < ApplicationController
     respond_to do |format|
       if @podcast.save
         @podcast.copy_media
+        @podcast.publish!
         format.html { redirect_to podcast_url(@podcast), notice: t(".notice") }
       else
         flash.now[:error] = t(".error")
@@ -85,6 +86,7 @@ class PodcastsController < ApplicationController
     respond_to do |format|
       if @podcast.save
         @podcast.copy_media
+        @podcast.publish!
         format.html { redirect_to edit_podcast_url(@podcast), notice: t(".notice") }
       else
         flash.now[:error] = t(".error")


### PR DESCRIPTION
Oversight: forgot to call `podcast.publish!` to write the updated RSS feed.

This logic was in several other places:

1. All the API controllers [already did this](https://github.com/PRX/feeder.prx.org/blob/main/app/controllers/api/podcasts_controller.rb#L9), calling `publish!` on the podcast in an after_action hook
    - TODO: should the episode APIs be publishing the episode, instead of the podcast???
2. Feed images will [publish! the podcast](https://github.com/PRX/feeder.prx.org/blob/master/app/models/concerns/feed_image_file.rb#L24) when the status becomes complete after processing.
3. Episode contents (audio/video) will [publish! the episode](https://github.com/PRX/feeder.prx.org/blob/master/app/models/content.rb#L45) when the status becomes complete after processing.
4. Episode images will [publish! the episode](https://github.com/PRX/feeder.prx.org/blob/master/app/models/episode_image.rb#L22) when the status becomes complete after processing.
5. The [release episodes cron job](https://github.com/PRX/feeder.prx.org/blob/main/app/jobs/release_episodes_job.rb#L5) will look for any scheduled episodes with [published_at < updated_at](https://github.com/PRX/feeder.prx.org/blob/main/app/models/episode.rb#L82) and call `.publish` on the podcast.
    - TODO: that updated_at logic makes my head hurt