### PR TITLE
Import UI improvements

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -63,6 +63,7 @@ class ImportsController < ApplicationController
   def import_params
     params.fetch(:podcast_import, {}).permit(
       :file_name,
+      :import_existing,
       :import_metadata,
       :timings,
       :type,

--- a/app/helpers/uploads_helper.rb
+++ b/app/helpers/uploads_helper.rb
@@ -119,7 +119,7 @@ module UploadsHelper
   end
 
   def upload_problem?(rec)
-    %w[invalid error].include?(rec&.status) || upload_stalled?(rec)
+    %w[invalid error].include?(rec&.status)
   end
 
   def upload_stalled?(rec)

--- a/app/models/imports/podcast_timings_import.rb
+++ b/app/models/imports/podcast_timings_import.rb
@@ -4,7 +4,7 @@ class PodcastTimingsImport < PodcastImport
   SAMPLE_ROWS = 10
   SAMPLE_PERCENT = 0.50
 
-  store :config, accessors: [:file_name, :timings, :guid_index, :timings_index, :has_header], coder: JSON
+  store :config, accessors: [:file_name, :timings, :guid_index, :timings_index, :has_header, :ad_breaks], coder: JSON
 
   has_many :episode_imports, dependent: :destroy, class_name: "EpisodeTimingsImport", foreign_key: :podcast_import_id
 
@@ -47,6 +47,7 @@ class PodcastTimingsImport < PodcastImport
   def validate_timings
     return errors.add(:timings, :blank) if timings.blank?
     return errors.add(:timings, :not_csv) if csv.blank? || csv[0].count < 2
+    return errors.add(:timings, :embedded_newlines) if csv.any? { |row| has_newlines?(row) }
 
     # sample to find guid column
     sample_rows = csv.first(SAMPLE_ROWS)
@@ -76,6 +77,9 @@ class PodcastTimingsImport < PodcastImport
     # cleanup existing dups - they may be recreated later
     episode_imports.status_duplicate.destroy_all
 
+    # reset ad break stats
+    self.ad_breaks = {}
+
     guids = []
     rows = has_header ? csv[1..] : csv
 
@@ -93,6 +97,11 @@ class PodcastTimingsImport < PodcastImport
         ei.timings = timings
         ei.save!
         ei.import_later
+
+        breaks = ei.parse_timings
+        unless breaks.nil?
+          ad_breaks[breaks.count] = ad_breaks[breaks.count].to_i + 1
+        end
       end
     end
 
@@ -114,6 +123,10 @@ class PodcastTimingsImport < PodcastImport
     end
   rescue
     nil
+  end
+
+  def has_newlines?(row)
+    row.any? { |col| col&.include?("\n") || col&.include?("\r") }
   end
 
   def find_guid_index(row)

--- a/app/views/imports/_episode_import.html.erb
+++ b/app/views/imports/_episode_import.html.erb
@@ -21,4 +21,9 @@
       &mdash;
     <% end %>
   </td>
+  <% if episode_import.is_a?(EpisodeTimingsImport) %>
+    <td class="pb-0">
+      <code><%= episode_import.timings %></code>
+    </td>
+  <% end %>
 </tr>

--- a/app/views/imports/_episode_imports.html.erb
+++ b/app/views/imports/_episode_imports.html.erb
@@ -5,6 +5,9 @@
         <th><%= t(".status") %></th>
         <th width=0><%= t(".guid") %></th>
         <th><%= t(".episode") %></th>
+        <% if import.is_a?(PodcastTimingsImport) %>
+          <th><%= t(".timings") %></th>
+        <% end %>
       </tr>
     </thead>
     <tbody>

--- a/app/views/imports/_form_rss.html.erb
+++ b/app/views/imports/_form_rss.html.erb
@@ -5,12 +5,22 @@
   </div>
 </div>
 
-<div class="col-12 prx-field-group">
+<div class="col-12 mt-2">
   <div class="form-check">
     <%= form.check_box :import_metadata, checked: true %>
     <div class="d-flex align-items-center">
       <%= form.label :import_metadata %>
       <%= help_text t(".help.import_metadata") %>
+    </div>
+  </div>
+</div>
+
+<div class="col-12">
+  <div class="form-check">
+    <%= form.check_box :import_existing, checked: true %>
+    <div class="d-flex align-items-center">
+      <%= form.label :import_existing %>
+      <%= help_text t(".help.import_existing") %>
     </div>
   </div>
 </div>

--- a/app/views/imports/_import_status.html.erb
+++ b/app/views/imports/_import_status.html.erb
@@ -49,6 +49,14 @@
         <td><%= t(".errors") %></td>
         <td><%= import.episode_imports.errors.count %></td>
       </tr>
+      <% if import.is_a?(PodcastTimingsImport) %>
+        <% import.ad_breaks&.each do |breaks, count| %>
+          <tr>
+            <td><%= t(".breaks", count: breaks.to_i) %></td>
+            <td><%= count %></td>
+          </tr>
+        <% end %>
+      <% end %>
     </table>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -426,6 +426,7 @@ en:
         caption: Caption
         credit: Credit
       podcast_import:
+        import_existing: Import Existing Episodes
         import_metadata: Import Podcast Metadata
         statuses:
           created: Queued
@@ -844,6 +845,7 @@ en:
       submit: Start Import
     form_rss:
       help:
+        import_existing: If selected, existing episodes in this podcast will be overwritten by any RSS item with the same GUID.
         import_metadata: If selected, the values from the RSS feed channel will override any values added to the Metadata tab. For example, if the title in the feed differs from the podcast title previously listed, the title in the RSS feed will be used.
     form_timings:
       help:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -318,7 +318,7 @@ en:
             timings:
               embedded_newlines: Your CSV has columns containing newlines, or has unclosed quotes - please fix or remove those columns before importing.
               guid_not_found: Unable to detect a guid column - check your CSV format, and confirm your guids match existing episodes in this podcast.
-              not_csv: Not aaaa CSV file, or contains unclosed quotes.
+              not_csv: Not a CSV file, or contains unclosed quotes.
               timings_not_found: Unable to detect a timings column - check your CSV format.
             url:
               bad_http_response: Unable to fetch feed url

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,8 +316,9 @@ en:
         podcast_import:
           attributes:
             timings:
+              embedded_newlines: Your CSV has columns containing newlines, or has unclosed quotes - please fix or remove those columns before importing.
               guid_not_found: Unable to detect a guid column - check your CSV format, and confirm your guids match existing episodes in this podcast.
-              not_csv: Not a CSV file
+              not_csv: Not aaaa CSV file, or contains unclosed quotes.
               timings_not_found: Unable to detect a timings column - check your CSV format.
             url:
               bad_http_response: Unable to fetch feed url
@@ -837,6 +838,7 @@ en:
       initializing: Initializing...
       no_imports: No Imports
       status: Status
+      timings: Timings
     form:
       title: Import
       submit: Start Import
@@ -860,6 +862,9 @@ en:
       failed: Failed
       duplicate: Duplicate GUID Count
     import_status:
+      breaks:
+        one: 1 Break
+        other: "%{count} Breaks"
       complete: Completed
       episode_count: Episode Count
       errors: Errors

--- a/test/models/imports/podcast_timings_import_test.rb
+++ b/test/models/imports/podcast_timings_import_test.rb
@@ -90,6 +90,12 @@ describe PodcastTimingsImport do
       assert import.errors.added? :timings, :not_csv
     end
 
+    it "checks for newlines and unclosed quotes embedded in lines" do
+      import.timings = "\"foo\nbar\"\tmore\tthings\n"
+      assert import.invalid?
+      assert import.errors.added? :timings, :embedded_newlines
+    end
+
     it "detects a guid column" do
       import.csv = [
         ["The Title", "The Guid", "Something Else", "Timings"],


### PR DESCRIPTION
Fixes #912.  Fixes #913.

Also adds an option to _only_ import new episodes.  Useful because if you've imported RSS, then Timings, then RSS again (to get newest eps before a redirect)... you don't want that 2nd RSS import to blow away the timings.

<img width=400 src="https://github.com/PRX/feeder.prx.org/assets/1410587/84835e97-f072-416b-a20e-45daeb246d0a"/>
