### PR TITLE
Add slight debounce to redrawing chart

### DIFF
--- a/app/javascript/controllers/podcast_metrics_controller.js
+++ b/app/javascript/controllers/podcast_metrics_controller.js
@@ -59,7 +59,8 @@ export default class extends Controller {
     // clear out yAxis max and update series
     this.chart.yAxis[0].update({ max: null }, false)
     this.chart.series[seriesIndex].setData(data, false)
-    this.chart.redraw()
+    clearTimeout(this.timer)
+    this.timer = setTimeout(() => this.chart.redraw(), 100)
 
     // set total element
     if (isTotal) {


### PR DESCRIPTION
Fixes #855.

Turns out, I just needed to debounce calling `chart.redraw()`.  Didn't bother to add any caching - Castle is returning these 40+ results real quick (IIRC, Castle has its own caching layer).