### PR TITLE
Feedback link + Mobile App Nav

### DIFF
--- a/app/javascript/controllers/audio_breakpoints_controller.js
+++ b/app/javascript/controllers/audio_breakpoints_controller.js
@@ -30,7 +30,7 @@ export default class extends Controller {
 
   durationValueChanged() {
     const endTimeInput = this.postRollControlTemplateTarget.content.querySelector(
-      '[data-audio-breakpoint-target="endTime"]',
+      '[data-audio-breakpoint-target="endTime"]'
     )
 
     endTimeInput?.setAttribute("placeholder", convertSecondsToDuration(this.durationValue))
@@ -78,8 +78,7 @@ export default class extends Controller {
 
     this.breakpointMarkers = [...Array(this.adBreaksValue).keys()]
       .map(
-        (key) =>
-          (allMarkers[key] && [allMarkers[key].startTime, allMarkers[key].endTime]) || this.adBreaks?.[key] || [],
+        (key) => (allMarkers[key] && [allMarkers[key].startTime, allMarkers[key].endTime]) || this.adBreaks?.[key] || []
       )
       .map((time, index) => ({
         id: allMarkers[index]?.id || Math.random().toString(16).split(".")[1],
@@ -97,7 +96,7 @@ export default class extends Controller {
         // Minimum times can not be zero or else segment doesn't render or function properly.
         startTime: this.minTime,
         endTime: this.preRollPoint || this.minTime,
-      },
+      }
     )
 
     this.breakpointMarkers.push(
@@ -106,7 +105,7 @@ export default class extends Controller {
         labelText: this.labelPostRollValue,
         startTime: this.postRollPoint || this.maxTime,
         endTime: this.durationValue,
-      },
+      }
     )
 
     this.initialMarkers = this.initialMarkers || this.breakpointMarkers
@@ -156,7 +155,7 @@ export default class extends Controller {
           ...newBreakpointMarker,
           startTime: Math.max(
             newBreakpointMarker.startTime,
-            previousBreakpointMarker.endTime || previousBreakpointMarker.startTime,
+            previousBreakpointMarker.endTime || previousBreakpointMarker.startTime
           ),
         }
       }
@@ -173,7 +172,7 @@ export default class extends Controller {
         newBreakpointMarker.startTime <= this.minTime || newBreakpointMarker.startTime >= this.maxTime
       const intersectingSegment = this.breakpointMarkers.find(
         ({ id: iId, startTime: iStartTime, endTime: iEndTime }) =>
-          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime,
+          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime
       )
 
       // Prevent point marker from being dropped in a segment.
@@ -218,7 +217,7 @@ export default class extends Controller {
           (id !== iId &&
             ((newStartTime > iStartTime && newStartTime < iEndTime) ||
               (newEndTime > iStartTime && newEndTime < iEndTime))) ||
-          (newStartTime < iStartTime && newEndTime > iEndTime),
+          (newStartTime < iStartTime && newEndTime > iEndTime)
       )
 
       if (
@@ -250,7 +249,7 @@ export default class extends Controller {
     } else {
       const intersectingSegment = this.breakpointMarkers.find(
         ({ id: iId, startTime: iStartTime, endTime: iEndTime }) =>
-          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime,
+          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime
       )
 
       // Prevent point marker from being dropped in a segment.

--- a/app/javascript/controllers/audio_breakpoints_controller.js
+++ b/app/javascript/controllers/audio_breakpoints_controller.js
@@ -15,8 +15,8 @@ export default class extends Controller {
   static values = {
     duration: Number,
     labelPrefix: { type: String, default: "Breakpoint" },
-    labelPreRoll: { type: String, default: "Pre-Roll" },
-    labelPostRoll: { type: String, default: "Post-Roll" },
+    labelPreRoll: { type: String, default: "Preroll" },
+    labelPostRoll: { type: String, default: "Postroll" },
     adBreaks: { type: Number, default: 1 },
     adBreaksValid: { type: Boolean, default: false },
     segments: { type: Array, default: [] },
@@ -30,7 +30,7 @@ export default class extends Controller {
 
   durationValueChanged() {
     const endTimeInput = this.postRollControlTemplateTarget.content.querySelector(
-      '[data-audio-breakpoint-target="endTime"]'
+      '[data-audio-breakpoint-target="endTime"]',
     )
 
     endTimeInput?.setAttribute("placeholder", convertSecondsToDuration(this.durationValue))
@@ -78,7 +78,8 @@ export default class extends Controller {
 
     this.breakpointMarkers = [...Array(this.adBreaksValue).keys()]
       .map(
-        (key) => (allMarkers[key] && [allMarkers[key].startTime, allMarkers[key].endTime]) || this.adBreaks?.[key] || []
+        (key) =>
+          (allMarkers[key] && [allMarkers[key].startTime, allMarkers[key].endTime]) || this.adBreaks?.[key] || [],
       )
       .map((time, index) => ({
         id: allMarkers[index]?.id || Math.random().toString(16).split(".")[1],
@@ -96,7 +97,7 @@ export default class extends Controller {
         // Minimum times can not be zero or else segment doesn't render or function properly.
         startTime: this.minTime,
         endTime: this.preRollPoint || this.minTime,
-      }
+      },
     )
 
     this.breakpointMarkers.push(
@@ -105,7 +106,7 @@ export default class extends Controller {
         labelText: this.labelPostRollValue,
         startTime: this.postRollPoint || this.maxTime,
         endTime: this.durationValue,
-      }
+      },
     )
 
     this.initialMarkers = this.initialMarkers || this.breakpointMarkers
@@ -155,7 +156,7 @@ export default class extends Controller {
           ...newBreakpointMarker,
           startTime: Math.max(
             newBreakpointMarker.startTime,
-            previousBreakpointMarker.endTime || previousBreakpointMarker.startTime
+            previousBreakpointMarker.endTime || previousBreakpointMarker.startTime,
           ),
         }
       }
@@ -172,7 +173,7 @@ export default class extends Controller {
         newBreakpointMarker.startTime <= this.minTime || newBreakpointMarker.startTime >= this.maxTime
       const intersectingSegment = this.breakpointMarkers.find(
         ({ id: iId, startTime: iStartTime, endTime: iEndTime }) =>
-          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime
+          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime,
       )
 
       // Prevent point marker from being dropped in a segment.
@@ -217,7 +218,7 @@ export default class extends Controller {
           (id !== iId &&
             ((newStartTime > iStartTime && newStartTime < iEndTime) ||
               (newEndTime > iStartTime && newEndTime < iEndTime))) ||
-          (newStartTime < iStartTime && newEndTime > iEndTime)
+          (newStartTime < iStartTime && newEndTime > iEndTime),
       )
 
       if (
@@ -249,7 +250,7 @@ export default class extends Controller {
     } else {
       const intersectingSegment = this.breakpointMarkers.find(
         ({ id: iId, startTime: iStartTime, endTime: iEndTime }) =>
-          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime
+          id !== iId && newBreakpointMarker.startTime > iStartTime && newBreakpointMarker.startTime < iEndTime,
       )
 
       // Prevent point marker from being dropped in a segment.

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -51,5 +51,31 @@
         </div>
       </nav>
     <% end %>
-  </div>
+
+    <nav class="navbar-nav navbar-expand-md">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarApps" aria-controls="navbarApps" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+    </nav>
+
+    <div class="collapse navbar-collapse d-md-none" id="navbarApps" aria-hidden="true">
+      <h2 class="visually-hidden">Your Applications</h2>
+      <ul class="navbar-nav m-2 mb-lg-0">
+        <li class="nav-item">
+          <%= link_to t(".feeder"), main_app.root_path, class: "nav-link active" %>
+        </li>
+        <% if current_user_app?("metrics") %>
+        <li class="nav-item">     
+          <%= link_to t(".metrics"), current_user_app("metrics"), class: "nav-link" %>
+        </li>
+        <% end %>
+         <% if current_user_app?("augury") %>
+        <li class="nav-item">
+          <%= link_to t(".augury"), current_user_app("augury"), class: "nav-link" %>
+        </li>
+        <% end %>
+      </ul>
+    </div>
+
+  </div>  
 </div>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -20,7 +20,7 @@
 
     <nav class="navbar-nav dropdown">
       <h2 class="visually-hidden">Help Menu</h2>
-      <a class="nav-link nav-link-icon dropdown-toggle" href="#" id="nav-help-dropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+      <a class="nav-link nav-link-icon dropdown-toggle" href="#" id="nav-help-dropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" title="Help">
         <span class="material-icons align-middle">help</span>
       </a>
       <div class="dropdown-menu dropdown-menu-end dropdown-menu-dark position-absolute shadow m-0" aria-labelledby="nav-help-dropdown">
@@ -35,7 +35,7 @@
 
     <nav class="navbar-nav">
       <h2 class="visually-hidden">Feedback link</h2>
-      <a class="nav-link nav-link-icon" href="mailto:dovetail-feedback@prx.org">
+      <a class="nav-link nav-link-icon" href="mailto:dovetail-feedback@prx.org" title="Feedback">
         <span class="material-icons align-middle">feedback</span>
       </a>
     </nav>
@@ -43,7 +43,7 @@
     <% if current_user %>
       <nav class="navbar-nav dropdown">
         <h2 class="visually-hidden">User Menu</h2>
-        <a class="nav-link nav-link-icon dropdown-toggle" href="#" id="nav-user-dropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" style="min-width:46px">
+        <a class="nav-link nav-link-icon dropdown-toggle" href="#" id="nav-user-dropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false" style="min-width:46px" title="User Menu">
           <% if current_user_image? %>
             <img src="<%= current_user_image %>" class="prx-header-nav-avatar" alt="<%= current_user_name %>'s avatar">
           <% else %>
@@ -60,7 +60,7 @@
     <% end %>
 
     <nav class="navbar-nav navbar-expand-md">
-      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarApps" aria-controls="navbarApps" aria-expanded="false" aria-label="Toggle navigation">
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarApps" aria-controls="navbarApps" aria-expanded="false" aria-label="Toggle navigation" title="Application Menu">
         <span class="navbar-toggler-icon"></span>
       </button>
     </nav>

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -32,6 +32,14 @@
         <%= link_to t(".home"), "https://prx.org/", class: "dropdown-item" %>
       </div>
     </nav>
+    
+    <nav class="navbar-nav">
+      <h2 class="visually-hidden">Feedback link</h2>
+      <a class="nav-link nav-link-icon" href="mailto:dovetail-feedback@prx.org">
+        <span class="material-icons align-middle">feedback</span>
+      </a>
+    </nav>  
+
 
     <% if current_user %>
       <nav class="navbar-nav dropdown">

--- a/app/views/layouts/_nav.html.erb
+++ b/app/views/layouts/_nav.html.erb
@@ -32,14 +32,13 @@
         <%= link_to t(".home"), "https://prx.org/", class: "dropdown-item" %>
       </div>
     </nav>
-    
+
     <nav class="navbar-nav">
       <h2 class="visually-hidden">Feedback link</h2>
       <a class="nav-link nav-link-icon" href="mailto:dovetail-feedback@prx.org">
         <span class="material-icons align-middle">feedback</span>
       </a>
-    </nav>  
-
+    </nav>
 
     <% if current_user %>
       <nav class="navbar-nav dropdown">
@@ -73,7 +72,7 @@
           <%= link_to t(".feeder"), main_app.root_path, class: "nav-link active" %>
         </li>
         <% if current_user_app?("metrics") %>
-        <li class="nav-item">     
+        <li class="nav-item">
           <%= link_to t(".metrics"), current_user_app("metrics"), class: "nav-link" %>
         </li>
         <% end %>
@@ -85,5 +84,5 @@
       </ul>
     </div>
 
-  </div>  
+  </div>
 </div>


### PR DESCRIPTION
~Requires: https://github.com/PRX/internal/issues/1045 before merging~ DONE!
Closes: #780 

Does three things:
- Removes hyphens on `Pre-roll` and `Post-roll` in the audio segmenter. We don't use hyphens elsewhere describing those zones.
- Fixes teaser `line-height` on the podcast dashboard (unrelated)
- Adds mobile context menu to navigate apps
- Adds a link that will open an email address