### PR TITLE
Multiple itunes categories

### DIFF
--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -68,6 +68,9 @@
   .invalid-feedback {
     order: 10;
   }
+  input[type="hidden"] + .invalid-feedback {
+    display: none;
+  }
 }
 
 label[required="required"],

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -107,8 +107,6 @@ class FeedsController < ApplicationController
       :title,
       :subtitle,
       :description,
-      :itunes_category,
-      :itunes_subcategory,
       :include_donation_url,
       :include_podcast_value,
       :private,
@@ -128,6 +126,8 @@ class FeedsController < ApplicationController
       :paid,
       :sonic_id,
       include_tags: [],
+      itunes_category: [],
+      itunes_subcategory: [],
       feed_tokens_attributes: %i[id label token _destroy],
       feed_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry],
       itunes_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry]

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -123,8 +123,8 @@ class PodcastsController < ApplicationController
         :id,
         :subtitle,
         :description,
-        :itunes_category,
-        :itunes_subcategory,
+        itunes_category: [],
+        itunes_subcategory: [],
         feed_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry],
         itunes_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry]
       ]

--- a/app/helpers/podcasts_helper.rb
+++ b/app/helpers/podcasts_helper.rb
@@ -50,14 +50,6 @@ module PodcastsHelper
     Podcast::VALID_EXPLICITS.map { |val| [I18n.t("helpers.label.podcast.explicits.#{val}"), val] }
   end
 
-  def itunes_category_options
-    ITunesCategoryValidator::CATEGORIES.keys
-  end
-
-  def itunes_subcategory_options(cat = nil)
-    ITunesCategoryValidator::CATEGORIES[cat] || []
-  end
-
   def podcast_serial_order_options
     [false, true].map { |val| [I18n.t("helpers.label.podcast.serial_orders.#{val}"), val] }
   end

--- a/app/javascript/controllers/nested_select_controller.js
+++ b/app/javascript/controllers/nested_select_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  // child select to updated
+  static targets = ["select"]
+
+  // map of parent select values
+  static values = { opts: Object }
+
+  // change child select options when parent selection changes
+  change(event) {
+    if (this.reordering) {
+      return
+    }
+
+    // lookup parent selections
+    const select = event.currentTarget
+    const selected = select.slim.getSelected()
+
+    // lookup child options, sorted in order of parent select
+    const childOpts = selected.map((o) => this.optsValue[o] || []).flat()
+    const childData = childOpts.map((o) => ({ text: o }))
+    const childSelected = this.selectTarget.slim.getSelected()
+    this.selectTarget.slim.setData(childData)
+    this.selectTarget.slim.setSelected(childSelected)
+
+    // reorder parent select out-of-band with this event
+    setTimeout(() => this.reorder(select), 1)
+  }
+
+  reorder(select) {
+    const data = select.slim.getData()
+    const selected = data.filter((d) => d.selected)
+    const rest = data.filter((d) => !d.selected).sort((a, b) => a.value.localeCompare(b.value))
+
+    // disable change event while reordering, to prevent recursion
+    this.reordering = true
+    select.slim.setData(selected.concat(rest))
+    this.reordering = false
+  }
+}

--- a/app/models/concerns/feed_itunes_category.rb
+++ b/app/models/concerns/feed_itunes_category.rb
@@ -1,0 +1,56 @@
+require "active_support/concern"
+
+module FeedITunesCategory
+  extend ActiveSupport::Concern
+
+  included do
+    alias_error_messages :itunes_category, :"itunes_categories.name"
+  end
+
+  def itunes_category
+    itunes_categories.reject(&:marked_for_destruction?).map(&:name).compact
+  end
+
+  def itunes_category=(val)
+    names = Array(val).reject(&:blank?)
+
+    # add new categories
+    names.each do |name|
+      itunes_categories.build(name: name) unless itunes_categories.map(&:name).include?(name)
+    end
+
+    # remove gone categories
+    itunes_categories.each do |cat|
+      cat.mark_for_destruction unless names.include?(cat.name)
+    end
+
+    # default feeds must have at least one category - add a blank one to trigger validaiton errors
+    if default? && itunes_categories.all?(&:marked_for_destruction?)
+      itunes_categories.build(name: nil)
+    end
+  end
+
+  def itunes_subcategory
+    itunes_categories.reject(&:marked_for_destruction?).map(&:subcategories).flatten.compact.uniq.sort
+  end
+
+  def itunes_subcategory=(val)
+    names = Array(val).reject(&:blank?)
+
+    itunes_categories.each do |cat|
+      cat.subcategories = names & (ITunesCategoryValidator::CATEGORIES[cat.name] || [])
+    end
+  end
+
+  def itunes_category_options
+    ((itunes_category || []) + ITunesCategoryValidator::CATEGORIES.keys).uniq
+  end
+
+  def itunes_category_map
+    ITunesCategoryValidator::CATEGORIES
+  end
+
+  def itunes_subcategory_options
+    (itunes_category || []).map { |c| ITunesCategoryValidator::CATEGORIES[c] || [] }.flatten
+  end
+end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -3,6 +3,7 @@ require "hash_serializer"
 class Feed < ApplicationRecord
   include FeedAudioFormat
   include FeedAdZone
