### PR TITLE
Disable AR query caching when grabbing the publishing lock 

### DIFF
--- a/app/models/concerns/advisory_locks.rb
+++ b/app/models/concerns/advisory_locks.rb
@@ -8,7 +8,9 @@ module AdvisoryLocks
   def with_advisory_lock(lock_type)
     raise "Cannot lock unpersisted instances" unless persisted? && id.present?
     ActiveRecord::Base.connection.execute("SELECT pg_advisory_lock(#{lock_type}, #{id})")
-    yield
+    ActiveRecord::Base.uncached do
+      yield
+    end
   ensure
     ActiveRecord::Base.connection.execute("SELECT pg_advisory_unlock(#{lock_type}, #{id})")
   end


### PR DESCRIPTION
This PR fixes a situation where we can get a stale read via AR query caching when we are probing of the current publishing item and state.

The uniqueness constraints here would prevent a duplicate state transition, but until https://github.com/PRX/feeder.prx.org/pull/752 the publishing attempts could land in an 'error' status because of those constraints.