### PR TITLE
Uncached feeds

### DIFF
--- a/app/models/apple/config.rb
+++ b/app/models/apple/config.rb
@@ -57,6 +57,7 @@ module Apple
         audio_format: DEFAULT_AUDIO_FORMAT,
         include_zones: ["billboard", "sonic_id"],
         tokens: [FeedToken.new(label: DEFAULT_TITLE)],
+        uncached: true,
         podcast: podcast
       )
     end

--- a/app/representers/api/auth/feed_representer.rb
+++ b/app/representers/api/auth/feed_representer.rb
@@ -2,6 +2,7 @@ class Api::Auth::FeedRepresenter < Api::BaseRepresenter
   property :id, writable: false
   property :created_at, writable: false
   property :updated_at, writable: false
+  property :uncached, writable: false
 
   property :slug
   property :file_name

--- a/db/migrate/20240215160548_add_uncached_to_feed.rb
+++ b/db/migrate/20240215160548_add_uncached_to_feed.rb
@@ -1,0 +1,8 @@
+class AddUncachedToFeed < ActiveRecord::Migration[7.0]
+  def change
+    add_column :feeds, :uncached, :boolean, default: false
+
+    # make all apple delegated delivery feeds uncached
+    Feed.where(id: Apple::Config.pluck(:private_feed_id)).update_all(uncached: true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_06_213452) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_15_160548) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -230,6 +230,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_213452) do
     t.boolean "include_donation_url", default: true
     t.text "exclude_tags"
     t.datetime "deleted_at", precision: nil
+    t.boolean "uncached", default: false
     t.index ["podcast_id", "slug"], name: "index_feeds_on_podcast_id_and_slug", unique: true, where: "(slug IS NOT NULL)"
     t.index ["podcast_id"], name: "index_feeds_on_podcast_id"
     t.index ["podcast_id"], name: "index_feeds_on_podcast_id_default", unique: true, where: "(slug IS NULL)"


### PR DESCRIPTION
For #833.

Adds a boolean indicator (only settable from the Rails console right now) to indicate that Dovetail Router should _not_ cache episode json for the feed.  This ensures requests through the Feed are always fresh, not read-behind cached.

Will need to update DTR to interpret this flag, after deploy.