### PR TITLE
Fix: no delivery files are expected if there is no delivery

### DIFF
--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -98,17 +98,14 @@ module Apple
       episode_bridge_results
     end
 
+    def self.select_podcast_deliveries(episodes)
+      episodes.map(&:podcast_deliveries).flatten
+    end
+
     def self.create_podcast_delivery_files(api, episodes)
       return [] if episodes.empty?
 
-      podcast_containers = episodes.map(&:podcast_container)
-      podcast_deliveries = podcast_containers.map do |pc|
-        raise("Missing podcast deliveries") if pc.podcast_deliveries.empty?
-
-        pc.podcast_deliveries
-      end
-
-      podcast_deliveries = podcast_deliveries.flatten
+      podcast_deliveries = select_podcast_deliveries(episodes)
 
       # filter for only the podcast deliveries that have missing podcast delivery files
       # podcast_delivery_files are soft deleted in rails when they are replaced

--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -31,7 +31,7 @@ module Apple
       end
     end
 
-    # Apple: AppMediaAssetState
+    # Apple: DeliveryState
     delivery_state = %W[AWAITING_UPLOAD UPLOAD_COMPLETE COMPLETE FAILED].freeze
     delivery_state.map do |state|
       define_method("delivery_#{state.downcase}?") do

--- a/test/models/apple/podcast_delivery_file_test.rb
+++ b/test/models/apple/podcast_delivery_file_test.rb
@@ -1,6 +1,21 @@
 require "test_helper"
 
 class ApplePodcastDeliveryFileTest < ActiveSupport::TestCase
+  describe ".select_podcast_delivery_files" do
+    it "should return the apple_podcast_deliveries from the episodes" do
+      ep1 = OpenStruct.new(podcast_deliveries: [1, 2])
+      ep2 = OpenStruct.new(podcast_deliveries: [3])
+      ep3 = OpenStruct.new(podcast_deliveries: [])
+
+      assert_equal [1, 2, 3], Apple::PodcastDeliveryFile.select_podcast_deliveries([ep1, ep2, ep3])
+    end
+
+    it "Operates on an array of Apple::Episodes" do
+      ep1 = create(:apple_episode)
+      assert_equal [], Apple::PodcastDeliveryFile.select_podcast_deliveries([ep1])
+    end
+  end
+
   describe ".get_delivery_file_bridge_params" do
     it "should format a single bridge param row" do
       assert_equal({

--- a/test/models/apple/podcast_delivery_file_test.rb
+++ b/test/models/apple/podcast_delivery_file_test.rb
@@ -11,7 +11,7 @@ class ApplePodcastDeliveryFileTest < ActiveSupport::TestCase
     end
 
     it "Operates on an array of Apple::Episodes" do
-      ep1 = create(:apple_episode)
+      ep1 = build(:apple_episode)
       assert_equal [], Apple::PodcastDeliveryFile.select_podcast_deliveries([ep1])
     end
   end


### PR DESCRIPTION
Fixes a case where an episode was uploaded to the apple system, but the wait for linked asset state timed out.

Upon manual retry, the episode was marked for re-upload by deleting the delivery/delivery_files on the episode (`PodcastContainer#reset_source_file_metadata`). But since the _creation_  of delivery files changed with 520f2c9 (now based on Episode#needs_delivery?), the guard in the Apple::PodcastDeliveryFile class was blowing up -- expecting a delivery to be inplace.

This PR removes the assumption that a Apple::PodcastDelivery has to be in place in the delivery file sync routine. If the file is in the container, there is no need to redeliver -- in this case the episode simply needed to be marked as published.