### PR TITLE
Fix bad mp3 durations

### DIFF
--- a/app/controllers/episode_media_controller.rb
+++ b/app/controllers/episode_media_controller.rb
@@ -25,6 +25,9 @@ class EpisodeMediaController < ApplicationController
     authorize @episode, :update?
     @episode.assign_attributes(parsed_episode_params)
 
+    # when an uncut is destroyed, also destroy sliced contents
+    @episode.contents.each(&:mark_for_destruction) if @episode.uncut&.marked_for_destruction?
+
     respond_to do |format|
       if @episode.save
         @episode.uncut&.slice_contents!

--- a/app/models/tasks/copy_media_task.rb
+++ b/app/models/tasks/copy_media_task.rb
@@ -87,10 +87,9 @@ class Tasks::CopyMediaTask < ::Task
   end
 
   def porter_slice_task
-    input_opts = []
-    input_opts << "-ss #{media_resource.slice_start}" if media_resource.slice_start.present?
-    input_opts << "-to #{media_resource.slice_end}" if media_resource.slice_end.present?
     output_opts = ["-map_metadata 0"]
+    output_opts << "-ss #{media_resource.slice_start}" if media_resource.slice_start.present?
+    output_opts << "-to #{media_resource.slice_end}" if media_resource.slice_end.present?
 
     {
       Type: "Transcode",
@@ -101,7 +100,6 @@ class Tasks::CopyMediaTask < ::Task
         ObjectKey: porter_escape(media_resource.path)
       },
       FFmpeg: {
-        InputFileOptions: input_opts.join(" "),
         OutputFileOptions: output_opts.join(" ")
       }
     }

--- a/app/models/tasks/fix_media_task.rb
+++ b/app/models/tasks/fix_media_task.rb
@@ -1,0 +1,33 @@
+class Tasks::FixMediaTask < ::Task
+  before_save :update_media_resource, if: ->(t) { t.status_changed? && t.media_resource }
+
+  def media_resource
+    owner
+  end
+
+  def source_url
+    media_resource&.href
+  end
+
+  def porter_tasks
+    [
+      {
+        Type: "Transcode",
+        Format: "INHERIT",
+        Destination: {
+          Mode: "AWS/S3",
+          BucketName: ENV["FEEDER_STORAGE_BUCKET"],
+          ObjectKey: porter_escape(media_resource.path)
+        },
+        FFmpeg: {
+          OutputFileOptions: "-acodec copy"
+        }
+      }
+    ]
+  end
+
+  def update_media_resource
+    media_resource.status = status
+    media_resource.save!
+  end
+end

--- a/test/factories/task_factory.rb
+++ b/test/factories/task_factory.rb
@@ -17,4 +17,11 @@ FactoryBot.define do
     job_id { "2345" }
     result { build(:porter_image_job_results) }
   end
+
+  factory :fix_media_task, class: Tasks::FixMediaTask do
+    association :owner, factory: :content
+    status { :complete }
+    job_id { "1234" }
+    options { {destination: "s3://test-prx-up/podcast/episode/filename.mp3"} }
+  end
 end

--- a/test/models/tasks/fix_media_task_test.rb
+++ b/test/models/tasks/fix_media_task_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+describe Tasks::FixMediaTask do
+  let(:task) { build_stubbed(:fix_media_task) }
+
+  describe "#source_url" do
+    it "is the media resource href" do
+      task.media_resource.stub(:href, "whatev") do
+        assert_equal "whatev", task.source_url
+      end
+    end
+  end
+
+  describe "#porter_tasks" do
+    it "runs an ffmpeg task" do
+      t = task.porter_tasks[0]
+
+      assert_equal "Transcode", t[:Type]
+      assert_equal "INHERIT", t[:Format]
+      assert_equal "AWS/S3", t[:Destination][:Mode]
+      assert_equal "test-prx-feed", t[:Destination][:BucketName]
+      assert_equal task.media_resource.path, t[:Destination][:ObjectKey]
+      assert_equal "-acodec copy", t[:FFmpeg][:OutputFileOptions]
+    end
+  end
+
+  describe "#update_media_resource" do
+    it "copies the task status to the media" do
+      task.media_resource.stub(:save!, true) do
+        task.status = "error"
+        task.update_media_resource
+        assert_equal "error", task.media_resource.status
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #941.  Fixes #940.  Fixes #942.

Porter is now returning a `"DurationDiscrepancy": 1234` milliseconds for audio (mp3s) where `mpck` and `ffprobe` disagree.

This PR takes a minimal-fix approach, and fires off a 2nd `Tasks::FixMediaTask` job when we detect a discrepancy > 500ms.  Which avoids running _everything_ through ffmpeg (slow), and storing basically duplicate copies of every original file.