### PR TITLE
Remove media_resources.replaced_at

### DIFF
--- a/app/models/concerns/episode_media.rb
+++ b/app/models/concerns/episode_media.rb
@@ -58,7 +58,7 @@ module EpisodeMedia
         existing[position]&.each(&:mark_for_destruction)
       elsif con.replace?(existing[position]&.first)
         contents.build(con.attributes.compact)
-        existing[position]&.first&.mark_for_replacement
+        existing[position]&.first&.mark_for_destruction
       else
         con.update_resource(existing[position].first)
       end

--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -50,7 +50,7 @@ class Content < MediaResource
   end
 
   def replace_resources!
-    Content.where(episode_id: episode_id, position: position).where.not(id: id).touch_all(:replaced_at, :deleted_at)
+    Content.where(episode_id: episode_id, position: position).where.not(id: id).destroy_all
   end
 
   private

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -211,7 +211,7 @@ class Episode < ApplicationRecord
 
     if medium_changed? && medium_was.present?
       if medium_was == "uncut" && medium == "audio"
-        uncut&.mark_for_replacement
+        uncut&.mark_for_destruction
       elsif medium_was == "audio" && medium == "uncut"
         if (c = contents.first)
           build_uncut.tap do |u|
@@ -223,9 +223,9 @@ class Episode < ApplicationRecord
             u.original_url = (c.status_complete? && is_old) ? c.url : c.original_url
           end
         end
-        contents.each(&:mark_for_replacement)
+        contents.each(&:mark_for_destruction)
       else
-        contents.each(&:mark_for_replacement)
+        contents.each(&:mark_for_destruction)
       end
     end
 

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -21,13 +21,6 @@ class MediaResource < ApplicationRecord
 
   after_create :replace_resources!
 
-  scope :complete_or_replaced, -> do
-    with_deleted
-      .status_complete
-      .where("deleted_at IS NULL OR replaced_at IS NOT NULL")
-      .order("created_at DESC")
-  end
-
   def self.build(file, position = nil)
     media =
       if file&.is_a?(Hash)
@@ -179,20 +172,5 @@ class MediaResource < ApplicationRecord
 
   def _retry=(_val)
     retry!
-  end
-
-  def mark_for_replacement
-    mark_for_destruction
-    @marked_for_replacement = true if status_complete?
-  end
-
-  def marked_for_replacement?
-    @marked_for_replacement == true
-  end
-
-  def paranoia_destroy_attributes
-    super.tap do |attrs|
-      attrs[:replaced_at] = current_time_from_proper_timezone if marked_for_replacement?
-    end
   end
 end

--- a/db/migrate/20240206213452_remove_media_resource_replaced_at.rb
+++ b/db/migrate/20240206213452_remove_media_resource_replaced_at.rb
@@ -1,0 +1,5 @@
+class RemoveMediaResourceReplacedAt < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :media_resources, :replaced_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_21_144340) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_06_213452) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -288,7 +288,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_21_144340) do
     t.string "guid"
     t.integer "status"
     t.datetime "deleted_at", precision: nil
-    t.datetime "replaced_at", precision: nil
     t.text "segmentation"
     t.index ["episode_id"], name: "index_media_resources_on_episode_id"
     t.index ["guid"], name: "index_media_resources_on_guid", unique: true

--- a/test/models/concerns/episode_media_test.rb
+++ b/test/models/concerns/episode_media_test.rb
@@ -116,7 +116,7 @@ class EpisodeMediaTest < ActiveSupport::TestCase
       assert_equal 3, ep.contents.size
       assert_equal c1, ep.contents[0]
       assert_equal c2, ep.contents[1]
-      assert c2.marked_for_replacement?
+      assert c2.marked_for_destruction?
 
       new_content = ep.contents[2]
       assert new_content.new_record?
@@ -131,7 +131,6 @@ class EpisodeMediaTest < ActiveSupport::TestCase
       assert_equal c1, ep.media[0]
       assert_equal c2, ep.media[1]
       refute c2.marked_for_destruction?
-      refute c2.marked_for_replacement?
 
       new_content = ep.media[2]
       assert new_content.new_record?
@@ -148,7 +147,6 @@ class EpisodeMediaTest < ActiveSupport::TestCase
       assert_equal c2, ep.contents[1]
 
       assert c2.marked_for_destruction?
-      refute c2.marked_for_replacement?
     end
 
     it "ignores nil" do
@@ -156,7 +154,6 @@ class EpisodeMediaTest < ActiveSupport::TestCase
 
       assert_equal [c1, c2], ep.media
       assert ep.media.none?(&:marked_for_destruction?)
