### PR TITLE
820: Embed player forms

### DIFF
--- a/app/assets/stylesheets/shared/bootstrap-variables.scss
+++ b/app/assets/stylesheets/shared/bootstrap-variables.scss
@@ -146,6 +146,7 @@ $utilities: (
     property: line-height,
     class: lh,
     values: (
+      0: 0,
       1: 1,
       xs: $line-height-xs,
       sm: $line-height-sm,

--- a/app/controllers/episode_player_controller.rb
+++ b/app/controllers/episode_player_controller.rb
@@ -5,6 +5,10 @@ class EpisodePlayerController < ApplicationController
 
     authorize @episode, :show?
 
-    @embed_player_type = params[:embed_player_type]
+    @player_options = {}
+    @player_options[:embed_player_type] = params[:embed_player_type] || "standard"
+    @player_options[:embed_player_theme] = params[:embed_player_theme] || "dark"
+    @player_options[:accent_color] = params[:accent_color] || ['#ff9600']
+    @player_options[:episode_guid] = Episode.find_by_guid!(params[:episode_id])
   end
 end

--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -4,9 +4,10 @@ class PodcastPlayerController < ApplicationController
   # GET /podcasts/1/player
   def show
     @player_options = {}
-    @player_options[:embed_player_type] = params[:embed_player_type] || "card"
+    @player_options[:embed_player_type] = params[:embed_player_type] || "standard"
+    @player_options[:embed_player_theme] = params[:embed_player_theme] || "dark"
+    @player_options[:accent_color] = params[:accent_color] || ['#ff9600']
     @player_options[:all_episodes] = params[:all_episodes] || "all"
-
     @player_options[:episode_number] = params[:episode_number]
     @player_options[:season] = params[:season]
     @player_options[:category] = params[:category]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,14 +53,14 @@ module ApplicationHelper
     end
   end
 
-  def field_link(href)
-    link_to href, class: "input-group-text prx-input-group-text", target: :_blank do
+  def field_link(href, data = {})
+    link_to href, class: "input-group-text prx-input-group-text", target: :_blank, data: data do
       tag.span "open_in_new", class: "material-icons text-primary"
     end
   end
 
-  def field_copy(content)
-    data = {controller: "clipboard", clipboard_copy_value: content, clipboard_tooltip_value: t("helpers.application.field_copy_tooltip")}
+  def field_copy(content, data = {})
+    data = {controller: "clipboard", clipboard_copy_value: content, clipboard_tooltip_value: t("helpers.application.field_copy_tooltip")}.merge(data)
 
     tag.button class: "input-group-text prx-input-group-text", data: data do
       tag.span "link", class: "material-icons text-primary"

--- a/app/helpers/embed_player_helper.rb
+++ b/app/helpers/embed_player_helper.rb
@@ -3,6 +3,7 @@ module EmbedPlayerHelper
 
   EMBED_PLAYER_LANDING_PATH = "/listen"
   EMBED_PLAYER_PATH = "/e"
+  EMBED_PLAYER_PREVIEW_PATH = "/preview"
   EMBED_PLAYER_FEED = "uf"
   EMBED_PLAYER_GUID = "ge"
   EMBED_PLAYER_CARD = "ca"
@@ -48,48 +49,73 @@ module EmbedPlayerHelper
     params = {}
     params[EMBED_PLAYER_FEED] = podcast.published_url
 
-    params[EMBED_PLAYER_PLAYLIST] = (options[:all_episodes] == "all") ? options[:all_episodes] : options[:episode_number]
-    params[EMBED_PLAYER_SEASON] = options[:season]
-    params[EMBED_PLAYER_CATEGORY] = options[:category]
+    if options[:all_episodes] === "all"
+      params[EMBED_PLAYER_PLAYLIST] = "all"
+    end
 
-    # TODO: the height styling doesn't really work here in the way Play specifies how it needs to be for a playlist, so leaving this as a TODO for now.
-    # if options[:embed_player_type] == "card" || options[:embed_player_type] == "fixed_card"
-    #   params[EMBED_PLAYER_CARD] = "1"
-    # end
+    if options[:all_episodes] == "number" && options[:episode_number].to_i > 1
+      params[EMBED_PLAYER_PLAYLIST] = options[:episode_number]
+    end
+
+    if !options[:season].to_s.strip.empty? && options[:season].to_i > 0
+      params[EMBED_PLAYER_SEASON] = options[:season]
+    end
+
+    if !options[:category].to_s.strip.empty?
+      params[EMBED_PLAYER_CATEGORY] = options[:category]
+    end
+
+    if options[:embed_player_type] == "card" || options[:embed_player_type] == "fixed_card"
+      params[EMBED_PLAYER_CARD] = "1"
+    end
 
     embed_params(params)
   end
 
   def embed_player_episode_iframe(ep, type = nil, preview = false)
     src = embed_player_episode_url(ep, type, preview)
-    allow = "monetization"
+    allow = "monetization origin"
+    data = { :embed_preview_target => 'embedIframe' }
 
     if type == "card"
-      # TODO: this is NOW working, but I'm not sure how helpful this is to a producer that wishes to embed it.
-      tag.iframe src: src, allow: allow, width: "100%", height: "700", style: "--aspect-ratio: 2/3; width: 100%;"
+      # Responsive cards require a wrapper div around iframe. The wrapper uses padding to determine the size of the area the iframe should fill.
+      tag.div style: "position: relative; height: 0; width: 100%; padding-top: calc(100% + 200px);" do
+        tag.iframe src: src, allow: allow, width: "100%", height: "100%", style: "position: absolute; inset: 0;", data: data
+      end
     elsif type == "fixed_card"
-      tag.iframe src: src, allow: allow, width: "500", height: "700"
+      # Fixxed card heights should always be 200px larger than the width.
+      tag.iframe src: src, allow: allow, width: "500", height: "700", data: data
     else
-      tag.iframe src: src, allow: allow, width: "100%", height: "200"
+      tag.iframe src: src, allow: allow, width: "100%", height: "200", data: data
     end
   end
 
-  def embed_player_podcast_iframe(podcast, options, preview = false)
-    src = embed_player_podcast_url(podcast, options, preview)
+  def embed_player_iframe(options)
+    src = ''
     allow = "monetization"
+    iframeHeight = '200'
+    iframeStyle = ''
+    wrapperStyle = 'line-height: 0;'
 
     if options[:embed_player_type] == "card"
-      # TODO: this is NOW working, but I'm not sure how helpful this is to a producer that wishes to embed it.
-      tag.iframe src: src, allow: allow, width: "100%", height: "700", style: "--aspect-ratio: 2/3; width: 100%;"
-    elsif options[:embed_player_type] == "fixed_card"
-      tag.iframe src: src, allow: allow, width: "500", height: "700"
-    else
-      tag.iframe src: src, allow: allow, width: "100%", height: "200"
+      wrapperStyle = "position: relative; height: 0; width: 100%; padding-top: calc(100% + #{iframeHeight}px); line-height: 0;"
+      iframeHeight = '100%'
+      iframeStyle = "position: absolute; inset: 0;"
+    end
+
+
+    tag.div style: wrapperStyle, data: { :embed_preview_target => 'embedIframeWrapper' } do
+      tag.iframe class: 'bg-light', src: src, allow: allow, width: "100%", height: iframeHeight, style: iframeStyle, data: { :embed_preview_target => 'embedIframe' }
     end
   end
 
   def embed_player_type_options(selected)
-    opts = %w[standard card fixed_card].map { |v| [t("helpers.label.episode.embed_player_types.#{v}"), v] }
+    opts = %w[standard card].map { |v| [t("helpers.label.episode.embed_player_types.#{v}"), v] }
+    options_for_select(opts, selected)
+  end
+
+  def embed_player_theme_options(selected)
+    opts = %w[dark light auto].map { |v| [t("helpers.label.episode.embed_player_themes.#{v}"), v] }
     options_for_select(opts, selected)
   end
 
@@ -106,7 +132,7 @@ module EmbedPlayerHelper
   private
 
   def embed_params(params)
-    "#{play_root}#{EMBED_PLAYER_PATH}?#{params.to_query}"
+    "https://#{ENV["PLAY_HOST"]}#{EMBED_PLAYER_PREVIEW_PATH}?#{params.to_query}"
   end
 
   def enclosure_with_token(ep)

--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -3,7 +3,18 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static values = { copy: String, tooltip: String }
 
+  originalStyleDisplay
+
   connect() {
+    this.originalStyleDisplay = this.element.style.display;
+
+    navigator.permissions.query({ name: 'clipboard-write'}).then((result) => {
+      this.updatePermissionState(result.state);
+      result.addEventListener('change', () => {
+        this.updatePermissionState(result.state);
+      })
+    })
+
     this.element.dataset.action = "clipboard#copy"
     this.tip = new bootstrap.Tooltip(this.element, { title: this.tooltipValue })
     this.tip.disable()
@@ -13,9 +24,21 @@ export default class extends Controller {
     this.tip.dispose()
   }
 
-  copy(event) {
+  updatePermissionState(state) {
+    switch (state) {
+      case 'denied':
+        this.element.style.display = 'none';
+        break;
+      case 'prompt':
+        this.element.style.display = this.originalStyleDisplay;
+        break;
+    }
+  }
+
+  async copy(event) {
     event.preventDefault()
-    navigator.clipboard.writeText(this.copyValue)
+
+    await navigator.clipboard.writeText(this.copyValue)
 
     // briefly show "copied" tooltip
     this.tip.enable()

--- a/app/javascript/controllers/dynamic_form_controller.js
+++ b/app/javascript/controllers/dynamic_form_controller.js
@@ -1,7 +1,17 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["link"]
+  static targets = ["link", "help"]
+
+  static values = {
+    help: Object
+  }
+
+  updateHelp(event) {
+    if (this.hasHelpValue && this.hasHelpTarget) {
+      this.helpTarget.innerText = this.helpValue[event.target.value]
+    }
+  }
 
   change(event) {
     for (const link of this.linkTargets) {

--- a/app/javascript/controllers/embed_preview_controller.js
+++ b/app/javascript/controllers/embed_preview_controller.js
@@ -1,0 +1,128 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["accentColor", "embedIframe", "embedIframeWrapper", "embedUrl", "embedHtml"]
+
+  static values = {
+    embedUrl: String,
+    embedType: String
+  }
+
+  connect() {
+    const that = this
+    window.addEventListener('message', (e) => { that.handlePostMessage(e) }, false)
+
+    if (this.hasEmbedIframeTarget && this.hasEmbedUrlValue) {
+      this.embedIframeTarget.setAttribute('src', this.embedUrlValue)
+    }
+  }
+
+  disconnect() {
+    const that = this
+    window.removeEventListener('message', (e) => { that.handlePostMessage(e) }, false)
+  }
+
+  handlePostMessage(e) {
+    if (!/^https?:\/\/play(?:\.staging)?\.prx\.(?:org|tech|test)$/.test(e.origin)) return
+
+    this.previewSource = e.source
+    this.previewOrigin = e.origin
+
+    this.updateEmbedUrlTarget(e.data.embedUrl);
+    this.updateEmbedUHtmlTarget(e.data.embedHtml);
+    this.updateEmbedStyles(e.data.embedStyles, e.data.embedHeight);
+  }
+
+  postConfigChange(config) {
+    this.previewSource.postMessage(config, this.previewOrigin)
+  }
+
+  updateEmbedUrlTarget(embedUrl) {
+    if (!embedUrl) return;
+
+    for (const elm of this.embedUrlTargets) {
+      switch (elm.tagName) {
+        case 'INPUT':
+          elm.value = embedUrl
+          break;
+
+        case 'A':
+          elm.href = embedUrl
+          break;
+
+        case 'BUTTON':
+          elm.setAttribute('data-clipboard-copy-value', embedUrl)
+          break;
+      }
+    }
+  }
+
+  updateEmbedUHtmlTarget(embedHtml) {
+    if (!embedHtml) return;
+
+    for (const elm of this.embedHtmlTargets) {
+      switch (elm.tagName) {
+        case 'INPUT':
+          elm.value = embedHtml
+          break;
+
+        case 'BUTTON':
+          elm.setAttribute('data-clipboard-copy-value', embedHtml)
+          break;
+      }
+    }
+  }
+
+  updateEmbedStyles(styles, height) {
+    this.embedIframeTarget.removeAttribute('class')
+
+    if (this.embedType === 'card') {
+      this.embedIframeTarget.setAttribute('height', '100%')
+      this.embedIframeTarget.setAttribute('style', styles.iframe)
+      this.embedIframeWrapperTarget.setAttribute('style', styles.wrapper)
+    } else {
+      this.embedIframeTarget.setAttribute('height', height)
+      this.embedIframeTarget.setAttribute('style', styles.iframe)
+      this.embedIframeWrapperTarget.setAttribute('style', styles.wrapper)
+    }
+  }
+
+  changeType(e) {
+    this.embedType = e.target.value
+    this.postConfigChange({ showCoverArt: e.target.value === 'card' })
+  }
+
+  changeMaxWidth(e) {
+    let maxWidth = e.target.value ? parseInt(e.target.value, 10) : null
+
+    if (maxWidth && maxWidth < e.target.min) {
+      maxWidth = null
+    }
+
+    this.postConfigChange({ maxWidth })
+  }
+
+  changePlaylist(e) {
+    const showPlaylist = !e.target.value ? 'all' : e.target.value > 1 && e.target.value || null
+    
+    this.postConfigChange({ showPlaylist })
+  }
+
+  changeSeason(e) {
+    this.postConfigChange({ playlistSeason: e.target.value })
+  }
+
+  changeCategory(e) {
+    this.postConfigChange({ playlistCategory: e.target.value })
+  }
+
+  changeTheme(e) {
+    this.postConfigChange({ theme: e.target.value !== 'dark' ? e.target.value : null })
+  }
+
+  changeAccentColor(e) {
+    const accentColor = e.target.value !== '#ff9600' ? [e.target.value] : null
+
+    this.postConfigChange({ accentColor })
+  }
+}

--- a/app/views/episode_player/_form.html.erb
+++ b/app/views/episode_player/_form.html.erb
@@ -1,64 +1,118 @@
-<%= turbo_frame_tag "embed-player", data: {controller: "morphdom"} do %>
+<div class="row my-4 mx-2" data-controller="embed-preview"
+  data-embed-preview-embed-url-value="<%= embed_player_episode_url(episode, player_options, true) %>"
+>
+  <div class="col-8">
 
-  <div class="col-12 mb-4">
-    <div class="form-floating input-group" data-controller="dynamic-form">
-      <%= select_tag :embed_player_type, embed_player_type_options(embed_player_type), class: "form-control", data: {action: "dynamic-form#change"} %>
-      <%= label_tag :embed_player_style, t("helpers.label.episode.embed_player_type") %>
-      <a hidden href="<%= episode_player_path(episode) %>" data-dynamic-form-target="link"></a>
-    </div>
+    <div class="container-fluid mb-5">
+      <h3 class="fw-bold"><%= t(".title.preview") %></h3>
 
-    <div class="form-text">
-      <%= t(".help.types.#{embed_player_type || "standard"}") %>
-    </div>
-  </div>
-
-  <div class="col-12 mb-4">
-    <h3 class="fw-bold"><%= t(".title.copy") %></h3>
-
-    <div class="form-text mb-4">
-      <%= t(".help.copy") %>
-    </div>
-
-    <div class="form-floating input-group">
-      <%= text_field_tag :embed_player_url, embed_player_episode_url(episode, embed_player_type), class: "form-control", disabled: true, autocomplete: "off" %>
-      <%= label_tag :embed_player_url, t("helpers.label.episode.embed_player_url") %>
-      <%= field_link embed_player_episode_url(episode, embed_player_type) %>
-      <%= field_copy embed_player_episode_url(episode, embed_player_type) %>
-    </div>
-  </div>
-
-  <div class="col-12 mb-4">
-    <div class="form-floating input-group">
-      <%= text_field_tag :embed_player_iframe, embed_player_episode_iframe(episode, embed_player_type), class: "form-control", disabled: true, autocomplete: "off" %>
-      <%= label_tag :embed_player_iframe, t("helpers.label.episode.embed_player_iframe") %>
-      <%= field_copy embed_player_episode_iframe(episode, embed_player_type) %>
-    </div>
-  </div>
-
-  <div class="col-12 mb-4">
-    <div class="form-floating input-group">
-      <% if episode.media_ready? %>
-        <%= text_field_tag :enclosure_url, episode.enclosure_url, class: "form-control", disabled: true, autocomplete: "off" %>
-        <%= label_tag :enclosure_url, t("helpers.label.episode.enclosure_url") %>
-        <%= field_copy episode.enclosure_url %>
-      <% else %>
-        <%= text_field_tag :enclosure_url, t(".enclosure_not_ready"), class: "form-control", disabled: true, autocomplete: "off" %>
-        <%= label_tag :enclosure_url, t("helpers.label.episode.enclosure_url") %>
-      <% end %>
-    </div>
-  </div>
-
-  <div class="col-12 mb-4">
-    <h3 class="fw-bold"><%= t(".title.preview") %></h3>
-
-    <% unless episode.published? %>
-      <div class="alert alert-warning" role="alert">
-        <h4 class="alert-heading fw-bold"><%= t(".title.warning") %></h4>
-        <p class="mb-0"><%= t(".help.warning") %></p>
+      <div class="p-4 mx-auto border border-2" style="resize: horizontal; overflow: scroll; min-width: calc(304px + 3rem); max-width: 100%">
+        <div class="mb-4">
+          <%= render "layouts/skeleton_text", lines: 4 %>
+        </div>
+        <div class="lh-0"><%= embed_player_iframe(player_options) %></div>
+        <div class="mt-4">
+          <%= render "layouts/skeleton_text", lines: 4 %>
+        </div>
       </div>
-    <% end %>
+    </div>
 
-    <%= embed_player_episode_iframe(episode, embed_player_type, true) %>
+    <div class="container-fluid mb-4">
+      <h3 class="fw-bold"><%= t(".title.copy") %></h3>
+
+      <div class="form-text mb-4">
+        <%= t(".help.copy") %>
+      </div>
+
+      <div class="form-floating input-group">
+        <%= text_field_tag :embed_player_url, '', class: "form-control", disabled: true, autocomplete: "off", data: { :embed_preview_target => 'embedUrl' } %>
+        <%= label_tag :embed_player_url, t("helpers.label.podcast_player.embed_player_url") %>
+        <%= field_link '', { :embed_preview_target => 'embedUrl' } %>
+        <%= field_copy '', { :embed_preview_target => 'embedUrl' } %>
+      </div>
+    </div>
+
+    <div class="container-fluid mb-4">
+      <div class="form-floating input-group">
+        <%= text_field_tag :embed_player_iframe, '', class: "form-control", disabled: true, autocomplete: "off", data: { :embed_preview_target => 'embedHtml' } %>
+        <%= label_tag :embed_player_iframe, t("helpers.label.podcast_player.embed_player_iframe") %>
+        <%= field_copy '', { :embed_preview_target => 'embedHtml' } %>
+      </div>
+    </div>
+
+    <div class="container-fluid mb-4">
+      <div class="form-floating input-group">
+        <% if episode.media_ready? %>
+          <%= text_field_tag :enclosure_url, episode.enclosure_url, class: "form-control", disabled: true, autocomplete: "off" %>
+          <%= label_tag :enclosure_url, t("helpers.label.episode.enclosure_url") %>
+          <%= field_copy episode.enclosure_url %>
+        <% else %>
+          <%= text_field_tag :enclosure_url, t(".enclosure_not_ready"), class: "form-control", disabled: true, autocomplete: "off" %>
+          <%= label_tag :enclosure_url, t("helpers.label.episode.enclosure_url") %>
+        <% end %>
+      </div>
+    </div>
   </div>
 
-<% end %>
+  <div class="col-4">
+
+    <div class="container-fluid mb-4" data-controller="dynamic-form" data-dynamic-form-help-value="<%= t(".help.types").to_json %>">
+      <div class="form-floating input-group">
+        <%= select_tag :embed_player_type, embed_player_type_options(player_options[:embed_player_type]), class: "form-control", data: { action: "embed-preview#changeType dynamic-form#updateHelp" } %>
+        <%= label_tag :embed_player_type, t("helpers.label.podcast_player.embed_player_type") %>
+      </div>
+        
+      <div class="form-text" data-dynamic-form-target="help">
+        <%= t(".help.types.#{player_options[:embed_player_type] || "standard"}") %>
+      </div>
+    </div>
+
+    <div class="container-fluid mb-4">
+      <div class="form-floating input-group">
+        <%= number_field_tag :max_width, player_options[:max_width], min: 300, class: "form-control", data: { action: "embed-preview#changeMaxWidth" }, placeholder: '100%' %>
+        <%= label_tag :max_width, t("helpers.label.podcast_player.max_width") %>
+        <span class="input-group-text" id="basic-addon2">px</span>
+      </div>
+
+      <div class="form-text">
+        <%= t(".help.max_width") %>
+      </div>
+    </div>
+
+    <div class="card border-light mb-4">
+      <div class="card-header-light"><%= t(".title.customize") %></div>
+      <div class="card-body d-grid gap-3">
+        <div class="form-text">
+          <%= t(".help.customize") %>
+        </div>
+
+        <div class="row">
+          <div class="col-12" data-controller="dynamic-form" data-dynamic-form-help-value="<%= t(".help.themes").to_json %>">
+            <div class="form-floating input-group">
+              <%= select_tag :embed_player_theme, embed_player_theme_options(player_options[:embed_player_theme]), class: "form-control", data: { action: "embed-preview#changeTheme dynamic-form#updateHelp" } %>
+              <%= label_tag :embed_player_theme, t("helpers.label.podcast_player.embed_player_theme") %>
+            </div>
+
+            <div class="form-text" data-dynamic-form-target="help">
+              <%= t(".help.themes.#{player_options[:embed_player_theme] || "dark"}") %>
+            </div>
+          </div>
+        </div>
+
+        <div class="row">
+          <div class="col-12">
+          <%= label_tag :accent_color, t("helpers.label.podcast_player.accent_color") %>
+            <div class="input-group">
+              <%= tag.input type: 'color', value: player_options[:accent_color][0], class: "form-control form-control-color", data: { :embed_preview_target => "accentColor", action: "embed-preview#changeAccentColor" } %> 
+            </div>
+
+            <div class="form-text">
+              <%= t(".help.accent_color") %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/episode_player/_form.html.erb
+++ b/app/views/episode_player/_form.html.erb
@@ -114,5 +114,11 @@
       </div>
     </div>
 
+    <div class="card border-light mb-4">
+      <div class="card-footer d-grid">
+        <%= link_to t(".label.clear"), episode_player_path(episode), class: "btn btn-primary" %>
+      </div>
+    </div>
+
   </div>
 </div>

--- a/app/views/episode_player/show.html.erb
+++ b/app/views/episode_player/show.html.erb
@@ -2,12 +2,4 @@
 
 <%= render "episodes/tabs" %>
 
-<div class="row my-4 mx-2">
-  <div class="col-lg-8">
-    <div class="row">
-      <%= render "form", episode: @episode, embed_player_type: @embed_player_type %>
-    </div>
-  </div>
-  <div class="col-lg-4 d-grid align-content-start gap-3">
-  </div>
-</div>
+<%= render "form", episode: @episode, player_options: @player_options %>

--- a/app/views/layouts/_skeleton_text.html.erb
+++ b/app/views/layouts/_skeleton_text.html.erb
@@ -1,0 +1,4 @@
+<% (lines - 1).times do %>
+  <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
+<% end %>
+<span class="d-block pt-3 my-2 bg-light rounded-pill w-75"></span>

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -8,17 +8,11 @@
 
       <div class="p-4 mx-auto border border-2" style="resize: horizontal; overflow: scroll; min-width: calc(304px + 3rem); max-width: 100%">
         <div class="mb-4">
-          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
-          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
-          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
-          <span class="d-block pt-3 my-2 bg-light rounded-pill" style="max-width: 35%;"></span>
+          <%= render "layouts/skeleton_text", lines: 4 %>
         </div>
         <div class="lh-0"><%= embed_player_iframe(player_options) %></div>
         <div class="mt-4">
-          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
-          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
-          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
-          <span class="d-block pt-3 my-2 bg-light rounded-pill w-75"></span>
+          <%= render "layouts/skeleton_text", lines: 4 %>
         </div>
       </div>
     </div>

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -138,8 +138,11 @@
           </div>
         </div>
       </div>
-      <div class="card-footer">
-        <%= link_to t(".clear"), podcast_player_path(podcast), class: "btn btn-primary" %>
+    </div>
+
+    <div class="card border-light mb-4">
+      <div class="card-footer d-grid">
+        <%= link_to t(".label.clear"), podcast_player_path(podcast), class: "btn btn-primary" %>
       </div>
     </div>
 

--- a/app/views/podcast_player/_form.html.erb
+++ b/app/views/podcast_player/_form.html.erb
@@ -1,94 +1,153 @@
-<%= turbo_frame_tag "embed-player", data: {controller: "morphdom"} do %>
-  <div class="col-12 mb-4">
-    <div class="form-floating input-group" data-controller="dynamic-form">
-      <%= select_tag :embed_player_type, embed_player_type_options(player_options[:embed_player_type]), class: "form-control", data: {action: "dynamic-form#change"} %>
-      <%= label_tag :embed_player_type, t("helpers.label.podcast_player.embed_player_type") %>
-      <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+<div class="row my-4 mx-2" data-controller="embed-preview"
+  data-embed-preview-embed-url-value="<%= embed_player_podcast_url(podcast, player_options, true) %>"
+>
+  <div class="col-8">
+
+    <div class="container-fluid mb-5">
+      <h3 class="fw-bold"><%= t(".title.preview") %></h3>
+
+      <div class="p-4 mx-auto border border-2" style="resize: horizontal; overflow: scroll; min-width: calc(304px + 3rem); max-width: 100%">
+        <div class="mb-4">
+          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
+          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
+          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
+          <span class="d-block pt-3 my-2 bg-light rounded-pill" style="max-width: 35%;"></span>
+        </div>
+        <div class="lh-0"><%= embed_player_iframe(player_options) %></div>
+        <div class="mt-4">
+          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
+          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
+          <span class="d-block pt-3 my-2 bg-light rounded-pill"></span>
+          <span class="d-block pt-3 my-2 bg-light rounded-pill w-75"></span>
+        </div>
+      </div>
     </div>
 
-    <div class="form-text">
-      <%= t(".help.types.#{player_options[:embed_player_type] || "standard"}") %>
-    </div>
-  </div>
+    <div class="container-fluid mb-4">
+      <h3 class="fw-bold"><%= t(".title.copy") %></h3>
 
-  <div class="card border-light mb-4">
-    <div class="card-header-light"><%= t(".title.playlist") %></div>
-
-    <div class="card-body">
       <div class="form-text mb-4">
-        <%= t(".help.playlist") %>
+        <%= t(".help.copy") %>
       </div>
 
-      <div class="row mb-4" data-controller="toggle-field">
-        <div class="col-6">
-          <div class="form-floating input-group" data-controller="dynamic-form">
-            <%= select_tag :all_episodes, embed_player_all_episodes_options(player_options[:all_episodes]), class: "form-control", data: {action: "dynamic-form#change toggle-field#displayOnlyThisField"}, include_blank: false %>
-            <%= label_tag t("helpers.label.podcast_player.episode_number") %>
-            <%= field_help_text t(".help.episode_number") %>
-            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+      <div class="form-floating input-group">
+        <%= text_field_tag :embed_player_url, '', class: "form-control", disabled: true, autocomplete: "off", data: { :embed_preview_target => 'embedUrl' } %>
+        <%= label_tag :embed_player_url, t("helpers.label.podcast_player.embed_player_url") %>
+        <%= field_link '', { :embed_preview_target => 'embedUrl' } %>
+        <%= field_copy '', { :embed_preview_target => 'embedUrl' } %>
+      </div>
+    </div>
+
+    <div class="container-fluid mb-4">
+      <div class="form-floating input-group">
+        <%= text_field_tag :embed_player_iframe, '', class: "form-control", disabled: true, autocomplete: "off", data: { :embed_preview_target => 'embedHtml' } %>
+        <%= label_tag :embed_player_iframe, t("helpers.label.podcast_player.embed_player_iframe") %>
+        <%= field_copy '', { :embed_preview_target => 'embedHtml' } %>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="col-4">
+
+    <div class="container-fluid mb-4" data-controller="dynamic-form" data-dynamic-form-help-value="<%= t(".help.types").to_json %>">
+      <div class="form-floating input-group">
+        <%= select_tag :embed_player_type, embed_player_type_options(player_options[:embed_player_type]), class: "form-control", data: { action: "embed-preview#changeType dynamic-form#updateHelp" } %>
+        <%= label_tag :embed_player_type, t("helpers.label.podcast_player.embed_player_type") %>
+      </div>
+        
+      <div class="form-text" data-dynamic-form-target="help">
+        <%= t(".help.types.#{player_options[:embed_player_type] || "standard"}") %>
+      </div>
+    </div>
+
+    <div class="container-fluid mb-4">
+      <div class="form-floating input-group">
+        <%= number_field_tag :max_width, player_options[:max_width], min: 300, class: "form-control", data: { action: "embed-preview#changeMaxWidth" }, placeholder: '100%' %>
+        <%= label_tag :max_width, t("helpers.label.podcast_player.max_width") %>
+        <span class="input-group-text" id="basic-addon2">px</span>
+      </div>
+
+      <div class="form-text">
+        <%= t(".help.max_width") %>
+      </div>
+    </div>
+
+    <div class="card border-light mb-4">
+      <div class="card-header-light"><%= t(".title.customize") %></div>
+      <div class="card-body d-grid gap-3">
+        <div class="form-text">
+          <%= t(".help.customize") %>
+        </div>
+
+        <div class="row">
+          <div class="col-12" data-controller="dynamic-form" data-dynamic-form-help-value="<%= t(".help.themes").to_json %>">
+            <div class="form-floating input-group">
+              <%= select_tag :embed_player_theme, embed_player_theme_options(player_options[:embed_player_theme]), class: "form-control", data: { action: "embed-preview#changeTheme dynamic-form#updateHelp" } %>
+              <%= label_tag :embed_player_theme, t("helpers.label.podcast_player.embed_player_theme") %>
+            </div>
+
+            <div class="form-text" data-dynamic-form-target="help">
+              <%= t(".help.themes.#{player_options[:embed_player_theme] || "dark"}") %>
+            </div>
           </div>
         </div>
 
-        <div class="col-6">
-          <div class="<%= "d-none" unless player_options[:all_episodes] == "number" %> form-floating input-group" data-controller="dynamic-form" data-toggle-field-target="field" field="number">
-            <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "dynamic-form#change"}, min: 1, autocomplete: "off" %>
-            <%= label_tag t("helpers.label.podcast_player.episode_number") %>
-            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+        <div class="row">
+          <div class="col-12">
+          <%= label_tag :accent_color, t("helpers.label.podcast_player.accent_color") %>
+            <div class="input-group">
+              <%= tag.input type: 'color', value: player_options[:accent_color][0], class: "form-control form-control-color", data: { :embed_preview_target => "accentColor", action: "embed-preview#changeAccentColor" } %> 
+            </div>
+
+            <div class="form-text">
+              <%= t(".help.accent_color") %>
+            </div>
           </div>
         </div>
       </div>
+    </div>
 
-      <div class="row mb-4">
-        <div class="col-6">
-          <div class="form-floating input-group" data-controller="dynamic-form">
-            <%= number_field_tag :season, player_options[:season], class: "form-control #{"form-control-blank" unless player_options[:season].present?}", data: {action: "dynamic-form#change"}, min: 0, autocomplete: "off" %>
-            <%= label_tag :season, t("helpers.label.podcast_player.season") %>
-            <%= field_help_text t(".help.season") %>
-            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+    <div class="card border-light mb-4">
+      <div class="card-header-light"><%= t(".title.playlist") %></div>
+
+      <div class="card-body">
+        <div class="form-text mb-4">
+          <%= t(".help.playlist") %>
+        </div>
+
+        <div class="row mb-4">
+          <div class="col-12">
+            <div class="form-floating input-group">
+              <%= number_field_tag :episode_number, player_options[:episode_number], class: "form-control", data: {action: "embed-preview#changePlaylist"}, min: 1, autocomplete: "off", placeholder: t("helpers.label.podcast_player.episodes_all") %>
+              <%= label_tag t("helpers.label.podcast_player.episode_number") %>
+              <%= field_help_text t(".help.episode_number") %>
+            </div>
           </div>
         </div>
 
-        <div class="col-6">
-          <div class="form-floating input-group" data-controller="dynamic-form">
-            <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: true, class: "form-control #{"form-control-blank" unless player_options[:category].present?}", data: {action: "dynamic-form#change"} %>
-            <%= label_tag :category, t("helpers.label.podcast_player.category") %>
-            <%= field_help_text t(".help.episode_category") %>
-            <a hidden href="<%= request.fullpath %>" data-dynamic-form-target="link"></a>
+        <div class="row mb-2">
+          <div class="col-6">
+            <div class="form-floating input-group">
+              <%= number_field_tag :season, player_options[:season], class: "form-control", data: {action: "embed-preview#changeSeason"}, min: 0, autocomplete: "off", placeholder: '' %>
+              <%= label_tag :season, t("helpers.label.podcast_player.season") %>
+              <%= field_help_text t(".help.season") %>
+            </div>
+          </div>
+
+          <div class="col-6">
+            <div class="form-floating input-group">
+              <%= select_tag :category, embed_player_category_options(podcast, player_options[:category]), include_blank: t("helpers.label.podcast_player.no_category"), class: "form-control form-control-empty", data: {action: "embed-preview#changeCategory"} %>
+              <%= label_tag :category, t("helpers.label.podcast_player.category") %>
+              <%= field_help_text t(".help.episode_category") %>
+            </div>
           </div>
         </div>
       </div>
+      <div class="card-footer">
+        <%= link_to t(".clear"), podcast_player_path(podcast), class: "btn btn-primary" %>
+      </div>
     </div>
-    <div class="card-footer">
-  <%= link_to t(".clear"), podcast_player_path(podcast), class: "btn btn-primary" %>
-    </div>
+
   </div>
-
-  <div class="col-12 mb-4">
-    <h3 class="fw-bold"><%= t(".title.copy") %></h3>
-
-    <div class="form-text mb-4">
-      <%= t(".help.copy") %>
-    </div>
-
-    <div class="form-floating input-group">
-      <%= text_field_tag :embed_player_url, embed_player_podcast_url(podcast, player_options), class: "form-control", disabled: true, autocomplete: "off" %>
-      <%= label_tag :embed_player_url, t("helpers.label.podcast_player.embed_player_url") %>
-      <%= field_link embed_player_podcast_url(podcast, player_options) %>
-      <%= field_copy embed_player_podcast_url(podcast, player_options) %>
-    </div>
-  </div>
-
-  <div class="col-12 mb-4">
-    <div class="form-floating input-group">
-      <%= text_field_tag :embed_player_iframe, embed_player_podcast_iframe(podcast, player_options), class: "form-control", disabled: true, autocomplete: "off" %>
-      <%= label_tag :embed_player_iframe, t("helpers.label.podcast_player.embed_player_iframe") %>
-      <%= field_copy embed_player_podcast_iframe(podcast, player_options) %>
-    </div>
-  </div>
-
-  <div class="col-12 mb-4">
-    <h3 class="fw-bold"><%= t(".title.preview") %></h3>
-
-    <%= embed_player_podcast_iframe(podcast, player_options, true) %>
-  </div>
-<% end %>
+</div>

--- a/app/views/podcast_player/show.html.erb
+++ b/app/views/podcast_player/show.html.erb
@@ -1,9 +1,5 @@
+<% content_for :title, "#{@podcast.title} - #{t(".title")}" %>
+
 <%= render "podcasts/tabs" %>
 
-<div class="row my-4 mx-2">
-  <div class="col-lg-12">
-    <div class="row">
-      <%= render "form", podcast: @podcast, player_options: @player_options %>
-    </div>
-  </div>
-</div>
+<%= render "form", podcast: @podcast, player_options: @player_options %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -588,6 +588,7 @@ en:
       enclosure_not_ready: No Media Files Uploaded
       help: &player_help
         copy: Copy the code for one of the following players, and place it on your webpage.
+        customize: Customize the appearance of the embed.
         max_width: Cap the width the embed can scale to. It will continue to scale down when content width is less than the entered width. Minimum 300px.
         types:
           card: The player style that shows off your podcast's artwork. Size of embed will be responsive to the size of content is embedded into.
@@ -595,11 +596,12 @@ en:
         themes:
           dark: Dark theme that stands out in lighter themed sites.
           light: Light theme for that subtle look.
-          auto: Allow the users system preferences determine the theme.
+          auto: Allow the users system preferences to determine the theme.
         accent_color: Choose an accent color that works for your brand.
         warning: It looks like your episode is not yet published, or very recently published. The player below is only a preview of how it will appear after your feed is updated with the new episode. Your copyable iframe/links will begin to function as expected within a few minutes of publishing.
       title: &player_title
         copy: Copy and Use your Embed Code
+        customize: Make It Your Own
         preview: Player
         warning: Warning
     show:
@@ -934,14 +936,12 @@ en:
     form:
       help:
         <<: *player_help
-        customize: Customize the appearance of the embed.
         episode_number: (Optional) Limit the number of episodes included in the playlist. Leave blank to include all episodes.
         season: (Optional) Choose a single season for this playlist. Leaving this blank or 0 will not add a season filter.
         episode_category: (Optional) Choose a single category for this playlist. Leaving this blank will not add a category filter.
         playlist: Add any options below to better specify the playlist you want to create.
       title:
         <<: *player_title
-        customize: Make It Your Own
         playlist: Make It A Playlist
       clear: Clear options
   podcast_switcher:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -604,6 +604,8 @@ en:
         customize: Make It Your Own
         preview: Player
         warning: Warning
+      label: &player_label
+        clear: Restore Default Options
     show:
       title: Embeddable Player
   errors:
@@ -943,7 +945,8 @@ en:
       title:
         <<: *player_title
         playlist: Make It A Playlist
-      clear: Clear options
+      label:
+        <<: *player_label
   podcast_switcher:
     dropdown:
       all: View all my Podcasts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -324,6 +324,12 @@ en:
           standard: Standard
           card: Responsive Card
           fixed_card: Fixed Width Card
+        embed_player_theme: Embed Player Theme
+        embed_player_themes:
+          dark: Dark (Default)
+          light: Light
+          auto: User System Default
+        accent_color: Accent Color
         embed_player_url: Embeddable Player Link
         enclosure_url: Media Link
         episode_number: Episode Number
@@ -435,9 +441,12 @@ en:
         title: Title
       podcast_player:
         embed_player_type: Player Style
+        max_width: Player Width
         episode_number: Number of Episodes
+        episodes_all: All Episodes
         season: Season Number
         category: Category
+        no_category: (None)
         embed_player_url: Embeddable Player Link
         embed_player_iframe: Embeddable Player IFrame
         episodes_options:
@@ -579,10 +588,15 @@ en:
       enclosure_not_ready: No Media Files Uploaded
       help: &player_help
         copy: Copy the code for one of the following players, and place it on your webpage.
+        max_width: Cap the width the embed can scale to. It will continue to scale down when content width is less than the entered width. Minimum 300px.
         types:
-          card: The player style that shows off your podcast's artwork and will adjust to be responsive to the size of the user's screen and the website it is embedded on. Must always be 800px tall.
-          fixed_card: The player style that shows off your podcast's artwork. The size will NOT adjust to the user's screensize. Must always be 500px wide by 800px tall.
-          standard: Default view of the PRX Player, will adjust to be responsive to the size of the user's screen and the website it is embedded on. Must always be 200px tall.
+          card: The player style that shows off your podcast's artwork. Size of embed will be responsive to the size of content is embedded into.
+          standard: Default view of the PRX Player, will adjust to be responsive to the size of the user's screen and the website it is embedded on.
+        themes:
+          dark: Dark theme that stands out in lighter themed sites.
+          light: Light theme for that subtle look.
+          auto: Allow the users system preferences determine the theme.
+        accent_color: Choose an accent color that works for your brand.
         warning: It looks like your episode is not yet published, or very recently published. The player below is only a preview of how it will appear after your feed is updated with the new episode. Your copyable iframe/links will begin to function as expected within a few minutes of publishing.
       title: &player_title
         copy: Copy and Use your Embed Code
@@ -915,16 +929,20 @@ en:
       month: Weeks of the Month
       period: Weekly interval
   podcast_player:
+    show:
+      title: Embeddable Player
     form:
       help:
         <<: *player_help
-        episode_number: Choose between showing all episodes or only a number of episodes for this playlist.
+        customize: Customize the appearance of the embed.
+        episode_number: (Optional) Limit the number of episodes included in the playlist. Leave blank to include all episodes.
         season: (Optional) Choose a single season for this playlist. Leaving this blank or 0 will not add a season filter.
         episode_category: (Optional) Choose a single category for this playlist. Leaving this blank will not add a category filter.
         playlist: Add any options below to better specify the playlist you want to create.
       title:
         <<: *player_title
-        playlist: Make it a playlist
+        customize: Make It Your Own
+        playlist: Make It A Playlist
       clear: Clear options
   podcast_switcher:
     dropdown:


### PR DESCRIPTION
Closes #820 

- Reworks embed player forms to work with Play's new `/preview` route.
- Configuration changes are now sent to preview embed iframe via postMessage events, allowing the Play app to render changes without reloading iframe.
- Updated embed URL and HTML, along with height and styles, are sent from the preview iframe via postMessages for the feeder form to display and update preview iframe wrapper markup.
- Updates dyanamic-form controller to update select field help text based on selected values without needing to reload the form state (no phantom clicking a hidden button.)
- Simplifies embed style selection to "Standard" and "Card". Player embed markup is always responsive, but the added _Player Width_ option allows a max width to be set.
- Adds theme selection
- Adds accent color selection
- Reworks podcast embed player playlist options too not require an extra select field for "All" or "Number". _Number of Episodes_ field has been reworked to treat empty value as all, and 1 episode as latest episode only.
- Adds some skeleton text around preview to help demonstrate in-use behavior.
- Adds resizable wrapper around preview so user can easily test how their changes will responsively behave.
- Updates labels and help text to reflect changes, and for more clarity.

## To Review

- Get your Play local dev updated and running with PR PRX/Play-Next.js#123
- Make sure puma dev is configured to host `play.prx.test` from port 4300
- Checkout this branch in your feeder dev
- Add `PLAY_HOST=play.prx.test` to you `.env`
- Start server
- Go to the Embed Player of your favorite podcast
- Ensure embed player loads with default setting
- Ensure changing Player Type updates the preview, and the URL and HTML in copy fields
- Ensure setting a Player Width updates the preview, and the URL and HTML in copy fields
- Ensure changing Player Theme updates the preview, and the URL and HTML in copy fields
- Ensure changing the Accent Color updates the preview, and the URL and HTML in copy fields
- Ensure incrementing the Number Of Episodes updates the preview, and the URL and HTML in copy fields
  - Empty should show all episodes
  - 0 or 1 should not show a playlist
  - 2-5 should show playlist without scrollbars
  - > 5 should show playlist with scrollbars
  - Resizing preview area should result in no more than 5 and a half episode rows being shown
- Ensure changing the Session updates the preview playlist, and the URL and HTML in copy fields
- Ensure changing Category updates the preview playlist, and the URL and HTML in copy fields
- Ensure copy fields for Embed Player Link and Embed Player IFrame copy field content to clipboard (Should no ask for permission or not show button if user settings deny clipboard access.)
- Ensure _Restore Default Options_ button resets form
- Go to the Embed Player for a published episode
- Ensure preview uses RSS feed to render player
- Go to the Embed Player for an unpublished episode
- Ensure preview uses override parameters to render player