### PR TITLE
Clean up old delivery records upon retry

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -15,6 +15,18 @@ module Apple
     EPISODE_ASSET_WAIT_TIMEOUT = 15.minutes.freeze
     EPISODE_ASSET_WAIT_INTERVAL = 10.seconds.freeze
 
+    # Cleans up old delivery/delivery files iff the episode is to be delivered
+    def self.prepare_for_delivery(episodes)
+      episodes = episodes.select { |ep| ep.needs_delivery? }
+
+      episodes.map do |ep|
+        Rails.logger.info("Preparing episode #{ep.feeder_id} for delivery", {episode_id: ep.feeder_id})
+        ep.feeder_episode.apple_prepare_for_delivery!
+
+        ep
+      end
+    end
+
     # In the case where the episodes state is not yet ready to publish, but the
     # underlying models are ready. Poll the episodes audio asset state but
     # guard against waiting for episode assets that will never be processed.
@@ -472,11 +484,6 @@ module Apple
 
     def audio_asset_state_success?
       audio_asset_state == AUDIO_ASSET_SUCCESS
-    end
-
-    def reset_for_upload!
-      container.podcast_deliveries.each(&:destroy)
-      feeder_episode.reload
     end
 
     def needs_delivery?

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -121,6 +121,8 @@ module Apple
 
       Rails.logger.tagged("Apple::Publisher#publish!") do
         eps.each_slice(PUBLISH_CHUNK_LEN) do |eps|
+          prepare_for_delivery!(eps)
+
           # only create if needed
           sync_episodes!(eps)
           sync_podcast_containers!(eps)
@@ -142,6 +144,12 @@ module Apple
 
       # success
       SyncLog.log!(feeder_id: public_feed.id, feeder_type: :feeds, external_id: show.apple_id, api_response: {success: true})
+    end
+
+    def prepare_for_delivery!(eps)
+      Rails.logger.tagged("Apple::Publisher##{__method__}") do
+        Apple::Episode.prepare_for_delivery(api, eps)
+      end
     end
 
     def archive!(eps = episodes_to_archive)

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -148,7 +148,7 @@ module Apple
 
     def prepare_for_delivery!(eps)
       Rails.logger.tagged("Apple::Publisher##{__method__}") do
-        Apple::Episode.prepare_for_delivery(api, eps)
+        Apple::Episode.prepare_for_delivery(eps)
       end
     end
 

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -121,6 +121,7 @@ module Apple
 
       Rails.logger.tagged("Apple::Publisher#publish!") do
         eps.each_slice(PUBLISH_CHUNK_LEN) do |eps|
+          # Soft delete any existing delivery and delivery files
           prepare_for_delivery!(eps)
 
           # only create if needed

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -268,11 +268,15 @@ class Episode < ApplicationRecord
     uncut&.copy_media(force)
   end
 
-  def apple_mark_for_reupload!
+  def apple_prepare_for_delivery!
     # remove the previous delivery attempt (soft delete)
     apple_podcast_deliveries.map(&:destroy)
     apple_podcast_deliveries.reset
     apple_podcast_container&.podcast_deliveries&.reset
+  end
+
+  def apple_mark_for_reupload!
+    apple_prepare_for_delivery!
     apple_needs_delivery!
   end
 

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -272,6 +272,7 @@ class Episode < ApplicationRecord
     # remove the previous delivery attempt (soft delete)
     apple_podcast_deliveries.map(&:destroy)
     apple_podcast_deliveries.reset
+    apple_podcast_delivery_files.reset
     apple_podcast_container&.podcast_deliveries&.reset
   end
 

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -216,4 +216,25 @@ describe Apple::Episode do
       mock.verify
     end
   end
+
+  describe ".prepare_for_delivery" do
+    it "should filter for episodes that need delivery" do
+      mock = Minitest::Mock.new
+      mock.expect(:call, true, [])
+
+      apple_episode.feeder_episode.stub(:apple_prepare_for_delivery!, mock) do
+        apple_episode.stub(:needs_delivery?, true) do
+          assert_equal [apple_episode], Apple::Episode.prepare_for_delivery([apple_episode])
+        end
+      end
+
+      mock.verify
+    end
+
+    it "should reject delivered episodes" do
+      apple_episode.stub(:needs_delivery?, false) do
+        assert_equal [], Apple::Episode.prepare_for_delivery([apple_episode])
+      end
+    end
+  end
 end

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -236,5 +236,36 @@ describe Apple::Episode do
         assert_equal [], Apple::Episode.prepare_for_delivery([apple_episode])
       end
     end
+
+    describe "soft deleting the delivery files" do
+      let(:container) { create(:apple_podcast_container, episode: episode, apple_episode_id: "123") }
+
+      let(:delivery) do
+        pd = Apple::PodcastDelivery.new(episode: episode, podcast_container: container)
+        pd.save!
+        pd
+      end
+
+      let(:delivery_file) do
+        pdf = Apple::PodcastDeliveryFile.new(episode: episode, podcast_delivery: delivery)
+        pdf.update(apple_sync_log: SyncLog.new(**build(:podcast_delivery_file_api_response).merge(external_id: "123"), feeder_type: :podcast_delivery_files))
+        pdf.save!
+        pdf
+      end
+
+      before do
+        assert_equal [delivery_file], apple_episode.podcast_delivery_files
+      end
+
+      it "should delete the delivery files" do
+        assert apple_episode.podcast_delivery_files.length == 1
+
+        apple_episode.stub(:needs_delivery?, true) do
+          assert_equal [apple_episode], Apple::Episode.prepare_for_delivery([apple_episode])
+        end
+
+        assert apple_episode.podcast_delivery_files.length == 0
+      end
+    end
   end
 end

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -293,4 +293,17 @@ describe Apple::Publisher do
       mock.verify
     end
   end
+
+  describe "#prepare_for_delivery" do
+    it "should poll the podcast container state" do
+      mock = Minitest::Mock.new
+      mock.expect(:call, [], [[]])
+
+      Apple::Episode.stub(:prepare_for_delivery, mock) do
+        apple_publisher.prepare_for_delivery!([])
+      end
+
+      mock.verify
+    end
+  end
 end


### PR DESCRIPTION
Fallout from https://github.com/PRX/feeder.prx.org/pull/853

Fixes up a case where old delivery records (Apple::PodcastDelivery, Apple::PodcastDeliveryFile) are not cleaned up upon retry of delivery.

In #853 we switched from using the podcast delivery/delivery files as sentinels for determining when the audio needed reuploaded to using a flag that's independent of any remote state (primarily because the delivery records are ephemeral in Apple's systems).  But, various places in the codebase assume that there is only a single set of delivery related models at a time.

This PR sets up a top level guard in the publishing routine that:

- filters for episodes that need delivery
- removes deliveries and delivery files for those episodes to-be-uploaded 




