### PR TITLE
Raise exception if there are any processing errors

### DIFF
--- a/app/models/apple/podcast_delivery_file.rb
+++ b/app/models/apple/podcast_delivery_file.rb
@@ -2,6 +2,8 @@
 
 module Apple
   class PodcastDeliveryFile < ApplicationRecord
+    class DeliveryFileError < StandardError; end
+
     include Apple::ApiResponse
     include Apple::ApiWaiting
 

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -136,7 +136,7 @@ module Apple
 
           publish_drafting!(eps)
 
-          log_delivery_processing_errors(eps)
+          raise_delivery_processing_errors(eps)
         end
       end
 
@@ -162,17 +162,21 @@ module Apple
       end
     end
 
-    def log_delivery_processing_errors(eps)
-      eps.each do |ep|
-        ep.podcast_delivery_files.each do |pdf|
-          next unless pdf.processed_errors?
+    def raise_delivery_processing_errors(eps)
+      pdfs_with_errors = eps.map(&:podcast_delivery_files).flatten.filter(&:processed_errors?)
 
-          Rails.logger.error("Episode has processing errors",
-            {episode_id: ep.feeder_id,
-             podcast_delivery_file_id: pdf.id,
-             asset_processing_state: pdf.asset_processing_state,
-             asset_delivery_state: pdf.asset_delivery_state})
-        end
+      pdfs_with_errors.each do |pdf|
+        Rails.logger.error("Podcast delivery file has processing errors",
+          {episode_id: pdf.episode.id,
+           podcast_delivery_file_id: pdf.id,
+           asset_processing_state: pdf.asset_processing_state,
+           asset_delivery_state: pdf.asset_delivery_state})
+      end
+
+      if pdfs_with_errors.any?
+        raise Apple::PodcastDeliveryFile::DeliveryFileError.new(
+          "Found processing errors on #{pdfs_with_errors.length} podcast delivery files"
+        )
       end
 
       true

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -313,12 +313,14 @@ describe Apple::Publisher do
     end
 
     it "should not raise an error if there are any" do
+      refute podcast_delivery_file.processed_errors?
       assert_equal apple_publisher.raise_delivery_processing_errors([apple_episode]), true
     end
 
     describe "non completed/complete states" do
       let(:asset_processing_state) { "VALIDATION_FAILED" }
       it "should raise an error if there are any" do
+        assert podcast_delivery_file.processed_errors?
         assert_raises(Apple::PodcastDeliveryFile::DeliveryFileError) do
           apple_publisher.raise_delivery_processing_errors([apple_episode])
         end

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -312,14 +312,14 @@ describe Apple::Publisher do
       assert podcast_delivery_file.save!
     end
 
-    it "should not raise an error if there are any" do
+    it "should not raise an error if there are no processing errors" do
       refute podcast_delivery_file.processed_errors?
       assert_equal apple_publisher.raise_delivery_processing_errors([apple_episode]), true
     end
 
     describe "non completed/complete states" do
       let(:asset_processing_state) { "VALIDATION_FAILED" }
-      it "should raise an error if there are any" do
+      it "should raise an error if there are processing errors" do
         assert podcast_delivery_file.processed_errors?
         assert_raises(Apple::PodcastDeliveryFile::DeliveryFileError) do
           apple_publisher.raise_delivery_processing_errors([apple_episode])


### PR DESCRIPTION
Fixes a case where the episode's podcast delivery files had processing errors, but because we were not using exception semantics (only logging errors),  we did not block the publishing of RSS.

This unites the exception handling / publishing blocking with the verification of the PodcastDeliveryFile processing status.