### PR TITLE
Guard for no current or scheduled publishing items

### DIFF
--- a/app/models/publishing_pipeline_state.rb
+++ b/app/models/publishing_pipeline_state.rb
@@ -127,6 +127,8 @@ class PublishingPipelineState < ApplicationRecord
         else
           PublishFeedJob.perform_now(podcast, latest_unfinished_item)
         end
+
+        latest_unfinished_item
       end
     end
   end

--- a/test/models/publishing_pipeline_state_test.rb
+++ b/test/models/publishing_pipeline_state_test.rb
@@ -46,7 +46,7 @@ describe PublishingPipelineState do
 
       assert_difference "PublishingPipelineState.count", 1 do
         res = PublishingPipelineState.attempt!(podcast)
-        assert_equal PublishFeedJob, res.class
+        assert_equal PublishingQueueItem, res.class
       end
     end
   end


### PR DESCRIPTION
Bug fix for the cases where:

- the job is started but there is no current publishing item to compare (which would itself be an error condition)
- the in-flight jobs via https://github.com/PRX/feeder.prx.org/pull/750 may not have had a pub item supplied as top level params.