### PR TITLE
Feat/podcast embed player

### DIFF
--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -5,12 +5,10 @@ class PodcastPlayerController < ApplicationController
   def show
     @player_options = {}
     @player_options[:embed_player_type] = params[:embed_player_type]
+
     @player_options[:episode_number] = params[:episode_number]
-    @player_options[:season_present] = params[:season].present?
     @player_options[:season] = params[:season]
-    @player_options[:category_present] = params[:category].present?
     @player_options[:category] = params[:category]
-    @player_options[:recent] = params[:recent]
   end
 
   private

--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -5,6 +5,7 @@ class PodcastPlayerController < ApplicationController
   def show
     @player_options = {}
     @player_options[:embed_player_type] = params[:embed_player_type] || "card"
+    @player_options[:all_episodes] = params[:all_episodes] || "all"
 
     @player_options[:episode_number] = params[:episode_number]
     @player_options[:season] = params[:season]

--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -3,6 +3,12 @@ class PodcastPlayerController < ApplicationController
 
   # GET /podcasts/1/player
   def show
+    @player_options = {}
+    @player_options[:embed_player_type] = params[:embed_player_type]
+    @player_options[:episode_number] = params[:episode_number]
+    @player_options[:season] = params[:season]
+    @player_options[:category] = params[:category]
+    @player_options[:recent] = params[:recent]
   end
 
   private

--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -6,6 +6,7 @@ class PodcastPlayerController < ApplicationController
     @player_options = {}
     @player_options[:embed_player_type] = params[:embed_player_type]
     @player_options[:episode_number] = params[:episode_number]
+    @player_options[:season_present] = params[:season].present?
     @player_options[:season] = params[:season]
     @player_options[:category_present] = params[:category].present?
     @player_options[:category] = params[:category]

--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -4,7 +4,7 @@ class PodcastPlayerController < ApplicationController
   # GET /podcasts/1/player
   def show
     @player_options = {}
-    @player_options[:embed_player_type] = params[:embed_player_type]
+    @player_options[:embed_player_type] = params[:embed_player_type] || "card"
 
     @player_options[:episode_number] = params[:episode_number]
     @player_options[:season] = params[:season]

--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -7,6 +7,7 @@ class PodcastPlayerController < ApplicationController
     @player_options[:embed_player_type] = params[:embed_player_type]
     @player_options[:episode_number] = params[:episode_number]
     @player_options[:season] = params[:season]
+    @player_options[:category_present] = params[:category].present?
     @player_options[:category] = params[:category]
     @player_options[:recent] = params[:recent]
   end

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -36,7 +36,7 @@ module EmbedPlayerHelper
     embed_params(params)
   end
 
-  def embed_player_podcast_url(podcast, preview = false, options)
+  def embed_player_podcast_url(podcast, options, preview = false)
     params = {}
 
     params[EMBED_PLAYER_FEED] = podcast.published_url
@@ -63,8 +63,8 @@ module EmbedPlayerHelper
     end
   end
 
-  def embed_player_podcast_iframe(podcast, preview = false, options)
-    src = embed_player_podcast_url(podcast, preview, options)
+  def embed_player_podcast_iframe(podcast, options, preview = false)
+    src = embed_player_podcast_url(podcast, options, preview)
     allow = "monetization"
 
     if options[:embed_player_type] == "card"

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -42,9 +42,10 @@ module EmbedPlayerHelper
     params[EMBED_PLAYER_FEED] = podcast.published_url
     params[EMBED_PLAYER_PLAYLIST] = options[:episode_number] || "10"
 
-    # if options[:embed_player_type] == "card" || options[:embed_player_type] == "fixed_card"
-    #   params[EMBED_PLAYER_CARD] = "1"
-    # end
+    if params[EMBED_PLAYER_PLAYLIST].present?
+      params[EMBED_PLAYER_SEASON] = options[:season]
+      params[EMBED_PLAYER_CATEGORY] = options[:category]
+    end
 
     embed_params(params)
   end
@@ -79,6 +80,11 @@ module EmbedPlayerHelper
 
   def embed_player_type_options(selected)
     opts = %w[standard card fixed_card].map { |v| [t("helpers.label.episode.embed_player_types.#{v}"), v] }
+    options_for_select(opts, selected)
+  end
+
+  def embed_player_category_options(podcast, selected)
+    opts = podcast.feed_episodes.pluck(:categories).flatten.uniq
     options_for_select(opts, selected)
   end
 

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -40,7 +40,7 @@ module EmbedPlayerHelper
     params = {}
     params[EMBED_PLAYER_FEED] = podcast.published_url
 
