### PR TITLE
Add conditional on filter to default to base query

### DIFF
--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -14,7 +14,11 @@ class PodcastsController < ApplicationController
   # GET /podcasts
   def index
     base_query = policy_scope(Podcast).page(params[:page]).per(DEFAULT_PAGE_SIZE).includes(default_feed: :feed_images)
-    filtered_podcasts = base_query.filter_by_title(params[:q])
+    filtered_podcasts = if params[:q].present?
+      base_query.filter_by_title(params[:q])
+    else
+      base_query
+    end
     @podcasts = add_sorting(filtered_podcasts)
 
     @published_episodes_counts = Episode.where(podcasts: @podcasts).published.group(:podcast_id).count


### PR DESCRIPTION
resolves #798 

masqueraded as Farski and was able to reproduce the mismatched podcast bug. it was an issue of the search filter used on each; the switcher does not use a text filter if nothing is input, whereas `podcasts#index` did not have that conditional. as a result, `podcasts#index` seemed to be filtering some podcasts even with an empty string, resulting in the mismatched podcast numbers.