### PR TITLE
Increase audio asset state wait timeout

### DIFF
--- a/app/models/apple/api_waiting.rb
+++ b/app/models/apple/api_waiting.rb
@@ -5,8 +5,12 @@ module Apple
   module ApiWaiting
     extend ActiveSupport::Concern
     included do
+      def self.current_time
+        Time.now.utc
+      end
+
       def self.wait_for(remaining_records, wait_timeout: API_WAIT_TIMEOUT, wait_interval: API_WAIT_INTERVAL)
-        t_beg = Time.now.utc
+        t_beg = current_time
 
         waited = 0
         loop do
@@ -17,7 +21,7 @@ module Apple
 
           sleep(wait_interval)
 
-          waited = Time.now.utc - t_beg
+          waited = current_time - t_beg
           Rails.logger.info(".wait_for", {remaining_record_count: remaining_records.count, have_waited: waited})
 
           remaining_records = yield(remaining_records)

--- a/app/models/apple/api_waiting.rb
+++ b/app/models/apple/api_waiting.rb
@@ -9,6 +9,15 @@ module Apple
         Time.now.utc
       end
 
+      def self.wait_timed_out?(waited, wait_timeout)
+        if waited > wait_timeout
+          Rails.logger.info("Timed out waiting for Apple API to process", waited: waited, wait_timeout: wait_timeout)
+          true
+        else
+          false
+        end
+      end
+
       def self.wait_for(remaining_records, wait_timeout: API_WAIT_TIMEOUT, wait_interval: API_WAIT_INTERVAL)
         t_beg = current_time
 
@@ -17,7 +26,8 @@ module Apple
           # All done, return `timeout == false`
           break [false, []] if remaining_records.empty?
           # Return `timeout == true` if we've waited too long
-          break [true, remaining_records] if waited > wait_timeout
+
+          break [true, remaining_records] if wait_timed_out?(waited, wait_timeout)
 
           sleep(wait_interval)
 

--- a/app/models/apple/api_waiting.rb
+++ b/app/models/apple/api_waiting.rb
@@ -18,13 +18,22 @@ module Apple
         end
       end
 
+      def self.work_done?(remaining_records, waited, wait_timeout)
+        if remaining_records.empty?
+          Rails.logger.info("Done waiting for Apple Api work", waited: waited, wait_timeout: wait_timeout)
+          true
+        else
+          false
+        end
+      end
+
       def self.wait_for(remaining_records, wait_timeout: API_WAIT_TIMEOUT, wait_interval: API_WAIT_INTERVAL)
         t_beg = current_time
 
         waited = 0
         loop do
           # All done, return `timeout == false`
-          break [false, []] if remaining_records.empty?
+          break [false, []] if work_done?(remaining_records, waited, wait_timeout)
           # Return `timeout == true` if we've waited too long
 
           break [true, remaining_records] if wait_timed_out?(waited, wait_timeout)

--- a/app/models/apple/api_waiting.rb
+++ b/app/models/apple/api_waiting.rb
@@ -1,24 +1,26 @@
+API_WAIT_INTERVAL = 2.seconds
+API_WAIT_TIMEOUT = 5.minutes
+
 module Apple
   module ApiWaiting
-    API_WAIT_INTERVAL = 2.seconds
-    API_WAIT_TIMEOUT = 5.minutes
-
     extend ActiveSupport::Concern
     included do
-      def self.wait_for(remaining_records)
+      def self.wait_for(remaining_records, wait_timeout: API_WAIT_TIMEOUT, wait_interval: API_WAIT_INTERVAL)
         t_beg = Time.now.utc
+
+        waited = 0
         loop do
-          Rails.logger.info(".wait_for", {remaining_record_count: remaining_records.count, have_waited: Time.now.utc - t_beg})
-
-          # Return `timeout == true` if we've waited too long
-          break [true, remaining_records] if Time.now.utc - t_beg > self::API_WAIT_TIMEOUT
-
-          remaining_records = yield(remaining_records)
-
           # All done, return `timeout == false`
           break [false, []] if remaining_records.empty?