-    params[EMBED_PLAYER_PLAYLIST] = options[:episode_number]
+    params[EMBED_PLAYER_PLAYLIST] = (options[:all_episodes] == "all") ? options[:all_episodes] : options[:episode_number]
     params[EMBED_PLAYER_SEASON] = options[:season]
     params[EMBED_PLAYER_CATEGORY] = options[:category]
 
@@ -87,6 +87,11 @@ module EmbedPlayerHelper
 
   def embed_player_category_options(podcast, selected)
     opts = podcast.feed_episodes.pluck(:categories).flatten.uniq
+    options_for_select(opts, selected)
+  end
+
+  def embed_player_all_episodes_options(selected)
+    opts = %w[all number].map { |v| [t("helpers.label.podcast_player.episodes_options.#{v}"), v] }
     options_for_select(opts, selected)
   end
 

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -44,6 +44,11 @@ module EmbedPlayerHelper
     params[EMBED_PLAYER_SEASON] = options[:season]
     params[EMBED_PLAYER_CATEGORY] = options[:category]
 
+    # TODO: the height styling doesn't really work here in the way Play specifies how it needs to be for a playlist, so leaving this as a TODO for now.
+    # if options[:embed_player_type] == "card" || options[:embed_player_type] == "fixed_card"
+    #   params[EMBED_PLAYER_CARD] = "1"
+    # end
+
     embed_params(params)
   end
 
@@ -71,7 +76,7 @@ module EmbedPlayerHelper
     elsif options[:embed_player_type] == "fixed_card"
       tag.iframe src: src, allow: allow, width: "500", height: "700"
     else
-      tag.iframe src: src, allow: allow, width: "100%", height: "600", style: "--aspect-ratio: 2/3; width: 100%;"
+      tag.iframe src: src, allow: allow, width: "100%", height: "200"
     end
   end
 

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -11,6 +11,9 @@ module EmbedPlayerHelper
   EMBED_PLAYER_RSS_URL = "us"
   EMBED_PLAYER_AUDIO_URL = "ua"
   DOVETAIL_TOKEN = "_t"
+  EMBED_PLAYER_PLAYLIST = "sp"
+  EMBED_PLAYER_SEASON = "se"
+  EMBED_PLAYER_CATEGORY = "ct"
 
   def embed_player_episode_url(ep, type = nil, preview = false)
     params = {}
@@ -33,6 +36,19 @@ module EmbedPlayerHelper
     embed_params(params)
   end
 
+  def embed_player_podcast_url(podcast, preview = false, options)
+    params = {}
+
+    params[EMBED_PLAYER_FEED] = podcast.published_url
+    params[EMBED_PLAYER_PLAYLIST] = options[:episode_number] || "10"
+
+    # if options[:embed_player_type] == "card" || options[:embed_player_type] == "fixed_card"
+    #   params[EMBED_PLAYER_CARD] = "1"
+    # end
+
+    embed_params(params)
+  end
+
   def embed_player_episode_iframe(ep, type = nil, preview = false)
     src = embed_player_episode_url(ep, type, preview)
     allow = "monetization"
@@ -44,6 +60,20 @@ module EmbedPlayerHelper
       tag.iframe src: src, allow: allow, width: "500", height: "700"
     else
       tag.iframe src: src, allow: allow, width: "100%", height: "200"
+    end
+  end
+
+  def embed_player_podcast_iframe(podcast, preview = false, options)
+    src = embed_player_podcast_url(podcast, preview, options)
+    allow = "monetization"
+
+    if options[:embed_player_type] == "card"
+      # TODO: this is NOW working, but I'm not sure how helpful this is to a producer that wishes to embed it.
+      tag.iframe src: src, allow: allow, width: "100%", height: "700", style: "--aspect-ratio: 2/3; width: 100%;"
+    elsif options[:embed_player_type] == "fixed_card"
+      tag.iframe src: src, allow: allow, width: "500", height: "700"
+    else
+      tag.iframe src: src, allow: allow, width: "100%", height: "600", style: "--aspect-ratio: 2/3; width: 100%;"
     end
   end
 

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -38,14 +38,11 @@ module EmbedPlayerHelper
 
   def embed_player_podcast_url(podcast, options, preview = false)
     params = {}
-
     params[EMBED_PLAYER_FEED] = podcast.published_url
