### PR TITLE
Publishing Pipeline expire! can handle deleted podcasts

### DIFF
--- a/app/models/publishing_pipeline_state.rb
+++ b/app/models/publishing_pipeline_state.rb
@@ -166,7 +166,7 @@ class PublishingPipelineState < ApplicationRecord
   end
 
   def self.expire_pipelines!
-    Podcast.where(id: expired_pipelines.select(:podcast_id)).each do |podcast|
+    Podcast.with_deleted.where(id: expired_pipelines.select(:podcast_id)).each do |podcast|
       Rails.logger.tagged("PublishingPipeLineState.expire_pipelines!", "Podcast:#{podcast.id}") do
         expire!(podcast)
       end

--- a/test/models/publishing_pipeline_state_test.rb
+++ b/test/models/publishing_pipeline_state_test.rb
@@ -178,6 +178,11 @@ describe PublishingPipelineState do
 
       PublishingPipelineState.expire_pipelines!
       assert_equal ["created", "expired"].sort, PublishingPipelineState.latest_pipeline(podcast).map(&:status).sort
+
+      # All pipelines are in a terminal state
+      # There is nothing running:
+      assert PublishingPipelineState.running_pipelines.empty?
+      assert PublishingPipelineState.expired_pipelines.empty?
     end
   end
 

--- a/test/models/publishing_pipeline_state_test.rb
+++ b/test/models/publishing_pipeline_state_test.rb
@@ -164,6 +164,21 @@ describe PublishingPipelineState do
       refute PublishingPipelineState.expired?(podcast)
       refute PublishingPipelineState.expired?(podcast2)
     end
+
+    it "cleans up pipelines for deleted podcasts" do
+      podcast = create(:podcast)
+      pa1 = PublishingPipelineState.create!(podcast: podcast, publishing_queue_item: PublishingQueueItem.create!(podcast: podcast))
+      pa1.update_column(:created_at, 30.minutes.ago)
+
+      assert_equal [pa1].sort, PublishingPipelineState.expired_pipelines.sort
+
+      # Now model deleting the podcast
+      podcast.destroy!
+      assert_equal [pa1].sort, PublishingPipelineState.expired_pipelines.sort
+
+      PublishingPipelineState.expire_pipelines!
+      assert_equal ["created", "expired"].sort, PublishingPipelineState.latest_pipeline(podcast).map(&:status).sort
+    end
   end
 
   describe ".retry_failed_pipelines!" do


### PR DESCRIPTION
Handles the case where the publishing pipeline cannot expire podcasts marked as deleted. 