### PR TITLE
Dropdate errors

### DIFF
--- a/app/models/concerns/publishing_status.rb
+++ b/app/models/concerns/publishing_status.rb
@@ -34,11 +34,14 @@ module PublishingStatus
     @publishing_status = value
 
     if value == "draft"
+      self.released_at = published_at if published_at.present?
       self.published_at = nil
     elsif value == "scheduled"
       self.published_at = released_at
     elsif value == "published"
-      self.released_at ||= Time.now unless publishing_status_was == "published"
+      if publishing_status_was == "draft" && (released_at.blank? || released_at > Time.now)
+        self.released_at = Time.now
+      end
       self.published_at = released_at
     end
   end

--- a/app/views/episodes/_form_dropdate.html.erb
+++ b/app/views/episodes/_form_dropdate.html.erb
@@ -1,4 +1,4 @@
-<% editing = policy(episode).update? && (episode.published_or_released_date.blank? || episode.released_at_changed?) %>
+<% editing = policy(episode).update? && (episode.published_or_released_date.blank? || episode.released_at_changed? || episode.errors[:released_at_date].present?) %>
 
 <div class="row" data-controller="dropdate-picker">
   <%= form.hidden_field :released_at, value: episode.published_or_released_date&.iso8601, data: {dropdate_picker_target: "input"} %>

--- a/test/models/concerns/publishing_status_test.rb
+++ b/test/models/concerns/publishing_status_test.rb
@@ -42,9 +42,12 @@ class PublishingStatusTest < ActiveSupport::TestCase
 
   describe "#publishing_status=" do
     it "sets an episode to draft" do
-      ep = build(:episode, published_at: 10.hours.ago)
+      time = 10.hours.ago
+      ep = build(:episode, published_at: time)
+
       ep.publishing_status = "draft"
       assert_nil ep.published_at
+      assert_equal time, ep.released_at
       assert_equal "draft", ep.publishing_status
     end
 
@@ -55,11 +58,31 @@ class PublishingStatusTest < ActiveSupport::TestCase
       assert_equal "scheduled", ep.publishing_status
     end
 
-    it "sets an episode to published" do
+    it "sets an episode with no released_at to published" do
       now = Time.now
 
       Time.stub(:now, now) do
-        ep = build(:episode, published_at: nil)
+        ep = build(:episode, published_at: nil, released_at: nil)
+        ep.publishing_status = "published"
+        assert_equal now, ep.published_at
+        assert_equal now, ep.released_at
+      end
+    end
+
+    it "sets a episode with past released_at to published" do
+      time = 10.hours.ago
+      ep = build(:episode, published_at: nil, released_at: time)
+      ep.publishing_status = "published"
+      assert_equal time, ep.published_at
+      assert_equal time, ep.released_at
+    end
+
+    it "sets a episode with future released_at to published" do
+      time = 10.hours.from_now
+      now = Time.now
+
+      Time.stub(:now, now) do
+        ep = build(:episode, published_at: nil, released_at: time)
         ep.publishing_status = "published"
         assert_equal now, ep.published_at
         assert_equal now, ep.released_at


### PR DESCRIPTION
Fixes #902.

Two changes:

1. The episode dropdate form was previously hidden (behind that edit-pencil) when you had a validation error.  So it was hard to see why the save failed.  This shows the form automatically, if there's an error on the dropdate field.  (Try scheduling an episode with a past-dropdate to see).
2. IF the episode was draft but had a future-dropdate ... resets that to `Time.now`.  So changing the publishing status from Draft to Published should always "just work" now.