### PR TITLE
Include enclosures for replaced Uncut media

### DIFF
--- a/app/controllers/api/podcasts_controller.rb
+++ b/app/controllers/api/podcasts_controller.rb
@@ -13,7 +13,13 @@ class Api::PodcastsController < Api::BaseController
   end
 
   def show
-    super if visible?
+    if visible?
+      if request.format.rss?
+        render plain: FeedBuilder.new(show_resource).to_feed_xml
+      else
+        super
+      end
+    end
   end
 
   def visible?

--- a/app/models/concerns/episode_media.rb
+++ b/app/models/concerns/episode_media.rb
@@ -31,8 +31,8 @@ module EpisodeMedia
     complete_media.any?
   end
 
-  def no_media?
-    medium.nil? && segment_count.nil? && !media?
+  def media?
+    medium.present? || segment_count.present? || media.present?
   end
 
   def media
@@ -79,10 +79,6 @@ module EpisodeMedia
         self.medium = "video"
       end
     end
-  end
-
-  def media?
-    media.any?
   end
 
   def media_content_type(feed = nil)

--- a/app/models/enclosure_url_builder.rb
+++ b/app/models/enclosure_url_builder.rb
@@ -38,9 +38,9 @@ class EnclosureUrlBuilder
   end
 
   def podcast_episode_expansions(podcast, episode, feed)
-    media = episode.contents.first
+    media = episode.uncut || episode.contents.first
 
-    original_url = media.try(:original_url) || ""
+    original_url = media.try(:original_url) || "media"
     original = Addressable::URI.parse(original_url).to_hash
     original = original.map { |k, v| ["original_#{k}".to_sym, v] }.to_h
 

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -330,10 +330,10 @@ class Episode < ApplicationRecord
   end
 
   def include_in_feed?
-    if no_media?
-      true
-    else
+    if media?
       complete_media?
+    else
+      true
     end
   end
 
@@ -406,7 +406,7 @@ class Episode < ApplicationRecord
   end
 
   def validate_media_ready
-    return if published_at.blank? || no_media?
+    return unless published_at.present? && media?
 
     # media must be complete on _initial_ publish
     # otherwise - having files in any status is good enough

--- a/test/models/concerns/episode_media_test.rb
+++ b/test/models/concerns/episode_media_test.rb
@@ -92,12 +92,12 @@ class EpisodeMediaTest < ActiveSupport::TestCase
     end
   end
 
-  describe "#no_media?" do
+  describe "#media?" do
     it "allows episodes to have no media" do
-      assert build_stubbed(:episode, medium: nil, segment_count: nil, contents: []).no_media?
-      refute build_stubbed(:episode, medium: "audio", segment_count: nil, contents: []).no_media?
-      refute build_stubbed(:episode, medium: nil, segment_count: 1, contents: []).no_media?
-      refute build_stubbed(:episode, medium: nil, segment_count: nil, contents: [c1]).no_media?
+      refute build_stubbed(:episode, medium: nil, segment_count: nil, contents: []).media?
+      assert build_stubbed(:episode, medium: "audio", segment_count: nil, contents: []).media?
+      assert build_stubbed(:episode, medium: nil, segment_count: 1, contents: []).media?
+      assert build_stubbed(:episode, medium: nil, segment_count: nil, contents: [c1]).media?
     end
   end
 
@@ -202,14 +202,6 @@ class EpisodeMediaTest < ActiveSupport::TestCase
 
       assert c2.marked_for_destruction?
       refute c2.marked_for_replacement?
-    end
-  end
-
-  describe "#media?" do
-    it "checks for any contents" do
-      assert ep.media?
-      assert build_stubbed(:episode, contents: [build_stubbed(:content, status: "created")]).media?
-      refute build_stubbed(:episode, contents: []).media?
     end
   end
 

--- a/test/models/enclosure_url_builder_test.rb
+++ b/test/models/enclosure_url_builder_test.rb
@@ -50,6 +50,32 @@ describe EnclosureUrlBuilder do
     _(expansions[:path]).must_match(/\/#{podcast.path}\/ba047dce-9df5-4132-a04b-31d24c7c55a(\d+)\/ca047dce-9df5-4132-a04b-31d24c7c55a(\d+).mp3/)
   end
 
+  describe "uncut filenames" do
+    it "prefers the uncut filename over contents" do
+      exp = builder.podcast_episode_expansions(podcast, episode, feed)
+      assert_equal "audio.mp3", exp[:original_filename]
+
+      episode.build_uncut(original_url: "http://some.where/uncut.flac")
+
+      exp = builder.podcast_episode_expansions(podcast, episode, feed)
+      assert_equal "uncut.flac", exp[:original_filename]
+      assert_equal "uncut", exp[:original_basename]
+      assert_equal ".flac", exp[:original_extension]
+    end
+
+    it "has a default, just in case there is no undeleted media" do
+      ep_no_media = build_stubbed(:episode, podcast: podcast)
+      assert_empty ep_no_media.contents
+      assert_nil ep_no_media.uncut
+
+      # published eps should always have media in _some_ status, but just in case
+      exp = builder.podcast_episode_expansions(podcast, ep_no_media, feed)
+      assert_equal "media", exp[:original_filename]
+      assert_equal "media", exp[:original_basename]
+      assert_equal "", exp[:original_extension]
+    end
+  end
+
   describe "default feed extensions when audio format is not present" do
     before do
       feed.audio_format[:f] = nil

--- a/test/models/episode_entry_handler_test.rb
+++ b/test/models/episode_entry_handler_test.rb
@@ -136,6 +136,7 @@ describe EpisodeEntryHandler do
     podcast = create(:podcast)
     episode = EpisodeEntryHandler.create_from_entry!(podcast, entry_no_enclosure)
     episode.contents.clear
+    episode.medium = nil
     refute episode.media?
     refute episode.media_ready?
   end

--- a/test/representers/api/episode_representer_test.rb
+++ b/test/representers/api/episode_representer_test.rb
@@ -19,7 +19,7 @@ describe Api::EpisodeRepresenter do
   end
 
   it "is feed ready with no media" do
-    assert episode.no_media?
+    refute episode.media?
     assert_equal json["isFeedReady"], true
     assert_nil json["_links"]["enclosure"]
   end


### PR DESCRIPTION
Fixes #915.  This tackles leaving the `<enclosure>` in the RSS while we're waiting for the user to segment an Uncut file.

This does not tackle RSS/API metadata (duration, content type, file size) matching the exact files Dovetail Router is going to serve you.