### PR TITLE
Filter episodes by dropdate

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -1,5 +1,6 @@
 class Api::EpisodesController < Api::BaseController
   include ApiUpdatedSince
+  include ApiPublishedRange
 
   api_versions :v1
   represent_with Api::EpisodeRepresenter

--- a/app/controllers/concerns/api_published_range.rb
+++ b/app/controllers/concerns/api_published_range.rb
@@ -9,7 +9,7 @@ module ApiPublishedRange
     end
   end
 
-  def resources_base
+  def filtered(resources)
     if published_after.present? && published_before.present?
       super.after(published_after).before(published_before)
     elsif published_after.present?

--- a/app/controllers/concerns/api_published_range.rb
+++ b/app/controllers/concerns/api_published_range.rb
@@ -1,0 +1,35 @@
+require "active_support/concern"
+
+module ApiPublishedRange
+  extend ActiveSupport::Concern
+
+  included do
+    class_eval do
+      allow_params :index, [:after, :before]
+    end
+  end
+
+  def resources_base
+    if published_after.present? && published_before.present?
+      super.after(published_after).before(published_before)
+    elsif published_after.present?
+      super.after(published_after)
+    elsif published_before.present?
+      super.before(published_before)
+    else
+      super
+    end
+  end
+
+  def published_after
+    DateTime.parse(params[:after])
+  rescue
+    nil
+  end
+
+  def published_before
+    DateTime.parse(params[:before])
+  rescue
+    nil
+  end
+end

--- a/app/controllers/concerns/api_updated_since.rb
+++ b/app/controllers/concerns/api_updated_since.rb
@@ -9,7 +9,7 @@ module ApiUpdatedSince
     end
   end
 
-  def resources_base
+  def filtered(resources)
     if updated_since?
       super.where("updated_at >= ?", updated_since).order(updated_at: :asc)
     else

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -67,7 +67,8 @@ class Episode < ApplicationRecord
   scope :draft, -> { where("episodes.published_at IS NULL") }
   scope :scheduled, -> { where("episodes.published_at IS NOT NULL AND episodes.published_at > now()") }
   scope :draft_or_scheduled, -> { draft.or(scheduled) }
-  scope :after, ->(time) { where("#{DROP_DATE} > ?", time) }
+  scope :after, ->(time) { where("#{DROP_DATE} >= ?", time) }
+  scope :before, ->(time) { where("#{DROP_DATE} < ?", time) }
   scope :filter_by_title, ->(text) { where("episodes.title ILIKE ?", "%#{text}%") if text.present? }
   scope :dropdate_asc, -> { reorder(Arel.sql("#{DROP_DATE} ASC NULLS FIRST")) }
   scope :dropdate_desc, -> { reorder(Arel.sql("#{DROP_DATE} DESC NULLS LAST")) }

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -87,6 +87,26 @@ describe Api::EpisodesController do
     refute_includes guids, episode_deleted.guid
   end
 
+  it "should filter by published date" do
+    pubdate = episode.published_at
+
+    get(:index, params: {api_version: "v1", format: "json"})
+    assert_response :success
+    assert_equal 1, JSON.parse(response.body)["_embedded"]["prx:items"].length
+
+    get(:index, params: {api_version: "v1", format: "json", after: pubdate - 1.day, before: pubdate + 1.day})
+    assert_response :success
+    assert_equal 1, JSON.parse(response.body)["_embedded"]["prx:items"].length
+
+    get(:index, params: {api_version: "v1", format: "json", after: pubdate + 1.day})
+    assert_response :success
+    assert_empty JSON.parse(response.body)["_embedded"]["prx:items"]
+
+    get(:index, params: {api_version: "v1", format: "json", before: pubdate - 1.day})
+    assert_response :success
+    assert_empty JSON.parse(response.body)["_embedded"]["prx:items"]
+  end
+
   describe "with a valid token" do
     let(:account_id) { 123 }
     let(:podcast) { create(:podcast, prx_account_uri: "/api/v1/accounts/#{account_id}") }


### PR DESCRIPTION
Fixes #914.

Adds 2 params to the episodes APIs (both public and auth'd)...

- `?after=2023-11-14` filters by publishedAt `>=` (or releasedAt, for draft/scheduled episodes in the auth API)
- `?before=2023-11-14` filters by publishedAt `<` (exclusive)

Date strings are parsed with `DateTime.parse` - which is generally fairly permissive.