### PR TITLE
Fix form updated_at cascading

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -23,10 +23,10 @@ class Episode < ApplicationRecord
   serialize :overrides, HashSerializer
 
   belongs_to :podcast, -> { with_deleted }, touch: true
-  has_many :contents, -> { order("position ASC, created_at DESC") }, autosave: true, dependent: :destroy
+  has_many :contents, -> { order("position ASC, created_at DESC") }, autosave: true, dependent: :destroy, inverse_of: :episode
   has_many :media_versions, -> { order("created_at DESC") }, dependent: :destroy
-  has_many :images, -> { order("created_at DESC") }, class_name: "EpisodeImage", autosave: true, dependent: :destroy
-  has_one :uncut, -> { order("created_at DESC") }, autosave: true, dependent: :destroy
+  has_many :images, -> { order("created_at DESC") }, class_name: "EpisodeImage", autosave: true, dependent: :destroy, inverse_of: :episode
+  has_one :uncut, -> { order("created_at DESC") }, autosave: true, dependent: :destroy, inverse_of: :episode
 
   accepts_nested_attributes_for :contents, allow_destroy: true, reject_if: ->(c) { c[:id].blank? && c[:original_url].blank? }
   accepts_nested_attributes_for :images, allow_destroy: true, reject_if: ->(i) { i[:id].blank? && i[:original_url].blank? }

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -20,15 +20,15 @@ class Feed < ApplicationRecord
   serialize :audio_format, HashSerializer
 
   belongs_to :podcast, -> { with_deleted }, optional: true, touch: true
-  has_many :feed_tokens, autosave: true, dependent: :destroy
+  has_many :feed_tokens, autosave: true, dependent: :destroy, inverse_of: :feed
   alias_attribute :tokens, :feed_tokens
   accepts_nested_attributes_for :feed_tokens, allow_destroy: true, reject_if: ->(ft) { ft[:token].blank? }
 
   has_many :apple_configs, autosave: true, dependent: :destroy, foreign_key: :public_feed_id,
     class_name: "::Apple::Config"
 
-  has_many :feed_images, -> { order("created_at DESC") }, autosave: true, dependent: :destroy
-  has_many :itunes_images, -> { order("created_at DESC") }, autosave: true, dependent: :destroy
+  has_many :feed_images, -> { order("created_at DESC") }, autosave: true, dependent: :destroy, inverse_of: :feed
+  has_many :itunes_images, -> { order("created_at DESC") }, autosave: true, dependent: :destroy, inverse_of: :feed
   has_many :itunes_categories, validate: true, autosave: true, dependent: :destroy
 
   has_one :apple_sync_log, -> { feeds }, foreign_key: :feeder_id, class_name: "SyncLog"

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -17,7 +17,7 @@ class Podcast < ApplicationRecord
   serialize :keywords, JSON
   serialize :restrictions, JSON
 
-  has_one :default_feed, -> { default }, class_name: "Feed", validate: true, autosave: true
+  has_one :default_feed, -> { default }, class_name: "Feed", validate: true, autosave: true, inverse_of: :podcast
 
   has_many :episodes, -> { order("published_at desc") }, dependent: :destroy
   has_many :feeds, dependent: :destroy


### PR DESCRIPTION
Fixes #776.

Bit of a weird one - some of our `touch: true` associations weren't bubbling up to the parent records.  But only from UI updates - API and console updates worked fine.

Doing a bunch of QA, the places I saw it was:

- Updated a podcast -> settings description (a field on the `default_feed`) didn't touch the podcast
- Updating image fields (caption/credit) didn't touch parent feed+podcast or episode+podcast
- Sometimes, changing an image/media would update the podcast but _not_ the episode?
- Adding/removing images/media didn't always bubble up

Turns out, it was related to `accepts_nested_attributes_for`.  There was an issue in rails core, but that was solved several major versions ago.  The best suggestion I could find was [this stackoverflow](https://stackoverflow.com/questions/46448140/belongs-to-touch-true-not-fired-on-association-build-and-nested-attribute-assig) ... which recommended marking these nested attributes relations with an `inverse_of`.

I _think_ these problems were only occurring where the assocation name didn't match the model name?  But I couldn't nail that down, so I added the `inverse_of` to every assocation that accepts nested attributes.  Doesn't hurt anything.