### PR TITLE
Extract the call to podcast publish to a job

### DIFF
--- a/app/jobs/start_publishing_pipeline_job.rb
+++ b/app/jobs/start_publishing_pipeline_job.rb
@@ -1,0 +1,7 @@
+class StartPublishingPipelineJob < ApplicationJob
+  queue_as :feeder_publishing
+
+  def perform(podcast)
+    PublishingPipelineState.start_pipeline!(podcast)
+  end
+end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -146,7 +146,7 @@ class Podcast < ApplicationRecord
       return false
     end
 
-    PublishingPipelineState.start_pipeline!(self)
+    StartPublishingPipelineJob.perform_later(self)
   end
 
   def with_publish_lock(&block)

--- a/test/jobs/start_publishing_pipeline_job_test.rb
+++ b/test/jobs/start_publishing_pipeline_job_test.rb
@@ -7,5 +7,7 @@ describe StartPublishingPipelineJob do
     PublishingPipelineState.stub :start_pipeline!, mock do
       StartPublishingPipelineJob.perform_now(create(:podcast))
     end
+
+    mock.verify
   end
 end

--- a/test/jobs/start_publishing_pipeline_job_test.rb
+++ b/test/jobs/start_publishing_pipeline_job_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+describe StartPublishingPipelineJob do
+  it "calls start_pipeline!" do
+    mock = Minitest::Mock.new
+    mock.expect :call, ->(_podcast) {}, [Podcast]
+    PublishingPipelineState.stub :start_pipeline!, mock do
+      StartPublishingPipelineJob.perform_now(create(:podcast))
+    end
+  end
+end

--- a/test/models/podcast_test.rb
+++ b/test/models/podcast_test.rb
@@ -72,14 +72,14 @@ describe Podcast do
   describe "publishing" do
     it "creates a publish job on publish" do
       PublishingPipelineState.stub(:start_pipeline!, "published!") do
-        assert_equal podcast.publish!, "published!"
+        assert_equal StartPublishingPipelineJob, podcast.publish!.class
       end
     end
 
     it "wont create a publish job when podcast is locked" do
       PublishingPipelineState.stub(:start_pipeline!, "published!") do
         podcast.locked = true
-        refute_equal podcast.publish!, "published!"
+        refute_equal StartPublishingPipelineJob, podcast.publish!.class
       end
     end
 


### PR DESCRIPTION
In the case where we have a transaction block calling `Podcast#publish!`, we can have dirty reads from other threads _outside_ of the transaction. This PR wraps the manipulation of the partitioned concurrency publishing queues in another async job invocation. This way, the database sessions outside of the authoring transactions can see the new state of the publishing queues.