-    params[EMBED_PLAYER_PLAYLIST] = options[:episode_number] || "10"
 
-    if params[EMBED_PLAYER_PLAYLIST].present?
-      params[EMBED_PLAYER_SEASON] = options[:season]
-      params[EMBED_PLAYER_CATEGORY] = options[:category]
-    end
+    params[EMBED_PLAYER_PLAYLIST] = options[:episode_number]
+    params[EMBED_PLAYER_SEASON] = options[:season]
+    params[EMBED_PLAYER_CATEGORY] = options[:category]
 
     embed_params(params)
   end

--- a/app/javascript/controllers/toggle_field_controller.js
+++ b/app/javascript/controllers/toggle_field_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["check", "field"]
+  static targets = ["check", "field", "clear"]
 
   changeCheck() {
     this.checkTarget.parentElement.classList.add("d-none")
@@ -33,5 +33,13 @@ export default class extends Controller {
 
   toggleDisplay() {
     this.fieldTarget.classList.toggle("d-none")
+  }
+
+  clearSelection() {
+    const classes = Array.from(this.clearTarget.parentElement.classList)
+    if (classes.includes("d-none")) {
+      this.clearTarget.value = null
+      this.clearTarget.dispatchEvent(new Event("change"))
+    }
   }
 }

--- a/app/javascript/controllers/toggle_field_controller.js
+++ b/app/javascript/controllers/toggle_field_controller.js
@@ -1,7 +1,7 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["check", "field", "clear"]
+  static targets = ["check", "field"]
 
   changeCheck() {
     this.checkTarget.parentElement.classList.add("d-none")
@@ -33,13 +33,5 @@ export default class extends Controller {
 
   toggleDisplay() {
     this.fieldTarget.classList.toggle("d-none")
-  }
-
-  clearSelection() {
-    const classes = Array.from(this.clearTarget.parentElement.classList)
-    if (classes.includes("d-none")) {
-      this.clearTarget.value = null
-      this.clearTarget.dispatchEvent(new Event("change"))
-    }
   }
 }

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -11,43 +11,56 @@
     </div>
   </div>
 
-  <div class="col-12 mb-4">
-    <h3 class="fw-bold"><%= t(".title.playlist") %></h3>
+  <div class="card border-light mb-4">
+    <div class="card-header-light"><%= t(".title.playlist") %></div>
 
-    <div class="form-text mb-4">
-      <%= t(".help.playlist") %>
-    </div>
-
-    <div data-controller="toggle-field">
-      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
-        <%= select_tag :all_episodes, embed_player_all_episodes_options(player_options[:all_episodes]), class: "form-control", data: {action: "dynamic-form#change toggle-field#displayOnlyThisField"}, include_blank: false %>
-        <%= label_tag t("helpers.label.podcast_player.episode_number") %>
-        <%= field_help_text t(".help.episode_number") %>
-        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    <div class="card-body">
+      <div class="form-text mb-4">
+        <%= t(".help.playlist") %>
       </div>
 
-      <div class="<%= "d-none" unless player_options[:all_episodes] == "number" %> form-floating input-group mb-2" data-controller="dynamic-form" data-toggle-field-target="field" field="number">
-        <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
-        <%= label_tag t("helpers.label.podcast_player.episode_number") %>
-        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+      <div class="row mb-4" data-controller="toggle-field">
+        <div class="col-6">
+          <div class="form-floating input-group" data-controller="dynamic-form">
+            <%= select_tag :all_episodes, embed_player_all_episodes_options(player_options[:all_episodes]), class: "form-control", data: {action: "dynamic-form#change toggle-field#displayOnlyThisField"}, include_blank: false %>
+            <%= label_tag t("helpers.label.podcast_player.episode_number") %>
+            <%= field_help_text t(".help.episode_number") %>
+            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+          </div>
+        </div>
+
+        <div class="col-6">
+          <div class="<%= "d-none" unless player_options[:all_episodes] == "number" %> form-floating input-group" data-controller="dynamic-form" data-toggle-field-target="field" field="number">
+            <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
+            <%= label_tag t("helpers.label.podcast_player.episode_number") %>
+            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="row mb-4">
+        <div class="col-6">
+          <div class="form-floating input-group" data-controller="dynamic-form">
+            <%= number_field_tag :season, player_options[:season], class: "form-control #{"form-control-blank" unless player_options[:season].present?}", data: {action: "dynamic-form#change"}, min: 0, autocomplete: "off" %>
+            <%= label_tag :season, t("helpers.label.podcast_player.season") %>
+            <%= field_help_text t(".help.season") %>
+            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+          </div>
+        </div>
+
+        <div class="col-6">
+          <div class="form-floating input-group" data-controller="dynamic-form">
+            <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control #{"form-control-blank" unless player_options[:category].present?}", data: {action: "dynamic-form#change"} %>
+            <%= label_tag :category, t("helpers.label.podcast_player.category") %>
+            <%= field_help_text t(".help.episode_category") %>
+            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+          </div>
+        </div>
       </div>
     </div>
-
-    <div class="form-floating input-group mb-2" data-controller="dynamic-form">
-      <%= number_field_tag :season, player_options[:season], class: "form-control", data: {action: "dynamic-form#change"}, min: 0, autocomplete: "off" %>
-      <%= label_tag :season, t("helpers.label.podcast_player.season") %>
-      <%= field_help_text t(".help.season") %>
-      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    <div class="card-footer">
+  <%= link_to t(".clear"), podcast_player_path(podcast), class: "btn btn-primary" %>
     </div>
-
-    <div class="form-floating input-group mb-2" data-controller="dynamic-form">
-      <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control", data: {action: "dynamic-form#change"} %>
-      <%= label_tag :category, t("helpers.label.podcast_player.category") %>
-      <%= field_help_text t(".help.episode_category") %>
-      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
-    </div>
-
-    <%= link_to t(".clear"), podcast_player_path(podcast), class: "btn btn-primary" %>
   </div>
 
   <div class="col-12 mb-4">
@@ -78,5 +91,4 @@
 
     <%= embed_player_podcast_iframe(podcast, player_options, true) %>
   </div>
-
 <% end %>

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -1,0 +1,65 @@
+<%= turbo_frame_tag "embed-player", data: {controller: "morphdom"} do %>
+
+  <div class="col-12 mb-4">
+    <div class="form-floating input-group" data-controller="dynamic-form">
+      <%= select_tag :embed_player_type, embed_player_type_options(player_options[:embed_player_type]), class: "form-control", data: {action: "dynamic-form#change"} %>
+      <%= label_tag :embed_player_style, t("helpers.label.episode.embed_player_type") %>
+      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    </div>
+
+    <div class="form-text">
+      <%= t(".help.types.#{player_options[:embed_player_type] || "card"}") %>
+    </div>
+  </div>
+
+  <div class="col-12 mb-4" data-controller="toggle-field">
+    <div class="mb-4">
+      <div class="form-check">
+        <%= check_box_tag :playlist, "1", true, data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay"}, class: "form-check-input" %>
+        <%= label_tag :playlist %>
+      </div>
+    </div>
+
+    <div class="" data-toggle-field-target="field">
+      <div class="form-floating input-group" data-controller="dynamic-form">
+        <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1 %>
+        <%= label_tag "Number of Episodes" %>
+        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+      </div>
+
+      <div class="form-check">
+        <%= check_box_tag :season, nil, false %>
+        <%= label_tag :season, "Play a single season" %>
+      </div>
+
+      <div class="form-check">
+        <%= check_box_tag :category, nil, false %>
+        <%= label_tag :category, "Play a single category" %>
+      </div>
+
+      <div class="form-check">
+        <%= check_box_tag :recent, nil, false %>
+        <%= label_tag :recent, "Play the most recent episode" %>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-12 mb-4">
+    <div class="form-floating input-group">
+
+    </div>
+  </div>
+
+  <div class="col-12 mb-4">
+    <div class="form-floating input-group">
+
+    </div>
+  </div>
+
+  <div class="col-12 mb-4">
+    <h3 class="fw-bold"><%= t(".title.preview") %></h3>
+
+    <%= embed_player_podcast_iframe(podcast, true, player_options) %>
+  </div>
+
+<% end %>

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -12,50 +12,27 @@
     </div>
   </div>
 
-  <div class="col-12 mb-4" data-controller="toggle-field">
-    <div class="mb-4">
-      <div class="form-check">
-        <%= check_box_tag :playlist, "1", true, data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay"}, class: "form-check-input" %>
-        <%= label_tag :playlist %>
-      </div>
-    </div>
-
-    <div class="" data-toggle-field-target="field">
-      <div class="form-floating input-group" data-controller="dynamic-form">
-        <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1 %>
+  <div class="col-12 mb-4">
+    <div>
+      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
+        <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
         <%= label_tag "Number of Episodes" %>
+        <%= field_help_text t(".help.episode_number") %>
         <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
       </div>
 
-      <div data-controller="toggle-field">
-        <div class="form-check">
-          <%= check_box_tag :season_present, player_options[:season_present], player_options[:season_present], data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay toggle-field#clearSelection"}, class: "form-check-input" %>
-          <%= label_tag :season_present, "Play a single season" %>
-        </div>
-
-        <div class="<%= "d-none" unless player_options[:season_present] %> form-floating input-group" data-toggle-field-target="field" data-controller="dynamic-form">
-          <%= number_field_tag :season, player_options[:season], class: "form-control", data: {toggle_field_target: "clear", action: "dynamic-form#change"} %>
-          <%= label_tag :season, t("helpers.label.episode.season") %>
-          <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
-        </div>
+      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
+        <%= number_field_tag :season, player_options[:season], class: "form-control", data: {action: "dynamic-form#change"}, min: 0, autocomplete: "off" %>
+        <%= label_tag :season, t("helpers.label.episode.season") %>
+        <%= field_help_text t(".help.season") %>
+        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
       </div>
 
-      <div data-controller="toggle-field">
-        <div class="form-check">
-          <%= check_box_tag :category_present, player_options[:category_present], player_options[:category_present], data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay toggle-field#clearSelection"}, class: "form-check-input" %>
-          <%= label_tag :category_present, "Play a single category" %>
-        </div>
-
-        <div class="<%= "d-none" unless player_options[:category_present] %> form-floating input-group" data-toggle-field-target="field" data-controller="dynamic-form">
-          <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control", data: {toggle_field_target: "clear", action: "dynamic-form#change"} %>
-          <%= label_tag :category, t("helpers.label.episode.embed_player_type") %>
-          <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
-        </div>
-      </div>
-
-      <div class="form-check">
-        <%= check_box_tag :recent, nil, false, class: "form-check-input" %>
-        <%= label_tag :recent, "Play the most recent episode" %>
+      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
+        <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control", data: {action: "dynamic-form#change"} %>
+        <%= label_tag :category, t("helpers.label.episode.category") %>
+        <%= field_help_text t(".help.episode_category") %>
+        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
       </div>
     </div>
   </div>

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -3,7 +3,7 @@
   <div class="col-12 mb-4">
     <div class="form-floating input-group" data-controller="dynamic-form">
       <%= select_tag :embed_player_type, embed_player_type_options(player_options[:embed_player_type]), class: "form-control", data: {action: "dynamic-form#change"} %>
-      <%= label_tag :embed_player_style, t("helpers.label.episode.embed_player_type") %>
+      <%= label_tag :embed_player_type, t("helpers.label.episode.embed_player_type") %>
       <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
     </div>
 
@@ -28,13 +28,22 @@
       </div>
 
       <div class="form-check">
-        <%= check_box_tag :season, nil, false %>
+        <%= check_box_tag :season, nil, false, data: {action: "dynamic-form#change"} %>
         <%= label_tag :season, "Play a single season" %>
+        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
       </div>
 
-      <div class="form-check">
-        <%= check_box_tag :category, nil, false %>
-        <%= label_tag :category, "Play a single category" %>
+      <div data-controller="toggle-field">
+        <div class="form-check">
+          <%= check_box_tag :category_present, player_options[:category_present], player_options[:category_present], data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay toggle-field#clearSelection"} %>
+          <%= label_tag :category_present, "Play a single category" %>
+        </div>
+
+        <div class="<%= "d-none" unless player_options[:category_present] %> form-floating input-group" data-toggle-field-target="field" data-controller="dynamic-form">
+          <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control", data: {toggle_field_target: "clear", action: "dynamic-form#change"} %>
+          <%= label_tag :category, t("helpers.label.episode.embed_player_type") %>
+          <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+        </div>
       </div>
 
       <div class="form-check">

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -1,40 +1,45 @@
 <%= turbo_frame_tag "embed-player", data: {controller: "morphdom"} do %>
-
   <div class="col-12 mb-4">
     <div class="form-floating input-group" data-controller="dynamic-form">
       <%= select_tag :embed_player_type, embed_player_type_options(player_options[:embed_player_type]), class: "form-control", data: {action: "dynamic-form#change"} %>
-      <%= label_tag :embed_player_type, t("helpers.label.episode.embed_player_type") %>
+      <%= label_tag :embed_player_type, t("helpers.label.podcast_player.embed_player_type") %>
       <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
     </div>
 
     <div class="form-text">
-      <%= t(".help.types.#{player_options[:embed_player_type] || "card"}") %>
+      <%= t(".help.types.#{player_options[:embed_player_type] || "standard"}") %>
     </div>
   </div>
 
   <div class="col-12 mb-4">
-    <div>
-      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
-        <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
-        <%= label_tag "Number of Episodes" %>
-        <%= field_help_text t(".help.episode_number") %>
-        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
-      </div>
+    <h3 class="fw-bold"><%= t(".title.playlist") %></h3>
 
-      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
-        <%= number_field_tag :season, player_options[:season], class: "form-control", data: {action: "dynamic-form#change"}, min: 0, autocomplete: "off" %>
-        <%= label_tag :season, t("helpers.label.episode.season") %>
-        <%= field_help_text t(".help.season") %>
-        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
-      </div>
-
-      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
-        <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control", data: {action: "dynamic-form#change"} %>
-        <%= label_tag :category, t("helpers.label.episode.category") %>
-        <%= field_help_text t(".help.episode_category") %>
-        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
-      </div>
+    <div class="form-text mb-4">
+      <%= t(".help.playlist") %>
     </div>
+
+    <div class="form-floating input-group mb-2" data-controller="dynamic-form">
+      <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
+      <%= label_tag t("helpers.label.podcast_player.episode_number") %>
+      <%= field_help_text t(".help.episode_number") %>
+      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    </div>
+
+    <div class="form-floating input-group mb-2" data-controller="dynamic-form">
+      <%= number_field_tag :season, player_options[:season], class: "form-control", data: {action: "dynamic-form#change"}, min: 0, autocomplete: "off" %>
+      <%= label_tag :season, t("helpers.label.podcast_player.season") %>
+      <%= field_help_text t(".help.season") %>
+      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    </div>
+
+    <div class="form-floating input-group mb-2" data-controller="dynamic-form">
+      <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control", data: {action: "dynamic-form#change"} %>
+      <%= label_tag :category, t("helpers.label.podcast_player.category") %>
+      <%= field_help_text t(".help.episode_category") %>
+      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    </div>
+
+    <%= link_to t(".clear"), podcast_player_path(podcast), class: "btn btn-primary" %>
   </div>
 
   <div class="col-12 mb-4">
@@ -46,7 +51,7 @@
 
     <div class="form-floating input-group">
       <%= text_field_tag :embed_player_url, embed_player_podcast_url(podcast, player_options), class: "form-control", disabled: true, autocomplete: "off" %>
-      <%= label_tag :embed_player_url, t("helpers.label.episode.embed_player_url") %>
+      <%= label_tag :embed_player_url, t("helpers.label.podcast_player.embed_player_url") %>
       <%= field_link embed_player_podcast_url(podcast, player_options) %>
       <%= field_copy embed_player_podcast_url(podcast, player_options) %>
     </div>
@@ -55,7 +60,7 @@
   <div class="col-12 mb-4">
     <div class="form-floating input-group">
       <%= text_field_tag :embed_player_iframe, embed_player_podcast_iframe(podcast, player_options), class: "form-control", disabled: true, autocomplete: "off" %>
-      <%= label_tag :embed_player_iframe, t("helpers.label.episode.embed_player_iframe") %>
+      <%= label_tag :embed_player_iframe, t("helpers.label.podcast_player.embed_player_iframe") %>
       <%= field_copy embed_player_podcast_iframe(podcast, player_options) %>
     </div>
   </div>

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -45,21 +45,32 @@
   </div>
 
   <div class="col-12 mb-4">
-    <div class="form-floating input-group">
+    <h3 class="fw-bold"><%= t(".title.copy") %></h3>
 
+    <div class="form-text mb-4">
+      <%= t(".help.copy") %>
+    </div>
+
+    <div class="form-floating input-group">
+      <%= text_field_tag :embed_player_url, embed_player_podcast_url(podcast, player_options), class: "form-control", disabled: true, autocomplete: "off" %>
+      <%= label_tag :embed_player_url, t("helpers.label.episode.embed_player_url") %>
+      <%= field_link embed_player_podcast_url(podcast, player_options) %>
+      <%= field_copy embed_player_podcast_url(podcast, player_options) %>
     </div>
   </div>
 
   <div class="col-12 mb-4">
     <div class="form-floating input-group">
-
+      <%= text_field_tag :embed_player_iframe, embed_player_podcast_iframe(podcast, player_options), class: "form-control", disabled: true, autocomplete: "off" %>
+      <%= label_tag :embed_player_iframe, t("helpers.label.episode.embed_player_iframe") %>
+      <%= field_copy embed_player_podcast_iframe(podcast, player_options) %>
     </div>
   </div>
 
   <div class="col-12 mb-4">
     <h3 class="fw-bold"><%= t(".title.preview") %></h3>
 
-    <%= embed_player_podcast_iframe(podcast, true, player_options) %>
+    <%= embed_player_podcast_iframe(podcast, player_options, true) %>
   </div>
 
 <% end %>

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -18,11 +18,19 @@
       <%= t(".help.playlist") %>
     </div>
 
-    <div class="form-floating input-group mb-2" data-controller="dynamic-form">
-      <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
-      <%= label_tag t("helpers.label.podcast_player.episode_number") %>
-      <%= field_help_text t(".help.episode_number") %>
-      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    <div data-controller="toggle-field">
+      <div class="form-floating input-group mb-2" data-controller="dynamic-form">
+        <%= select_tag :all_episodes, embed_player_all_episodes_options(player_options[:all_episodes]), class: "form-control", data: {action: "dynamic-form#change toggle-field#displayOnlyThisField"}, include_blank: false %>
+        <%= label_tag t("helpers.label.podcast_player.episode_number") %>
+        <%= field_help_text t(".help.episode_number") %>
+        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+      </div>
+
+      <div class="<%= "d-none" unless player_options[:all_episodes] == "number" %> form-floating input-group mb-2" data-controller="dynamic-form" data-toggle-field-target="field" field="number">
+        <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
+        <%= label_tag t("helpers.label.podcast_player.episode_number") %>
+        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+      </div>
     </div>
 
     <div class="form-floating input-group mb-2" data-controller="dynamic-form">

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -27,15 +27,22 @@
         <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
       </div>
 
-      <div class="form-check">
-        <%= check_box_tag :season, nil, false, data: {action: "dynamic-form#change"} %>
-        <%= label_tag :season, "Play a single season" %>
-        <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+      <div data-controller="toggle-field">
+        <div class="form-check">
+          <%= check_box_tag :season_present, player_options[:season_present], player_options[:season_present], data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay toggle-field#clearSelection"}, class: "form-check-input" %>
+          <%= label_tag :season_present, "Play a single season" %>
+        </div>
+
+        <div class="<%= "d-none" unless player_options[:season_present] %> form-floating input-group" data-toggle-field-target="field" data-controller="dynamic-form">
+          <%= number_field_tag :season, player_options[:season], class: "form-control", data: {toggle_field_target: "clear", action: "dynamic-form#change"} %>
+          <%= label_tag :season, t("helpers.label.episode.season") %>
+          <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+        </div>
       </div>
 
       <div data-controller="toggle-field">
         <div class="form-check">
-          <%= check_box_tag :category_present, player_options[:category_present], player_options[:category_present], data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay toggle-field#clearSelection"} %>
+          <%= check_box_tag :category_present, player_options[:category_present], player_options[:category_present], data: {toggle_field_target: "check", action: "toggle-field#toggleDisplay toggle-field#clearSelection"}, class: "form-check-input" %>
           <%= label_tag :category_present, "Play a single category" %>
         </div>
 
@@ -47,7 +54,7 @@
       </div>
 
       <div class="form-check">
-        <%= check_box_tag :recent, nil, false %>
+        <%= check_box_tag :recent, nil, false, class: "form-check-input" %>
         <%= label_tag :recent, "Play the most recent episode" %>
       </div>
     </div>

--- a/app/views/podcast_player/show.html.erb
+++ b/app/views/podcast_player/show.html.erb
@@ -1,3 +1,11 @@
 <%= render "podcasts/tabs" %>
 
-podcast player
+<div class="row my-4 mx-2">
+  <div class="col-lg-8">
+    <div class="row">
+      <%= render "form", podcast: @podcast, player_options: @player_options %>
+    </div>
+  </div>
+  <div class="col-lg-4 d-grid align-content-start gap-3">
+  </div>
+</div>

--- a/app/views/podcast_player/show.html.erb
+++ b/app/views/podcast_player/show.html.erb
@@ -1,11 +1,9 @@
 <%= render "podcasts/tabs" %>
 
 <div class="row my-4 mx-2">
-  <div class="col-lg-8">
+  <div class="col-lg-12">
     <div class="row">
       <%= render "form", podcast: @podcast, player_options: @player_options %>
     </div>
-  </div>
-  <div class="col-lg-4 d-grid align-content-start gap-3">
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -174,6 +174,13 @@ en:
           true: Serial
         subtitle: Teaser
         title: Title
+      podcast_player:
+        embed_player_type: Player Style
+        episode_number: Number of Episodes
+        season: Season Number
+        category: Category
+        embed_player_url: Embeddable Player Link
+        embed_player_iframe: Embeddable Player IFrame
   # specific pages/views
   episodes:
     confirm_destroy:
@@ -265,14 +272,14 @@ en:
   episode_player:
     form:
       enclosure_not_ready: No Media Files Uploaded
-      help:
+      help: &player_help
         copy: Copy the code for one of the following players, and place it on your webpage.
         types:
           card: Something about a responsive card
-          card_fixed: Fixed width card something blah
+          fixed_card: Fixed width card something blah
           standard: The standard player is responsive, meaning it automatically adjusts to the content column it is embedded in. Resize this panel to see how the player adjusts and looks at different widths.
         warning: It looks like your episode is not yet published, or very recently published. The player below is only a preview of how it will appear after your feed is updated with the new episode. Your copyable iframe/links will begin to function as expected within a few minutes of publishing.
-      title:
+      title: &player_title
         copy: Copy and Use your Embed Code
         preview: Player
         warning: Warning
@@ -583,6 +590,18 @@ en:
       end_date: End date
       month: Weeks of the Month
       period: Weekly interval
+  podcast_player:
+    form:
+      help:
+        <<: *player_help
+        episode_number: Choose the number of episodes for this playlist. Leaving this blank will play only the most recent episode.
+        season: (Optional) Choose a single season for this playlist. Leaving this blank or 0 will not add a season filter.
+        episode_category: (Optional) Choose a single category for this playlist. Leaving this blank will not add a category filter.
+        playlist: Add any options below to better specify the playlist you want to create.
+      title:
+        <<: *player_title
+        playlist: Make it a playlist
+      clear: Clear options
   podcast_switcher:
     dropdown:
       all: View all my Podcasts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -181,6 +181,9 @@ en:
         category: Category
         embed_player_url: Embeddable Player Link
         embed_player_iframe: Embeddable Player IFrame
+        episodes_options:
+          all: All Episodes
+          number: Capped Number of Episodes
   # specific pages/views
   episodes:
     confirm_destroy:
@@ -594,7 +597,7 @@ en:
     form:
       help:
         <<: *player_help
-        episode_number: Choose the number of episodes for this playlist. Leaving this blank will play only the most recent episode.
+        episode_number: Choose between showing all episodes or only a number of episodes for this playlist.
         season: (Optional) Choose a single season for this playlist. Leaving this blank or 0 will not add a season filter.
         episode_category: (Optional) Choose a single category for this playlist. Leaving this blank will not add a category filter.
         playlist: Add any options below to better specify the playlist you want to create.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -278,9 +278,9 @@ en:
       help: &player_help
         copy: Copy the code for one of the following players, and place it on your webpage.
         types:
-          card: Something about a responsive card
-          fixed_card: Fixed width card something blah
-          standard: The standard player is responsive, meaning it automatically adjusts to the content column it is embedded in. Resize this panel to see how the player adjusts and looks at different widths.
+          card: The player style that shows off your podcast's artwork and will adjust to be responsive to the size of the user's screen and the website it is embedded on. Must always be 800px tall.
+          fixed_card: The player style that shows off your podcast's artwork. The size will NOT adjust to the user's screensize. Must always be 500px wide by 800px tall.
+          standard: Default view of the PRX Player, will adjust to be responsive to the size of the user's screen and the website it is embedded on. Must always be 200px tall.
         warning: It looks like your episode is not yet published, or very recently published. The player below is only a preview of how it will appear after your feed is updated with the new episode. Your copyable iframe/links will begin to function as expected within a few minutes of publishing.
       title: &player_title
         copy: Copy and Use your Embed Code


### PR DESCRIPTION
resolves #634 

Differs slightly off design by changing the playlist checkboxes directly into inputs/selects. Added a select that displays a choice between all episodes or a number (according to how the `sp` param works). Added a "clear" button. Followed embed link structure from the Episode Embeddable Player, sans the audio link since I wasn't sure how that would work with a playlist. The card type/style doesn't really function as expected, so it's currently commented out as a TODO, along with any other customization work that needs to be added to this feature in the future.