### PR TITLE
Show skips updates via API

### DIFF
--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -126,8 +126,6 @@ module Apple
 
     def update_show!(sync)
       Rails.logger.warn("Skipping update for existing show!")
-      nil
-
       # TODO, map out the cases where we'd actually need to update a show
       # data = show_data(update_attributes, id: apple_id)
       # Rails.logger.info("Updating show", show_data: data)

--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -63,21 +63,32 @@ module Apple
       [{"type" => "categories", "id" => "1301"}]
     end
 
-    def show_data
+    def update_attributes
+      create_attributes.except(:releaseFrequency)
+    end
+
+    def create_attributes
       {
-        data: {
-          type: "shows",
-          relationships: {
-            allowedCountriesAndRegions: {data: api.countries_and_regions}
-          },
-          attributes: {
-            kind: "RSS",
-            rssUrl: feed_published_url,
-            releaseFrequency: "OPTOUT",
-            thirdPartyRights: "HAS_RIGHTS_TO_THIRD_PARTY_CONTENT"
+        kind: "RSS",
+        rssUrl: feed_published_url,
+        releaseFrequency: "WEEKLY",
+        thirdPartyRights: "HAS_RIGHTS_TO_THIRD_PARTY_CONTENT"
+      }
+    end
+
+    def show_data(attributes, id: nil)
+      res =
+        {
+          data: {
+            type: "shows",
+            relationships: {
+              allowedCountriesAndRegions: {data: api.countries_and_regions}
+            },
+            attributes: attributes
           }
         }
-      }
+      res[:data][:id] = id if id.present?
+      res
     end
 
     def apple_id
@@ -106,7 +117,7 @@ module Apple
     end
 
     def create_show!
-      data = show_data
+      data = show_data(create_attributes)
       Rails.logger.info("Creating show", show_data: data)
       resp = api.post("shows", data)
 
@@ -114,11 +125,17 @@ module Apple
     end
 
     def update_show!(sync)
-      show_data_with_id = show_data
-      show_data_with_id[:data][:id] = sync.external_id
-      Rails.logger.info("Updating show", show_data: show_data_with_id)
-      resp = api.patch("shows/#{sync.external_id}", show_data_with_id)
+      Rails.logger.warn("Skipping update for existing show!")
+      nil
 
+      # TODO, map out the cases where we'd actually need to update a show
+      # data = show_data(update_attributes, id: apple_id)
+      # Rails.logger.info("Updating show", show_data: data)
+      # resp = api.patch("shows/#{sync.external_id}", data)
+      #
+      # api.response(resp)
+
+      resp = api.get("shows/#{sync.external_id}")
       api.response(resp)
     end
 

--- a/test/models/apple/show_test.rb
+++ b/test/models/apple/show_test.rb
@@ -107,7 +107,9 @@ describe Apple::Show do
 
   describe "#sync!" do
     it "runs sync!" do
-      apple_show.api.stub(:patch, OpenStruct.new(body: {"data" => {"id" => "123", "attributes" => {"foo" => "bar"}}}.to_json, code: "200")) do
+      # TODO, do we need update the show?
+      # apple_show.api.stub(:patch, OpenStruct.new(body: {"data" => {"id" => "123", "attributes" => {"foo" => "bar"}}}.to_json, code: "200")) do
+      apple_show.api.stub(:get, OpenStruct.new(body: {"data" => {"id" => "123", "attributes" => {"foo" => "bar"}}}.to_json, code: "200")) do
         assert apple_show.sync_log.present?
         apple_show.sync_log.update!(api_response: {})
 
@@ -122,7 +124,7 @@ describe Apple::Show do
     end
 
     it "creates a sync log if one does not exist" do
-      apple_show.api.stub(:patch, OpenStruct.new(body: {"data" => {"id" => "123", "attributes" => {"foo" => "bar"}}}.to_json, code: "200")) do
+      apple_show.api.stub(:get, OpenStruct.new(body: {"data" => {"id" => "123", "attributes" => {"foo" => "bar"}}}.to_json, code: "200")) do
         assert apple_show.sync_log.present?
 
         sync = apple_show.sync!
@@ -161,7 +163,7 @@ describe Apple::Show do
 
   describe "#show_data" do
     it "returns a hash" do
-      assert_equal apple_show.show_data.class, Hash
+      assert_equal apple_show.show_data({}).class, Hash
     end
   end
 


### PR DESCRIPTION
Since the API has a more stringent set of requirements on the required fields,
and we don't specifically need to do updates via the API,
we can skip the updates from the Apple::Publisher publish routine.

For now lets skip any updates to the show and figure out if we really need to do that via https://github.com/PRX/feeder.prx.org/issues/739