### PR TITLE
Switch to PRX/FFprobe for audiowaveforms

### DIFF
--- a/app/models/tasks/copy_media_task.rb
+++ b/app/models/tasks/copy_media_task.rb
@@ -95,8 +95,8 @@ class Tasks::CopyMediaTask < ::Task
   def porter_waveform_task
     {
       Type: "Waveform",
-      Generator: "BBC/audiowaveform/v1.x",
-      DataFormat: "JSON",
+      Generator: "PRX/FFprobe",
+      DataFormat: "audiowaveform/JSON",
       Destination: {
         Mode: "AWS/S3",
         BucketName: ENV["FEEDER_STORAGE_BUCKET"],

--- a/test/models/tasks/copy_media_task_test.rb
+++ b/test/models/tasks/copy_media_task_test.rb
@@ -36,8 +36,8 @@ describe Tasks::CopyMediaTask do
 
         t = task.porter_tasks[2]
         assert_equal "Waveform", t[:Type]
-        assert_equal "BBC/audiowaveform/v1.x", t[:Generator]
-        assert_equal "JSON", t[:DataFormat]
+        assert_equal "PRX/FFprobe", t[:Generator]
+        assert_equal "audiowaveform/JSON", t[:DataFormat]
         assert_equal "AWS/S3", t[:Destination][:Mode]
         assert_equal "test-prx-feed", t[:Destination][:BucketName]
         assert_equal task.media_resource.waveform_path, t[:Destination][:ObjectKey]


### PR DESCRIPTION
`BBC/audiowaveform/v1.x` wasn't working for flac files.  So switch to `PRX/FFprobe`, which handles more file types.