+  include FeedITunesCategory
 
   DEFAULT_FILE_NAME = "feed-rss.xml".freeze
 
@@ -255,33 +256,5 @@ class Feed < ApplicationRecord
 
   def ready_image
     @ready_image ||= (ready_feed_image || ready_itunes_image)
-  end
-
-  def itunes_category
-    itunes_categories[0]&.name
-  end
-
-  def itunes_category=(value)
-    cat = itunes_categories[0] || itunes_categories.build
-
-    # allow destroying for non-default feeds
-    if custom? && value.blank?
-      cat.mark_for_destruction
-    elsif cat.name != value
-      cat.name = value
-      cat.subcategories = []
-    end
-  end
-
-  def itunes_subcategory
-    itunes_categories[0]&.subcategories&.first
-  end
-
-  def itunes_subcategory=(value)
-    if (cat = itunes_categories[0])
-      cat.subcategories = [value]
-    else
-      itunes_categories.build(subcategories: [value])
-    end
   end
 end

--- a/app/views/feeds/_form_overrides.html.erb
+++ b/app/views/feeds/_form_overrides.html.erb
@@ -22,28 +22,26 @@
           </div>
         </div>
 
-        <div class="col-lg-6 mb-4">
-          <div class="form-floating input-group" data-controller="dynamic-form">
-            <%# HACK: display nested validation errors %>
-            <% nested_errors = feed.errors.full_messages_for("itunes_categories.name").join(", ") %>
-            <% klass = nested_errors.present? ? "is-invalid form-select" : "form-select" %>
-            <%= form.select :itunes_category, itunes_category_options, {include_blank: true}, class: klass, data: {action: "dynamic-form#change"} %>
-            <% if nested_errors.present? %><div class="invalid-feedback"><%= nested_errors %></div><% end %>
-            <%= form.label :itunes_category %>
-            <%= field_help_text t(".help.itunes_category") %>
-            <%# update subcategory turbo-frame when category changes %>
-            <a hidden href="<%= new_podcast_feed_path(podcast) %>" data-dynamic-form-target="link" data-turbo-frame="itunes-subcategory"></a>
-          </div>
-        </div>
-
-        <div class="col-lg-6 mb-4">
-          <%= turbo_frame_tag "itunes-subcategory" do %>
-            <div class="form-floating">
-              <% opts = itunes_subcategory_options(feed.itunes_category) %>
-              <%= form.select :itunes_subcategory, opts, {include_blank: true}, disabled: opts.blank? %>
-              <%= form.label :itunes_subcategory %>
+        <div class="container" data-controller="nested-select" data-nested-select-opts-value="<%= feed.itunes_category_map.to_json %>">
+          <div class="row">
+            <div class="col-6 mb-4">
+              <div class="form-floating input-group">
+                <% opts = feed.itunes_category_options %>
+                <% data = {action: "nested-select#change"} %>
+                <%= form.select :itunes_category, opts, {include_blank: true}, multiple: true, data: data %>
+                <%= form.label :itunes_category %>
+              </div>
             </div>
-          <% end %>
+
+            <div class="col-6 mb-4">
+              <div class="form-floating input-group">
+                <% opts = feed.itunes_subcategory_options %>
+                <% data = {nested_select_target: "select"} %>
+                <%= form.select :itunes_subcategory, opts, {include_blank: true}, multiple: true, data: data %>
+                <%= form.label :itunes_subcategory %>
+              </div>
+            </div>
+          </div>
         </div>
 
         <div class="col-lg-6 mb-4">

--- a/app/views/podcasts/_form_main.html.erb
+++ b/app/views/podcasts/_form_main.html.erb
@@ -48,33 +48,29 @@
   </div>
 </div>
 
