### PR TITLE
Segment existing contents

### DIFF
--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -110,6 +110,10 @@ module UploadsHelper
     rec.new_record? || rec.marked_for_destruction?
   end
 
+  def upload_uploaded?(rec)
+    rec.new_record? && rec.original_url.present?
+  end
+
   def upload_processing?(rec)
     %w[started created processing retrying].include?(rec&.status)
   end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -223,10 +223,20 @@ class Episode < ApplicationRecord
     super
 
     if medium_changed? && medium_was.present?
-      unless medium == "audio" && medium_was == "uncut"
+      if medium_was == "uncut" && medium == "audio"
+        uncut&.mark_for_replacement
+      elsif medium_was == "audio" && medium == "uncut"
+        if contents.first&.status_complete?
+          (uncut || build_uncut).tap do |u|
+            u.original_url = contents.first.url
+            u.file_size = contents.first.file_size
+            u.duration = contents.first.duration
+          end
+        end
+        contents.each(&:mark_for_replacement)
+      else
         contents.each(&:mark_for_replacement)
       end
-      uncut&.mark_for_replacement
     end
 
     self.segment_count = 1 if medium_video?

--- a/app/views/episode_media/media/_new.html.erb
+++ b/app/views/episode_media/media/_new.html.erb
@@ -5,7 +5,7 @@
   <%= form.hidden_field :_destroy, value: true, data: {upload_target: "replace"} %>
 
   <%# step 1: file field %>
-  <div class="form-floating" data-upload-target="picker">
+  <div class="form-floating <%= "d-none" if upload_uploaded?(media) %>" data-upload-target="picker">
     <% cls = "form-control position-absolute opacity-0 z-1" %>
     <% data = {action: "change->unsaved#change upload#upload", upload_target: "field"} %>
     <% data[:unsaved_target] = "changed" if media.marked_for_destruction? %>
@@ -55,15 +55,17 @@
   </div>
 
   <%# step 3a: hidden original_url field pointing to the uploaded temporary s3 file %>
-  <div class="form-floating d-none input-group" data-upload-target="success">
+  <div class="form-floating input-group <%= "d-none" unless upload_uploaded?(media) %>" data-upload-target="success">
     <%= form.hidden_field :original_url, value: nil, data: {upload_target: "originalUrl"} %>
     <%= form.hidden_field :file_size, value: nil, data: {upload_target: "fileSize"} %>
     <%= form.hidden_field :position %>
 
     <div class="form-control d-flex align-items-center is-changed if-visible">
       <span class="material-icons text-primary"><%= episode.medium_video? ? "video_file" : "audio_file" %></span>
-      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate" data-upload-target="fileName"></div>
-      <small class="text-muted">(<span data-upload-target="fileSize"></span>)</small>
+      <div class="text-secondary mx-2 flex-grow-1 overflow-hidden text-truncate" data-upload-target="fileName">
+        <%= media.file_name %>
+      </div>
+      <small class="text-muted">(<span data-upload-target="fileSize"><%= episode_media_duration(media) %></span>)</small>
     </div>
 
     <button class="input-group-text prx-input-group-text" data-action="upload#cancelUpload">

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -282,6 +282,8 @@ describe Episode do
 
       episode.medium = "uncut"
       assert episode.contents.first.marked_for_replacement?
+      assert episode.uncut.new_record?
+      assert_equal episode.contents.first.url, episode.uncut.original_url
     end
 
     it "sets segment count for videos" do


### PR DESCRIPTION
So previously, if you changed an episode from "Upload single file" to "Upload multiple files", any existing contents we sliced from your single file will show up as the "multiple files".

This kind of does the inverse: if your "Upload multiple files" episode has a completed file in position 1, we preset that as the new file.  But - without saving it yet - clicking save will reprocess it.

![image](https://github.com/PRX/feeder.prx.org/assets/1410587/269350c5-8f07-4d0f-8362-6dcfbe7ddcb4)

Did notice we tend to get guid filenames doing these types of conversions - opened #874 to figure that out.