### PR TITLE
#800: Fix import help text

### DIFF
--- a/app/views/feeds/_form_audio_format.html.erb
+++ b/app/views/feeds/_form_audio_format.html.erb
@@ -8,7 +8,7 @@
     <div class="card-body">
       <div class="row">
         <div class="col-3">
-          <div class="form-floating input-group">
+          <div class="form-floating input-group" aria-label="audio type">
             <%= form.select :audio_type, audio_format_options, {include_blank: true}, data: {action: "toggle-field#displayOnlyThisField"} %>
             <%= form.label :audio_type %>
           </div>

--- a/app/views/imports/_form_status.html.erb
+++ b/app/views/imports/_form_status.html.erb
@@ -9,8 +9,6 @@
         <%= form.select :feed_source, ["RSS"] %>
         <%= form.label :feed_source, required: true %>
       </div>
-
-      <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= "help" %>"><span class="material-icons">help</span></button>
     </div>
 
     <div class="col-12 prx-field-group">
@@ -18,14 +16,15 @@
         <%= form.text_field :url %>
         <%= form.label :url, required: true %>
       </div>
-
-      <button type="button" class="prx-btn-help" data-bs-toggle="popover" data-bs-content="<%= "help" %>"><span class="material-icons">help</span></button>
     </div>
 
     <div class="col-12 prx-field-group">
       <div class="form-check">
         <%= form.check_box :import_metadata, checked: true %>
-        <%= form.label :import_metadata %>
+        <div class="d-flex align-items-center">
+          <%= form.label :import_metadata %>
+          <%= help_text t(".help.import_metadata") %>
+        </div>
       </div>
     </div>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -723,6 +723,8 @@ en:
     form_status:
       title: Import
       submit: Start Import
+      help:
+        import_metadata: If selected, the values from the RSS feed channel will override any values added to the Metadata tab. For example, if the title in the feed differs from the podcast title previously listed, the title in the RSS feed will be used.
     import:
       id: Import ID
       url: URL


### PR DESCRIPTION
Closes: #800 

- Removes empty help text on Feed type and feed URL
- Adds help text to "import podcast metadata"