### PR TITLE
Add div wrapping to metadata and episode description fields

### DIFF
--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -29,7 +29,9 @@
       <%= help_text t(".help.description") %>
     </div>
     <div class="card-body">
-      <%= form.trix_editor :description %>
+      <div class="form-floating">
+        <%= form.trix_editor :description %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -23,9 +23,11 @@
       <%= help_text t(".help.description") %>
     </div>
     <div class="card-body">
-      <%= form.fields_for :default_feed do |fields| %>
-        <%= fields.trix_editor :description %>
-      <% end %>
+      <div class="form-floating">
+        <%= form.fields_for :default_feed do |fields| %>
+          <%= fields.trix_editor :description %>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
resolves #802 

the `div` wrappers solve the `is-changed` part of the bug. and it seems that in staging the other part of the bug no longer shows up, so it seems resolved for now.