### PR TITLE
Fix z-index and other style bugs

### DIFF
--- a/app/assets/stylesheets/shared/button.scss
+++ b/app/assets/stylesheets/shared/button.scss
@@ -71,7 +71,7 @@
   font-size: 14px;
   color: $white;
   text-transform: uppercase;
-  z-index: 9999;
+  z-index: $zindex-fixed;
   box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2), 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12);
 
   span {

--- a/app/assets/stylesheets/shared/episode-card.scss
+++ b/app/assets/stylesheets/shared/episode-card.scss
@@ -38,6 +38,7 @@
     .episode-card-inner {
       display: flex;
       flex-direction: column;
+      overflow: hidden;
       flex-grow: 1;
     }
 

--- a/app/assets/stylesheets/shared/header-nav.scss
+++ b/app/assets/stylesheets/shared/header-nav.scss
@@ -45,6 +45,7 @@
   .navbar-nav {
     display: grid;
     align-items: center;
+    z-index: $zindex-fixed;
 
     & + .navbar-nav {
       border-inline-start: 1px solid $blue;

--- a/app/assets/stylesheets/shared/header.scss
+++ b/app/assets/stylesheets/shared/header.scss
@@ -9,7 +9,7 @@
   width: 100%;
   border-bottom: 1px solid $gray-200;
   position: relative;
-  z-index: 1022;
+  z-index: $zindex-fixed;
 
   @media (min-width: 992px) {
     min-width: 350px;

--- a/app/assets/stylesheets/shared/toast.scss
+++ b/app/assets/stylesheets/shared/toast.scss
@@ -1,5 +1,5 @@
 .toaster {
-  z-index: 9999;
+  z-index: $zindex-toast;
 
   .bg-success,
   .bg-danger {

--- a/app/views/episodes/index.html.erb
+++ b/app/views/episodes/index.html.erb
@@ -34,6 +34,7 @@
     </div>
   </div>
 
+<div class="container">
   <%= turbo_frame_tag "episodes", target: "_top" do %>
     <div class="row mb-4">
       <div class="col-md-6">
@@ -61,4 +62,5 @@
       </div>
     </div>
   <% end %>
+</div>
 </div>

--- a/app/views/episodes/index.html.erb
+++ b/app/views/episodes/index.html.erb
@@ -34,33 +34,33 @@
     </div>
   </div>
 
-<div class="container">
-  <%= turbo_frame_tag "episodes", target: "_top" do %>
-    <div class="row mb-4">
-      <div class="col-md-6">
-        <h2 class="fw-bold"><%= t(".draft_or_scheduled") %></h2>
-        <% @scheduled_episodes.each do |episode| %>
-          <%= render episode %>
-        <% end %>
+  <div class="container">
+    <%= turbo_frame_tag "episodes", target: "_top" do %>
+      <div class="row mb-4">
+        <div class="col-md-6">
+          <h2 class="fw-bold"><%= t(".draft_or_scheduled") %></h2>
+          <% @scheduled_episodes.each do |episode| %>
+            <%= render episode %>
+          <% end %>
 
-        <div class="mt-2">
-          <%= paginate @scheduled_episodes, param_name: "scheduled_page", window: 2, outer_window: 1 %>
-          <%= page_entries_info @scheduled_episodes %>
+          <div class="mt-2">
+            <%= paginate @scheduled_episodes, param_name: "scheduled_page", window: 2, outer_window: 1 %>
+            <%= page_entries_info @scheduled_episodes %>
+          </div>
+        </div>
+
+        <div class="col-md-6">
+          <h2 class="fw-bold"><%= t(".published") %></h2>
+          <% @published_episodes.each do |episode| %>
+            <%= render episode %>
+          <% end %>
+
+          <div class="mt-2">
+            <%= paginate @published_episodes, param_name: "published_page", window: 2, outer_window: 1 %>
+            <%= page_entries_info @published_episodes %>
+          </div>
         </div>
       </div>
-
-      <div class="col-md-6">
-        <h2 class="fw-bold"><%= t(".published") %></h2>
-        <% @published_episodes.each do |episode| %>
-          <%= render episode %>
-        <% end %>
-
-        <div class="mt-2">
-          <%= paginate @published_episodes, param_name: "published_page", window: 2, outer_window: 1 %>
-          <%= page_entries_info @published_episodes %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-</div>
+    <% end %>
+  </div>
 </div>


### PR DESCRIPTION
- Fixes Z-index issue in the ID App Switcher dropdown menu on Episode pages by adjusting custom z-index values to [bootstrap z-index variables](https://getbootstrap.com/docs/5.2/layout/z-index/)

EPISODE Landing page:
- Adds a container div to the episodes index page, so that when teasers get long, the episode columns don't get wildly wide
- Audio status badge should now always be present in the episode-card