### PR TITLE
Playback video files as video

### DIFF
--- a/app/assets/stylesheets/app/uploads.scss
+++ b/app/assets/stylesheets/app/uploads.scss
@@ -108,3 +108,8 @@
     font-size: 10px;
   }
 }
+
+.prx-video-player {
+  width: 100%;
+  height: auto;
+}

--- a/app/views/episode_media/media/_complete.html.erb
+++ b/app/views/episode_media/media/_complete.html.erb
@@ -1,64 +1,10 @@
 <%= form.hidden_field :id %>
 <div class="col-12 mb-4">
-<% if episode.medium_video? %>
-  <video src="<%= media.href %>" class="prx-video-player mb-4" width="400" controls></video>
-
-  <div class="form-floating input-group">
-    <div class="form-control d-flex align-items-center">
-      <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
-
-      <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
-    </div>
-
-    <label><%= episode_media_label(episode, media) %></label>
-
-    <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
-      <span class="material-icons text-danger">delete</span>
-    <% end %>
-
-    <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
-      <span class="material-icons text-primary">info</span>
-    </button>
-  </div>
-<% else %>
-
-  <div class="form-floating input-group prx-audio-player" data-controller="audio-player">
-    <button type="button" class="prx-play input-group-text prx-input-group-text" data-action="audio-player#play">
-      <span class="material-icons text-primary">play_arrow</span>
-    </button>
-
-    <button type="button" class="prx-pause input-group-text prx-input-group-text" data-action="audio-player#pause">
-      <span class="material-icons text-primary">pause</span>
-    </button>
-
-    <div class="form-control d-flex align-items-center">
-      <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
-
-      <small class="text-danger flex-grow-1 me-2"><%= t(".unable") %></small>
-
-      <div class="flex-grow-1 me-2 py-2 prx-scrub" data-action="mousedown->audio-player#mouseDown" data-audio-player-target="scrubber">
-        <div class="progress" data-audio-player-target="progress">
-          <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-audio-player-target="progressBar"></div>
-        </div>
-      </div>
-
-      <audio class="d-none" src="<%= media.href %>" preload="none" data-audio-player-target="audio" data-action="timeupdate->audio-player#audioTimeUpdate ended->audio-player#audioEnded"></audio>
-
-      <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
-    </div>
-
-    <label><%= episode_media_label(episode, media) %></label>
-
-    <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
-      <span class="material-icons text-danger">delete</span>
-    <% end %>
-
-    <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
-      <span class="material-icons text-primary">info</span>
-    </button>
-  </div>
-
-<% end %>
+  <% if episode.medium_video? %>
+    <%= render "episode_media/media/complete_video", form: form, episode: episode, media: media %>
+  <% else %>
+    <%= render "episode_media/media/complete_audio", form: form, episode: episode, media: media %>
+  <% end %>
 </div>
 
 <%= render "episode_media/media/modal", episode: episode, media: media, id: "media-modal-#{media.id}" %>

--- a/app/views/episode_media/media/_complete.html.erb
+++ b/app/views/episode_media/media/_complete.html.erb
@@ -1,6 +1,27 @@
 <%= form.hidden_field :id %>
-
 <div class="col-12 mb-4">
+<% if episode.medium_video? %>
+  <video src="<%= media.href %>" class="prx-video-player mb-4" width="400" controls></video>
+
+  <div class="form-floating input-group">
+    <div class="form-control d-flex align-items-center">
+      <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
+
+      <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
+    </div>
+
+    <label><%= episode_media_label(episode, media) %></label>
+
+    <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
+      <span class="material-icons text-danger">delete</span>
+    <% end %>
+
+    <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
+      <span class="material-icons text-primary">info</span>
+    </button>
+  </div>
+<% else %>
+
   <div class="form-floating input-group prx-audio-player" data-controller="audio-player">
     <button type="button" class="prx-play input-group-text prx-input-group-text" data-action="audio-player#play">
       <span class="material-icons text-primary">play_arrow</span>
@@ -36,6 +57,8 @@
       <span class="material-icons text-primary">info</span>
     </button>
   </div>
+
+<% end %>
 </div>
 
 <%= render "episode_media/media/modal", episode: episode, media: media, id: "media-modal-#{media.id}" %>

--- a/app/views/episode_media/media/_complete_audio.html.erb
+++ b/app/views/episode_media/media/_complete_audio.html.erb
@@ -1,0 +1,35 @@
+<div class="form-floating input-group prx-audio-player" data-controller="audio-player">
+    <button type="button" class="prx-play input-group-text prx-input-group-text" data-action="audio-player#play">
+        <span class="material-icons text-primary">play_arrow</span>
+    </button>
+
+    <button type="button" class="prx-pause input-group-text prx-input-group-text" data-action="audio-player#pause">
+        <span class="material-icons text-primary">pause</span>
+    </button>
+
+    <div class="form-control d-flex align-items-center">
+        <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
+
+        <small class="text-danger flex-grow-1 me-2"><%= t(".unable") %></small>
+
+        <div class="flex-grow-1 me-2 py-2 prx-scrub" data-action="mousedown->audio-player#mouseDown" data-audio-player-target="scrubber">
+        <div class="progress" data-audio-player-target="progress">
+            <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-audio-player-target="progressBar"></div>
+        </div>
+        </div>
+
+        <audio class="d-none" src="<%= media.href %>" preload="none" data-audio-player-target="audio" data-action="timeupdate->audio-player#audioTimeUpdate ended->audio-player#audioEnded"></audio>
+
+        <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
+    </div>
+
+    <label><%= episode_media_label(episode, media) %></label>
+
+    <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
+        <span class="material-icons text-danger">delete</span>
+    <% end %>
+
+    <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
+        <span class="material-icons text-primary">info</span>
+    </button>
+</div>