+          # Return `timeout == true` if we've waited too long
+          break [true, remaining_records] if waited > wait_timeout
 
-          sleep(self::API_WAIT_INTERVAL)
+          sleep(wait_interval)
+
+          waited = Time.now.utc - t_beg
+          Rails.logger.info(".wait_for", {remaining_record_count: remaining_records.count, have_waited: waited})
+
+          remaining_records = yield(remaining_records)
         end
       end
     end

--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -12,11 +12,14 @@ module Apple
     AUDIO_ASSET_FAILURE = "FAILURE"
     AUDIO_ASSET_SUCCESS = "SUCCESS"
 
+    EPISODE_ASSET_WAIT_TIMEOUT = 8.minutes.freeze
+    EPISODE_ASSET_WAIT_INTERVAL = 10.seconds.freeze
+
     # In the case where the episodes state is not yet ready to publish, but the
     # underlying models are ready. Poll the episodes audio asset state but
     # guard against waiting for episode assets that will never be processed.
     def self.wait_for_asset_state(api, eps)
-      wait_for(eps) do |remaining_eps|
+      wait_for(eps, wait_timeout: EPISODE_ASSET_WAIT_TIMEOUT, wait_interval: EPISODE_ASSET_WAIT_INTERVAL) do |remaining_eps|
         Rails.logger.info("Probing for episode audio asset state")
         unwrapped = get_episodes(api, remaining_eps)
 

--- a/test/models/apple/api_waiting_test.rb
+++ b/test/models/apple/api_waiting_test.rb
@@ -2,15 +2,8 @@
 
 require "test_helper"
 
-class TestWait
+class Test
   include Apple::ApiWaiting
-  API_WAIT_INTERVAL = 0.seconds
-end
-
-class TestTimeout
-  include Apple::ApiWaiting
-  API_WAIT_INTERVAL = 0.seconds
-  API_WAIT_TIMEOUT = 0.seconds
 end
 
 describe Apple::ApiWaiting do
@@ -25,7 +18,7 @@ describe Apple::ApiWaiting do
 
       step = 0
 
-      (timed_out, remaining) = TestWait.wait_for(records) do |remaining|
+      (timed_out, remaining) = Test.wait_for(records, wait_interval: 0.seconds) do |remaining|
         rem = remaining.dup
 
         assert_equal intervals[step], rem
@@ -42,7 +35,7 @@ describe Apple::ApiWaiting do
     end
 
     it "times out" do
-      (timed_out, remaining) = TestTimeout.wait_for(["a", "b", "c"]) do |remaining|
+      (timed_out, remaining) = Test.wait_for(["a", "b", "c"], wait_interval: 0.seconds, wait_timeout: 0.seconds) do |remaining|
         remaining
       end
 

--- a/test/models/apple/api_waiting_test.rb
+++ b/test/models/apple/api_waiting_test.rb
@@ -42,5 +42,22 @@ describe Apple::ApiWaiting do
       assert_equal timed_out, true
       assert_equal remaining, ["a", "b", "c"]
     end
+
+    it "times out by default after 5 minutes" do
+      current_time = Time.utc(2021, 1, 1, 0, 0, 0)
+      index = 0
+
+      Test.stub(:current_time, -> {
+                                 current_time += index.minutes
+                                 index += 1
+                               }) do
+        (timed_out, remaining) = Test.wait_for(["a", "b", "c"], wait_interval: 0.seconds) do |remaining|
+          remaining
+        end
+
+        assert_equal timed_out, true
+        assert_equal remaining, ["a", "b", "c"]
+      end
+    end
   end
 end


### PR DESCRIPTION
Seeing some timeouts on the audio asset processing.  For the small sample size we're pretty consistently bumping into the timeout.

This PR:

- Increases the timeouts to help more publishing runs complete without error
- Adds logging around the waiting/polling routine, so that we can characterise the distribution of the wait times.