### PR TITLE
Fixup episode feed-ready logic

### DIFF
--- a/app/models/concerns/episode_media.rb
+++ b/app/models/concerns/episode_media.rb
@@ -7,8 +7,11 @@ module EpisodeMedia
     contents.complete_or_replaced.group_by(&:position).values.map(&:first)
   end
 
+  # TODO: not ideal, but we need to ensure this stays true forever, after the
+  # first time the episode is written to any feed. for now, just assume that
+  # takes about an hour.
   def complete_media?
-    if published?
+    if published? && published_at < 1.hour.ago
       complete_media.any?
     else
       media_ready?

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -80,8 +80,12 @@ class EpisodeStoryHandler
       []
     end
 
-    episode.media = audio.sort_by(&:position).map do |a|
-      a.links["prx:storage"].href
+    # possible race condition i couldn't quite track down, when replacing files on a
+    # published episode - so let's just not allow deleting it for now
+    unless episode.published? && audio.empty?
+      episode.media = audio.sort_by(&:position).map do |a|
+        a.links["prx:storage"].href
+      end
     end
   end
 

--- a/app/models/episode_story_handler.rb
+++ b/app/models/episode_story_handler.rb
@@ -105,22 +105,6 @@ class EpisodeStoryHandler
     end
   end
 
-  def build_content(audio)
-    update_content(Content.new, audio)
-  end
-
-  def update_content(content, audio)
-    content.tap do |c|
-      c.position = audio.attributes["position"]
-      c.href = audio.links["prx:storage"].href
-      c.mime_type = audio.links["prx:storage"].type || audio.attributes["content_type"]
-      c.file_size = audio.attributes["size"]
-      c.duration = audio.attributes["duration"]
-      c.bit_rate = audio.attributes["bit_rate"]
-      c.sample_rate = audio.attributes["frequency"] * 1000 if audio.attributes["frequency"]
-    end
-  end
-
   def get_story(account = nil)
     return nil unless episode.prx_uri
 

--- a/test/models/concerns/episode_media_test.rb
+++ b/test/models/concerns/episode_media_test.rb
@@ -5,7 +5,7 @@ class EpisodeMediaTest < ActiveSupport::TestCase
   let(:c2) { build_stubbed(:content, status: "complete", position: 2) }
   let(:ep) { build(:episode, segment_count: 2, contents: [c1, c2]) }
 
-  describe "#complete_media_ready?" do
+  describe "#complete_media?" do
     it "checks for any complete_media if published" do
       ep.published_at = 1.day.ago
 
@@ -14,6 +14,21 @@ class EpisodeMediaTest < ActiveSupport::TestCase
       end
 
       ep.stub(:complete_media, [c1]) do
+        assert ep.complete_media?
+      end
+    end
+
+    it "checks for media_ready? if published in the past hour" do
+      ep.stub(:complete_media, [c2]) do
+        # recently published - ignores complete media
+        ep.published_at = 10.minutes.ago
+        assert ep.complete_media?
+
+        c1.status = "processing"
+        refute ep.complete_media?
+
+        # published > 1 hour ago - will serve any complete_media
+        ep.published_at = 61.minutes.ago
         assert ep.complete_media?
       end
     end


### PR DESCRIPTION
Fixes 2 recent prod issues:

1. An episode publishing to the feed before all of its files had processed (`episode.include_in_feed?` was true ... because `complete_media?` was also true)
2. CMS announced updates to a published episode briefly resulted in `complete_media?` returning false (it deleted the old media files without setting `replaced_at`).  Dovetail 500'd.