### PR TITLE
HOTFIX: post roll handle initial render

### DIFF
--- a/app/javascript/controllers/audio_breakpoints_controller.js
+++ b/app/javascript/controllers/audio_breakpoints_controller.js
@@ -34,6 +34,8 @@ export default class extends Controller {
     )
 
     endTimeInput?.setAttribute("placeholder", convertSecondsToDuration(this.durationValue))
+
+    this.maxTime = this.durationValue - 0.01
   }
 
   /**
@@ -97,11 +99,13 @@ export default class extends Controller {
       }
     )
 
+    console.log(this.postRollPoint, this.durationValue)
+
     this.breakpointMarkers.push(
       postRollMarker || {
         id: "postRoll",
         labelText: this.labelPostRollValue,
-        startTime: this.postRollPoint || this.durationValue,
+        startTime: this.postRollPoint || this.maxTime,
         endTime: this.durationValue,
       }
     )
@@ -139,7 +143,7 @@ export default class extends Controller {
       ...breakpointMarker,
       changed: new Date().getMilliseconds(),
       startTime: hasEndTime
-        ? Math.max(this.minTime, Math.min(newStartTime, newEndTime, this.durationValue))
+        ? Math.max(this.minTime, Math.min(newStartTime, newEndTime, this.maxTime))
         : newStartTime,
       endTime: hasEndTime ? Math.min(this.durationValue, Math.max(newStartTime, newEndTime, this.minTime)) : undefined,
     }
@@ -169,7 +173,7 @@ export default class extends Controller {
       }
     } else {
       const inValidStartTime =
-        newBreakpointMarker.startTime <= this.minTime || newBreakpointMarker.startTime >= this.durationValue
+        newBreakpointMarker.startTime <= this.minTime || newBreakpointMarker.startTime >= this.maxTime
       const intersectingSegment = this.breakpointMarkers.find(
         ({ id: iId, startTime: iStartTime, endTime: iEndTime }) =>
           id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime

--- a/app/javascript/controllers/waveform_inspector_controller.js
+++ b/app/javascript/controllers/waveform_inspector_controller.js
@@ -109,7 +109,7 @@ export default class extends Controller {
       const zoomView = peaksInstance.views.getView("zoomview")
       const overviewView = peaksInstance.views.getView("overview")
 
-      zoomView.setMinSegmentDragWidth(0)
+      zoomView.setMinSegmentDragWidth(1)
       zoomView.setAmplitudeScale(2)
 
       // Prevent segments from overlapping other segments.


### PR DESCRIPTION
Ensures post roll handle doesn't render off canvas.

Noticed the post roll handle in wave form would show up initially on https://feeder.prx.test/episodes/1b1d0519-83b6-4150-ba1e-d4b362f69d45/media until edited via the ad break inputs. This PR should ensure the post roll segment has some renderable length in the waveform editor.