-      assert ep.media.none?(&:marked_for_replacement?)
     end
 
     it "ignores unchanged original_urls" do
@@ -164,7 +161,6 @@ class EpisodeMediaTest < ActiveSupport::TestCase
 
       assert_equal [c1, c2], ep.media
       assert ep.media.none?(&:marked_for_destruction?)
-      assert ep.media.none?(&:marked_for_replacement?)
     end
 
     it "also accepts hashes" do
@@ -172,7 +168,6 @@ class EpisodeMediaTest < ActiveSupport::TestCase
 
       assert_equal [c1, c2], ep.media
       assert ep.media.none?(&:marked_for_destruction?)
-      assert ep.media.none?(&:marked_for_replacement?)
     end
 
     it "infers episode medium audio" do
@@ -201,7 +196,6 @@ class EpisodeMediaTest < ActiveSupport::TestCase
       assert_equal c2, ep.contents[1]
 
       assert c2.marked_for_destruction?
-      refute c2.marked_for_replacement?
     end
   end
 

--- a/test/models/content_test.rb
+++ b/test/models/content_test.rb
@@ -133,7 +133,6 @@ describe Content do
       assert_equal [c1, c4, c3], episode.reload.contents
 
       refute_nil c2.reload.deleted_at
-      refute_nil c2.replaced_at
     end
   end
 end

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -302,24 +302,24 @@ describe Episode do
   end
 
   describe "#medium=" do
-    it "marks existing content for replacement on change" do
-      refute episode.contents.first.marked_for_replacement?
+    it "marks existing content for destruction on change" do
+      refute episode.contents.first.marked_for_destruction?
 
       episode.medium = "audio"
-      refute episode.contents.first.marked_for_replacement?
+      refute episode.contents.first.marked_for_destruction?
 
       episode.medium = "uncut"
-      assert episode.contents.first.marked_for_replacement?
+      assert episode.contents.first.marked_for_destruction?
       assert episode.uncut.new_record?
       assert_equal episode.contents.first.original_url, episode.uncut.original_url
     end
 
     it "sets segment count for videos" do
       episode.segment_count = 2
-      refute episode.contents.first.marked_for_replacement?
+      refute episode.contents.first.marked_for_destruction?
 
       episode.medium = "video"
-      assert episode.contents.first.marked_for_replacement?
+      assert episode.contents.first.marked_for_destruction?
       assert_equal 1, episode.segment_count
     end
   end

--- a/test/models/media_resource_test.rb
+++ b/test/models/media_resource_test.rb
@@ -133,43 +133,4 @@ describe MediaResource do
     refute mr.audio?
     refute mr.video?
   end
-
-  it "marks completed resources for replacement" do
-    mr = build_stubbed(:media_resource, status: "started")
-    refute mr.marked_for_destruction?
-    refute mr.marked_for_replacement?
-
-    mr.mark_for_replacement
-    assert mr.marked_for_destruction?
-    refute mr.marked_for_replacement?
-
-    mr.status = "complete"
-    mr.mark_for_replacement
-    assert mr.marked_for_destruction?
-    assert mr.marked_for_replacement?
-  end
-
-  it "sets both deleted_at and replaced_at on save" do
-    ep = create(:episode_with_media)
-    mr = ep.contents.first
-
-    mr.mark_for_replacement
-    ep.save!
-
-    assert mr.deleted_at.present?
-    assert mr.replaced_at.present?
-  end
-
-  it "sets just deleted_at" do
-    ep = create(:episode_with_media)
-    mr = ep.contents.first
-
-    # invalid doesn't count as "replaced"
-    mr.status = "invalid"
-    mr.mark_for_replacement
-    ep.save!
-
-    assert mr.deleted_at.present?
-    assert_nil mr.replaced_at
-  end
 end

--- a/test/models/uncut_test.rb
+++ b/test/models/uncut_test.rb
@@ -32,9 +32,6 @@ describe Uncut do
       assert_equal [uncut.url], episode.contents.pluck(:original_url).uniq
       assert_equal segs + [[0.5, 1], [3.5, nil]], episode.contents.pluck(:segmentation)
       assert_equal [false, false, false, true, true], episode.contents.map(&:changed?)
-
-      # NOTE: since only contents[0] was completed, it's the only one marked replaced
-      assert_equal [true, false, false, false, false], episode.contents.map(&:marked_for_replacement?)
       assert_equal [true, false, true, false, false], episode.contents.map(&:marked_for_destruction?)
     end
   end


### PR DESCRIPTION
Closes #835.

Now that we have the `media_versions` table, we don't need the `media_resources.replaced_at` field.

This removes it from the db, and just does a normal "mark for destruction" to set `deleted_at`.