--- a/app/views/episode_media/media/_complete_audio.html.erb
+++ b/app/views/episode_media/media/_complete_audio.html.erb
@@ -1,35 +1,35 @@
 <div class="form-floating input-group prx-audio-player" data-controller="audio-player">
-    <button type="button" class="prx-play input-group-text prx-input-group-text" data-action="audio-player#play">
-        <span class="material-icons text-primary">play_arrow</span>
-    </button>
+  <button type="button" class="prx-play input-group-text prx-input-group-text" data-action="audio-player#play">
+    <span class="material-icons text-primary">play_arrow</span>
+  </button>
 
-    <button type="button" class="prx-pause input-group-text prx-input-group-text" data-action="audio-player#pause">
-        <span class="material-icons text-primary">pause</span>
-    </button>
+  <button type="button" class="prx-pause input-group-text prx-input-group-text" data-action="audio-player#pause">
+    <span class="material-icons text-primary">pause</span>
+  </button>
 
-    <div class="form-control d-flex align-items-center">
-        <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
+  <div class="form-control d-flex align-items-center">
+    <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
 
-        <small class="text-danger flex-grow-1 me-2"><%= t(".unable") %></small>
+    <small class="text-danger flex-grow-1 me-2"><%= t(".unable") %></small>
 
-        <div class="flex-grow-1 me-2 py-2 prx-scrub" data-action="mousedown->audio-player#mouseDown" data-audio-player-target="scrubber">
-        <div class="progress" data-audio-player-target="progress">
-            <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-audio-player-target="progressBar"></div>
-        </div>
-        </div>
-
-        <audio class="d-none" src="<%= media.href %>" preload="none" data-audio-player-target="audio" data-action="timeupdate->audio-player#audioTimeUpdate ended->audio-player#audioEnded"></audio>
-
-        <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
+    <div class="flex-grow-1 me-2 py-2 prx-scrub" data-action="mousedown->audio-player#mouseDown" data-audio-player-target="scrubber">
+      <div class="progress" data-audio-player-target="progress">
+        <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" data-audio-player-target="progressBar"></div>
+      </div>
     </div>
 
-    <label><%= episode_media_label(episode, media) %></label>
+    <audio class="d-none" src="<%= media.href %>" preload="none" data-audio-player-target="audio" data-action="timeupdate->audio-player#audioTimeUpdate ended->audio-player#audioEnded"></audio>
 
-    <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
-        <span class="material-icons text-danger">delete</span>
-    <% end %>
+    <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
+  </div>
 
-    <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
-        <span class="material-icons text-primary">info</span>
-    </button>
+  <label><%= episode_media_label(episode, media) %></label>
+
+  <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
+    <span class="material-icons text-danger">delete</span>
+  <% end %>
+
+  <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
+    <span class="material-icons text-primary">info</span>
+  </button>
 </div>

--- a/app/views/episode_media/media/_complete_video.html.erb
+++ b/app/views/episode_media/media/_complete_video.html.erb
@@ -1,0 +1,19 @@
+  <video src="<%= media.href %>" class="prx-video-player mb-4" width="400" controls></video>
+
+  <div class="form-floating input-group">
+    <div class="form-control d-flex align-items-center">
+      <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
+
+      <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
+    </div>
+
+    <label><%= episode_media_label(episode, media) %></label>
+
+    <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
+      <span class="material-icons text-danger">delete</span>
+    <% end %>
+
+    <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
+      <span class="material-icons text-primary">info</span>
+    </button>
+  </div>

--- a/app/views/episode_media/media/_complete_video.html.erb
+++ b/app/views/episode_media/media/_complete_video.html.erb
@@ -1,19 +1,19 @@
-  <video src="<%= media.href %>" class="prx-video-player mb-4" width="400" controls></video>
+<video src="<%= media.href %>" class="prx-video-player mb-4" width="400" controls></video>
 
-  <div class="form-floating input-group">
-    <div class="form-control d-flex align-items-center">
-      <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
+<div class="form-floating input-group">
+  <div class="form-control d-flex align-items-center">
+    <div class="text-secondary me-2 overflow-hidden text-truncate"><%= media.file_name %></div>
 
-      <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
-    </div>
-
-    <label><%= episode_media_label(episode, media) %></label>
-
-    <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
-      <span class="material-icons text-danger">delete</span>
-    <% end %>
-
-    <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
-      <span class="material-icons text-primary">info</span>
-    </button>
+    <small class="text-muted" data-audio-player-target="duration">(<%= episode_media_duration(media) %>)</small>
   </div>
+
+  <label><%= episode_media_label(episode, media) %></label>
+
+  <%= link_to episode_media_path(media.episode, uploads_destroy_params(form)), class: "input-group-text prx-input-group-text" do %>
+    <span class="material-icons text-danger">delete</span>
+  <% end %>
+
+  <button type="button" class="input-group-text prx-input-group-text" data-bs-toggle="modal" data-bs-target="#media-modal-<%= media.id %>">
+    <span class="material-icons text-primary">info</span>
+  </button>
+</div>


### PR DESCRIPTION
Closes #773 

I went and outdid myself here! I got video files playing back as video without affect audio uploads.

- Videos are responsive to the card width.
- Uses the default browser player.

To test:

- [ ] Create a new episode
- [ ] Choose Video as the file option
- [ ] Upload a video file and then save
- [ ] After processing a video file should be playing back 

![Screenshot 2023-08-23 at 2 14 09 PM](https://github.com/PRX/feeder.prx.org/assets/369739/75bda129-4c4d-4cbb-b2f8-785faeacc882)

- [ ] Test audio by uploading a new audio file
- [ ] Ensure it works as expected
