### PR TITLE
Fix guard for podcast container

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -386,7 +386,9 @@ module Apple
     end
 
     def container_upload_complete?
-      feeder_episode.apple_podcast_container.container_upload_satisfied?
+      return false unless has_container?
+
+      podcast_container.container_upload_satisfied?
     end
 
     def audio_asset_vendor_id

--- a/app/models/apple/podcast_container.rb
+++ b/app/models/apple/podcast_container.rb
@@ -249,7 +249,8 @@ module Apple
     end
 
     def delivered?
-      return false if podcast_delivery_files.length == 0
+      # because we cannot infer if the podcast delivery files have expired
+      return true if podcast_delivery_files.length == 0
 
       (podcast_delivery_files.all?(&:delivered?) &&
         podcast_delivery_files.all?(&:processed?))
@@ -262,13 +263,7 @@ module Apple
     end
 
     def delivery_settled?
-      return false if podcast_delivery_files.length == 0
-
       delivered? && !processed_errors?
-    end
-
-    def skip_delivery?
-      container_upload_satisfied?
     end
 
     def container_upload_satisfied?
@@ -277,6 +272,10 @@ module Apple
       # get to that point and the audio is still missing, we should be able to
       # retry.
       has_podcast_audio? && delivery_settled?
+    end
+
+    def skip_delivery?
+      container_upload_satisfied?
     end
 
     def needs_delivery?

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -91,9 +91,9 @@ describe Apple::Episode do
       assert_equal true, apple_episode.waiting_for_asset_state?
     end
 
-    it "should be false if there are no podcast delivery files" do
+    it "should be true if there are no podcast delivery files and the asset state is UNSPECIFIED" do
       apple_episode.podcast_container.stub(:podcast_delivery_files, []) do
-        assert_equal false, apple_episode.waiting_for_asset_state?
+        assert_equal true, apple_episode.waiting_for_asset_state?
       end
     end
 

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -147,6 +147,18 @@ describe Apple::Episode do
         assert_equal false, ep.synced_with_apple?
       end
     end
+
+    it "should be false when the podcast_container is nil" do
+      ep = build(:apple_episode)
+      assert ep.podcast_container.nil?
+
+      # it returns early via the guard
+      ep.stub(:podcast_container, -> { raise "shouldn't happen" }) do
+        ep.stub(:has_container?, false) do
+          refute ep.container_upload_complete?
+        end
+      end
+    end
   end
 
   describe "#enclosure_filename" do

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -256,6 +256,31 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
     end
   end
 
+  describe "retry sentinals and gatekeeping" do
+    let(:container) { Apple::PodcastContainer.new }
+    describe "#delivery_settled?" do
+      it "should be settled if there are no delivery files" do
+        container.stub(:podcast_delivery_files, []) do
+          assert container.delivery_settled?
+          assert container.delivered?
+        end
+      end
+    end
+
+    describe "#container_upload_satisfied?" do
+      it "should be satisfied with podcast files and a settled delivery" do
+        container.stub(:files, [
+          {status: Apple::PodcastContainer::FILE_STATUS_SUCCESS,
+           assetRole: Apple::PodcastContainer::FILE_ASSET_ROLE_PODCAST_AUDIO}.with_indifferent_access
+        ]) do
+          container.stub(:podcast_delivery_files, []) do
+            assert container.container_upload_satisfied?
+          end
+        end
+      end
+    end
+  end
+
   describe "#destroy" do
     it "should destroy the podcast container and cascade to the delivery and delivery file" do
       apple_episode.stub(:apple_id, apple_episode_id) do


### PR DESCRIPTION
Fixes two issues:

- When polling remote data, an episode with missing delivery models necessarily has a settled delivery and falls back on the container to check if the file is present.
- Guards against a nil podcast container for episodes