### PR TITLE
Handle unpublish (update) from deleted story

### DIFF
--- a/app/workers/story_update_worker.rb
+++ b/app/workers/story_update_worker.rb
@@ -12,6 +12,7 @@ class StoryUpdateWorker < ApplicationWorker
   def receive_story_update(data)
     parse_message(data)
 
+    return :gone.tap { Rails.logger.warn("Gone story!") } if story_deleted?
     # don't allow incomplete stories to alter a published episode
     return if episode.try(:published?) && action == "update" && story.status != "complete"
 


### PR DESCRIPTION
Seeing some 404s from CMS staging. The story unpublish (update) worker action is invoked after the story (CMS) and episode (Feeder) are deleted.

This PR guards against a gone story in the story update worker, logging a warning in that case.