### PR TITLE
Gone podcast delivery metadata

### DIFF
--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -161,7 +161,7 @@ module Apple
     def self.get_podcast_delivery_files_via_deliveries(api, podcast_deliveries)
       delivery_files_response =
         api.bridge_remote_and_retry!("getPodcastDeliveryFiles",
-          get_delivery_podcast_delivery_files_bridge_params(podcast_deliveries), batch_size: 1)
+          get_delivery_podcast_delivery_files_bridge_params(podcast_deliveries), batch_size: 1, ignore_not_found: true)
 
       # Rather than mangling and persisting the enumerated view of the delivery files from the podcast delivery
       # Instead, re-fetch the podcast delivery file from the non-list podcast delivery file resource

--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -166,8 +166,9 @@ module Apple
       # Rather than mangling and persisting the enumerated view of the delivery files from the podcast delivery
       # Instead, re-fetch the podcast delivery file from the non-list podcast delivery file resource
       formatted_bridge_params =
-        join_on(PODCAST_DELIVERY_ID_ATTR, podcast_deliveries, delivery_files_response)
-          .map do |(podcast_delivery, row)|
+        join_on(PODCAST_DELIVERY_ID_ATTR, podcast_deliveries, delivery_files_response, left_join: true).map do |(podcast_delivery, row)|
+          next if row.nil?
+
           podcast_delivery_files_ids =
             row["api_response"]["val"]["data"].map do |podcast_delivery_file_data|
               podcast_delivery_file_data["id"]
@@ -179,8 +180,9 @@ module Apple
           end
         end
           .flatten
+          .compact
 
-      api.bridge_remote_and_retry!("getPodcastDeliveryFiles", formatted_bridge_params, batch_size: 1)
+      api.bridge_remote_and_retry!("getPodcastDeliveryFiles", formatted_bridge_params, batch_size: 1, ignore_not_found: true)
     end
 
     # Map across the podcast deliveries and get the bridge params for each


### PR DESCRIPTION
closes https://github.com/PRX/feeder.prx.org/issues/680

Sets up a way to filter responses that have a 404 status.

In the case of polling, we just want to make sure we have the most up-to-date copy of the remote API state. If the delivery or delivery files are missing on the remote state, we can still use our local copies as sentinels e.g. in `Apple::PodcastContainer#delivery_settled?` and `Episode#apple_mark_for_reupload`

