### PR TITLE
Filter out archived episodes

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -388,6 +388,10 @@ module Apple
       apple_json&.dig("attributes", "publishingState") == "DRAFTING"
     end
 
+    def archived?
+      apple_json&.dig("attributes", "publishingState") == "ARCHIVED"
+    end
+
     def container_upload_complete?
       return false if missing_container?
 

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -40,6 +40,7 @@ module Apple
       eps
         .reject(&:synced_with_apple?)
         .reject(&:video_content_type?)
+        .reject(&:archived?)
     end
 
     def poll_all_episodes!

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -81,6 +81,24 @@ describe Apple::Publisher do
         end
       end
     end
+
+    it "should filter episodes that are archived" do
+      apple_episode.stub(:synced_with_apple?, false) do
+        apple_episode.stub(:video_content_type?, false) do
+          apple_episode.stub(:archived?, true) do
+            assert_equal [], apple_publisher.filter_episodes([apple_episode])
+          end
+        end
+      end
+
+      apple_episode.stub(:synced_with_apple?, false) do
+        apple_episode.stub(:video_content_type?, false) do
+          apple_episode.stub(:archived?, false) do
+            assert_equal [apple_episode], apple_publisher.filter_episodes([apple_episode])
+          end
+        end
+      end
+    end
   end
 
   describe "#episodes_to_sync" do


### PR DESCRIPTION
It's not possible to update some attributes of the episode when it's in an archived state so filter out the archived episodes before entering into the publishing flow.