### PR TITLE
Description bytesize

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -42,6 +42,7 @@ class Episode < ApplicationRecord
 
   validates :podcast_id, :guid, presence: true
   validates :title, presence: true
+  validates :description, bytesize: {maximum: 4000}, if: :strict_validations
   validates :url, http_url: true
   validates :original_guid, presence: true, uniqueness: {scope: :podcast_id}, allow_nil: true
   alias_error_messages :item_guid, :original_guid

--- a/app/models/validators/bytesize_validator.rb
+++ b/app/models/validators/bytesize_validator.rb
@@ -1,0 +1,7 @@
+class BytesizeValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.present? && value.bytesize > options[:maximum]
+      record.errors.add(attribute, :too_long, count: options[:maximum])
+    end
+  end
+end

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -20,6 +20,25 @@ describe Episode do
     assert minimal_episode.updated_at > 10.minutes.ago
   end
 
+  it "validates descriptions have a maximum of 4000 bytes" do
+    e = build_stubbed(:episode, segment_count: 2, published_at: nil, strict_validations: true)
+
+    e.description = nil
+    assert e.valid?
+
+    e.description = "a" * 4000
+    assert e.valid?
+
+    e.description = "a" * 4001
+    refute e.valid?
+
+    e.description = "a" * 3999 + "’"
+    refute e.valid?
+
+    e.strict_validations = false
+    assert e.valid?
+  end
+
   it "validates unique original guids" do
     e1 = create(:episode, original_guid: "original")
     e2 = build(:episode, original_guid: "original", podcast: e1.podcast)


### PR DESCRIPTION
Similar to https://github.com/PRX/publish.prx.org/pull/776 ... validate description HTML is <= 4000 bytes.  Only applies to UI entry (not API calls or RSS imports) for now.