-<div class="col-6 mb-4">
-  <div class="form-floating input-group" data-controller="dynamic-form">
-    <%= form.fields_for :default_feed do |fields| %>
-      <%# HACK: display nested validation errors %>
-      <% nested_errors = fields.object.errors.full_messages_for("itunes_categories.name").join(", ") %>
-      <% klass = nested_errors.present? ? "is-invalid form-select" : "form-select" %>
-      <%= fields.select :itunes_category, itunes_category_options, {include_blank: true}, class: klass, data: {action: "dynamic-form#change"} %>
-      <% if nested_errors.present? %><div class="invalid-feedback"><%= nested_errors %></div><% end %>
-      <%= fields.label :itunes_category, required: true %>
-      <%= field_help_text t(".help.itunes_category") %>
-      <%# update subcategory turbo-frame when category changes %>
-      <a hidden href="<%= new_podcast_path %>" data-dynamic-form-target="link" data-turbo-frame="itunes-subcategory"></a>
-    <% end %>
-  </div>
-</div>
+<%= form.fields_for :default_feed do |fields| %>
+  <div class="container" data-controller="nested-select" data-nested-select-opts-value="<%= fields.object.itunes_category_map.to_json %>">
+    <div class="row">
+      <div class="col-6 mb-4">
+        <div class="form-floating input-group">
+          <% opts = fields.object.itunes_category_options %>
+          <% data = {action: "nested-select#change"} %>
+          <%= fields.select :itunes_category, opts, {include_blank: true}, multiple: true, data: data %>
+          <%= fields.label :itunes_category, required: true %>
+        </div>
+      </div>
 
-<div class="col-6 mb-4">
-  <%= turbo_frame_tag "itunes-subcategory" do %>
-    <div class="form-floating">
-      <%= form.fields_for :default_feed do |fields| %>
-        <% opts = itunes_subcategory_options(podcast.itunes_category) %>
-        <%= fields.select :itunes_subcategory, opts, {include_blank: true}, disabled: (opts.blank? || !policy(podcast).update?) %>
-        <%= fields.label :itunes_subcategory %>
-      <% end %>
+      <div class="col-6 mb-4">
+        <div class="form-floating input-group">
+          <% opts = fields.object.itunes_subcategory_options %>
+          <% data = {nested_select_target: "select"} %>
+          <%= fields.select :itunes_subcategory, opts, {include_blank: true}, multiple: true, data: data %>
+          <%= fields.label :itunes_subcategory %>
+        </div>
+      </div>
     </div>
-  <% end %>
-</div>
+  </div>
+<% end %>
 
 <div class="col-6 mb-4">
   <div class="form-floating input-group">

--- a/test/models/concerns/feed_itunes_category_test.rb
+++ b/test/models/concerns/feed_itunes_category_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class FeedITunesCategoryTest < ActiveSupport::TestCase
+  let(:feed) do
+    feed = build_stubbed(:feed)
+    feed.itunes_categories.build(name: "Business", subcategories: ["Investing", "Marketing"])
+    feed.itunes_categories.build(name: "Arts", subcategories: ["Food"])
+    feed.itunes_categories.build(name: "Technology")
+    feed
+  end
+
+  describe "#itunes_category" do
+    it "gets itunes category names" do
+      assert_equal ["Business", "Arts", "Technology"], feed.itunes_category
+    end
+
+    it "filters nil/destroyed categories" do
+      feed.itunes_categories[0].mark_for_destruction
+      feed.itunes_categories[1].name = nil
+      assert_equal ["Technology"], feed.itunes_category
+    end
+  end
+
+  describe "#itunes_category=" do
+    it "sets itunes categories" do
+      feed.itunes_category = ["Arts", "Science"]
+      assert_equal ["Arts", "Science"], feed.itunes_category
+      assert feed.itunes_categories[0].marked_for_destruction?
+      refute feed.itunes_categories[1].marked_for_destruction?
+      assert feed.itunes_categories[2].marked_for_destruction?
+      refute feed.itunes_categories[3].marked_for_destruction?
+    end
+
+    it "leaves a nil category for default feeds" do
+      refute feed.default?
+
+      # non-default feeds can destroy all cats
+      feed.itunes_category = []
+      assert feed.itunes_categories.all?(&:marked_for_destruction?)
+
+      feed.slug = nil
+      assert feed.default?
+
+      # default feeds add a new category with nil (invalid) name
+      feed.itunes_category = []
+      assert feed.itunes_categories[3].new_record?
+      assert_nil feed.itunes_categories[3].name
+
+      # but compacts the nil name out of the getter
+      assert_equal [], feed.itunes_category
+    end
+  end
+
+  describe "#itunes_subcategory" do
+    it "gets sorted itunes subcategory names" do
+      assert_equal ["Food", "Investing", "Marketing"], feed.itunes_subcategory
+    end
+
+    it "filters destroyed categories" do
+      feed.itunes_categories[0].mark_for_destruction
+      assert_equal ["Food"], feed.itunes_subcategory
+    end
+  end
+
+  describe "#itunes_subcategory=" do
+    it "sets itunes subcategories" do
+      feed.itunes_subcategory = ["Marketing", "Food", "Performing Arts", "Fitness"]
+      assert_equal ["Food", "Marketing", "Performing Arts"], feed.itunes_subcategory
+    end
+  end
+
+  describe "#itunes_category_options" do
+    it "gets the full list of options" do
+      opts = feed.itunes_category_options
+      assert_equal ITunesCategoryValidator::CATEGORIES.keys.length, opts.length
+
+      # selections are first, followed by alphabetical
+      assert_equal ["Business", "Arts", "Technology", "Comedy", "Education"], opts[0..4]
+    end
+  end
+
+  describe "#itunes_category_map" do
+    it "gets the full category-to-subcategory map" do
+      assert_equal ITunesCategoryValidator::CATEGORIES, feed.itunes_category_map
+    end
+  end
+
+  describe "#itunes_subcategory_options" do
+    it "gets just your current subcategory options" do
+      business = ITunesCategoryValidator::CATEGORIES["Business"]
+      arts = ITunesCategoryValidator::CATEGORIES["Arts"]
+      technology = ITunesCategoryValidator::CATEGORIES["Technology"]
+
+      assert_equal business + arts + technology, feed.itunes_subcategory_options
+    end
+  end
+end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -324,28 +324,4 @@ describe Feed do
       refute feed1.publish_to_apple?(create(:apple_config, public_feed: create(:feed), private_feed: create(:feed)))
     end
   end
