### PR TITLE
Turn down retry errors

### DIFF
--- a/app/models/apple/api.rb
+++ b/app/models/apple/api.rb
@@ -305,7 +305,7 @@ module Apple
     def retry_bridge_api_operation(bridge_resource, row_operations_ok, row_operation_errs, attempts = 1, batch_size: DEFAULT_BATCH_SIZE)
       return [row_operations_ok, row_operation_errs] if attempts >= ERROR_RETRIES || row_operation_errs.empty?
 
-      row_operation_errs.map { |err| Rails.logger.error("Retrying: #{err.to_json}") }
+      row_operation_errs.map { |err| Rails.logger.info("Retrying: #{err.to_json}") }
 
       # Slice off the api response and retry the row operation
       formatted_error_operations_for_retry = row_operation_errs.map do |r|

--- a/app/models/apple/api.rb
+++ b/app/models/apple/api.rb
@@ -305,7 +305,7 @@ module Apple
     def retry_bridge_api_operation(bridge_resource, row_operations_ok, row_operation_errs, attempts = 1, batch_size: DEFAULT_BATCH_SIZE)
       return [row_operations_ok, row_operation_errs] if attempts >= ERROR_RETRIES || row_operation_errs.empty?
 
-      row_operation_errs.map { |err| Rails.logger.info("Retrying: #{err.to_json}") }
+      row_operation_errs.map { |err| Rails.logger.warn("Retrying: #{err.to_json}") }
 
       # Slice off the api response and retry the row operation
       formatted_error_operations_for_retry = row_operation_errs.map do |r|


### PR DESCRIPTION
Turns down the log level from error to warn for API request retries. 