### PR TITLE
Apple config tracks apple data

### DIFF
--- a/app/models/apple/config.rb
+++ b/app/models/apple/config.rb
@@ -40,5 +40,21 @@ module Apple
     def apple_key
       Base64.decode64(apple_key_pem_b64)
     end
+
+    def apple_data
+      episode_data =
+        ::Episode.where(podcast: podcast).map do |episode|
+          [episode.apple_sync_log, episode.podcast_container]
+        end.flatten.compact
+
+      podcast_delivery_data = [
+        Apple::PodcastDelivery.with_deleted.where(episode: podcast.episodes),
+        Apple::PodcastDeliveryFile.with_deleted.where(episode: podcast.episodes)
+      ]
+
+      feed_data = [public_feed.apple_sync_log, private_feed.apple_sync_log].compact
+
+      [podcast_delivery_data, episode_data, feed_data]
+    end
   end
 end

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -8,7 +8,7 @@ module Apple
 
     default_scope { includes(:apple_sync_log) }
 
-    has_one :apple_sync_log, -> { podcast_containers }, foreign_key: :feeder_id, class_name: "SyncLog"
+    has_one :apple_sync_log, -> { podcast_containers }, foreign_key: :feeder_id, class_name: "SyncLog", dependent: :destroy
     has_many :podcast_deliveries, dependent: :destroy
     has_many :podcast_delivery_files, through: :podcast_deliveries
     belongs_to :episode, class_name: "::Episode"

--- a/app/models/apple/podcast_delivery.rb
+++ b/app/models/apple/podcast_delivery.rb
@@ -8,7 +8,7 @@ module Apple
 
     default_scope { includes(:apple_sync_log) }
 
-    has_one :apple_sync_log, -> { podcast_deliveries }, foreign_key: :feeder_id, class_name: "SyncLog"
+    has_one :apple_sync_log, -> { podcast_deliveries }, foreign_key: :feeder_id, class_name: "SyncLog", dependent: :destroy
     has_many :podcast_delivery_files, dependent: :destroy
     belongs_to :episode, class_name: "::Episode"
     belongs_to :podcast_container, class_name: "::Apple::PodcastContainer"

--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -9,7 +9,7 @@ module Apple
 
     default_scope { includes(:apple_sync_log) }
 
-    has_one :apple_sync_log, -> { podcast_delivery_files }, foreign_key: :feeder_id, class_name: "SyncLog", autosave: true
+    has_one :apple_sync_log, -> { podcast_delivery_files }, foreign_key: :feeder_id, class_name: "SyncLog", autosave: true, dependent: :delete
     belongs_to :podcast_delivery
     has_one :podcast_container, through: :podcast_delivery
     belongs_to :episode, class_name: "::Episode"


### PR DESCRIPTION
Sets up a convenience method to get at all the apple data in a single tree.  Related to https://github.com/PRX/feeder.prx.org/issues/735
This allows for a handle on the data as a means of resetting the delegated delivery state for a fresh sync.