-
-  describe "#itunes_category" do
-    it "is required for default feeds" do
-      assert_equal 1, feed1.itunes_categories.count
-      assert_equal "Leisure", feed1.itunes_category
-      assert_equal "Aviation", feed1.itunes_subcategory
-
-      feed1.itunes_category = nil
-      assert feed1.invalid?
-      assert_match(/can't be blank/i, feed1.errors.full_messages_for("itunes_categories.name").join)
-    end
-
-    it "can be deleted for non-default feeds" do
-      create(:itunes_category, feed: feed2)
-
-      assert_equal 1, feed2.itunes_categories.count
-      assert_equal "Leisure", feed2.itunes_category
-      assert_equal "Aviation", feed2.itunes_subcategory
-
-      feed2.itunes_category = nil
-      assert feed2.valid?
-      assert feed2.itunes_categories[0].marked_for_destruction?
-    end
-  end
 end

--- a/test/models/podcast_test.rb
+++ b/test/models/podcast_test.rb
@@ -54,21 +54,6 @@ describe Podcast do
     assert podcast.itunes_block
   end
 
-  it "gets and sets itunes categories" do
-    assert_equal 1, podcast.default_feed.itunes_categories.count
-    assert_equal 2, podcast.default_feed.itunes_categories.first.subcategories.count
-    assert_equal "Leisure", podcast.itunes_category
-    assert_equal "Aviation", podcast.itunes_subcategory
-
-    podcast.itunes_category = "Arts"
-    podcast.itunes_subcategory = "Books"
-
-    assert_equal 1, podcast.default_feed.itunes_categories.count
-    assert_equal 1, podcast.default_feed.itunes_categories.first.subcategories.count
-    assert_equal "Arts", podcast.itunes_category
-    assert_equal "Books", podcast.itunes_subcategory
-  end
-
   describe "publishing" do
     it "creates a publish job on publish" do
       PublishingPipelineState.stub(:start_pipeline!, "published!") do


### PR DESCRIPTION
Closes #890.

Allow setting multiple itunes categories/subcategories from the UI.

![image](https://github.com/PRX/feeder.prx.org/assets/1410587/ff51b074-a9c0-4e83-a1ab-4c611fae0913)

To make this work, I had to do a couple tricky things:

1. The Itunes Categories select is always sorted by the order you select them in.  So when you save, the top-most category in your RSS is the same as the leftmost one in this select.  NOT alphabetical.
2. The subcategories select updates every time you add a category.  To reflect all the subcategories under any of those categories.
3. Subcategories I just alphabetized.  We'll see if anyone cares how those are ordered, within the category.  I think it's most important to be able to pick which top-level category Apple sees.