### PR TITLE
Clean up spacing and shadow usage on Episode cards

### DIFF
--- a/app/assets/stylesheets/shared/episode-card.scss
+++ b/app/assets/stylesheets/shared/episode-card.scss
@@ -8,7 +8,6 @@
   border-right: none;
   border-bottom: none;
   border-radius: 0;
-  //margin-bottom: 0.25rem;
   height: 100px;
 
   .card-body {

--- a/app/assets/stylesheets/shared/episode-card.scss
+++ b/app/assets/stylesheets/shared/episode-card.scss
@@ -8,7 +8,7 @@
   border-right: none;
   border-bottom: none;
   border-radius: 0;
-  margin-bottom: 0.25rem;
+  //margin-bottom: 0.25rem;
   height: 100px;
 
   .card-body {
@@ -17,6 +17,7 @@
     justify-content: space-between;
     padding-top: 0;
     padding-bottom: 0;
+    border-bottom: 1px solid $border-color;
 
     &:hover {
       background: rgba(140, 210, 244, 0.1);

--- a/app/views/episodes/index.html.erb
+++ b/app/views/episodes/index.html.erb
@@ -10,7 +10,7 @@
       <% if params[:sort].present? %>
 
         <section class="col-lg-12">
-          <div class="dashboard-list mb-4 shadow">
+          <div class="dashboard-list shadow">
             <%= render partial: "episodes/episode", collection: @episodes, cached: true %>
           </div>
           <div class="my-4">
@@ -24,8 +24,10 @@
         <section class="col-md-6 col-12">
           <div class="row">
           <h2 class="fw-bold"><%= t(".draft_or_scheduled") %></h2>
-          <div class="dashboard-list mb-4 shadow">
+          <div class="dashboard-list">
+            <div class="shadow">
             <%= render partial: "episodes/episode", collection: @scheduled_episodes, cached: true %>
+            </div>
           </div>
           <div class="my-4">
             <%= paginate @scheduled_episodes, param_name: :scheduled_page %>
@@ -37,8 +39,10 @@
         <section class="col-md-6 col-12">
           <div class="row">
           <h2 class="fw-bold"><%= t(".published") %></h2>
-          <div class="dashboard-list mb-4 shadow">
+          <div class="dashboard-list">
+            <div class="shadow">
             <%= render partial: "episodes/episode", collection: @published_episodes, cached: true %>
+            </div>
           </div>
           <div class="my-4">
             <%= paginate @published_episodes, param_name: :published_page %>


### PR DESCRIPTION
Closes #885 

Since we now have filters and full width episode cards on the episodes index, I decided to change up the design of the cards on episodes very, very slightly to match the podcast card layout on the podcasts index.

- [ ] Navigate to /episodes confirm there's no longer the small gap between episode cards, and its replaced by a border
- [ ] Filter through the sort options, confirm consistency
- [ ] Go to Podcasts index (View all Podcasts) and confirm its similar.