### PR TITLE
Fix app access detection

### DIFF
--- a/app/helpers/current_user_helper.rb
+++ b/app/helpers/current_user_helper.rb
@@ -4,11 +4,16 @@ module CurrentUserHelper
   end
 
   def current_user_app(name)
-    current_user_apps.values.find do |url|
-      url.include?("#{name}.prx.org") ||
-        url.include?("#{name}.staging.prx.tech") ||
-        url.include?("#{name}.prx.test")
-    end
+    current_user_apps.filter_map do |key, url|
+      # TODO: temporary, as we shuffle/solidify these keys
+      if name == "augury"
+        url if key.downcase.include?(name) || key.downcase.include?("inventory")
+      elsif name == "feeder"
+        url if key.downcase.include?(name) || key.downcase.include?("podcasts")
+      elsif key.downcase.include?(name)
+        url
+      end
+    end.first
   end
 
   def current_user_id_profile

--- a/test/helpers/current_user_helper_test.rb
+++ b/test/helpers/current_user_helper_test.rb
@@ -18,9 +18,8 @@ describe CurrentUserHelper do
     it "determines if you have an app or not" do
       helper.current_user = {}
       helper.current_user_apps = {
-        "dev domain" => "https://foo.prx.dev",
-        "real domain" => "https://bar.prx.org",
-        "staging domain" => "https://baz.staging.prx.tech"
+        "app for BAR" => "https://bar.prx.org",
+        "and then BAZ" => "https://baz.staging.prx.tech"
       }
 
       refute helper.current_user_app?("foo")
@@ -34,8 +33,8 @@ describe CurrentUserHelper do
       helper.current_user = {}
       helper.current_user_apps = {
         "dev domain" => "https://foo.prx.dev",
-        "real domain" => "https://bar.prx.org",
-        "staging domain" => "https://baz.staging.prx.tech"
+        "real Bar domain" => "https://bar.prx.org",
+        "staging Baz domain" => "https://baz.staging.prx.tech"
       }
 
       assert_nil helper.current_user_app("foo")


### PR DESCRIPTION
The `current_user_app("metrics")` detection logic is broken.  This looks at the ID userinfo keys instead of url values, to detect if you have "metrics" / "augury" access.