### PR TITLE
Fix trix editor error messages

### DIFF
--- a/app/assets/stylesheets/shared/trix-custom.scss
+++ b/app/assets/stylesheets/shared/trix-custom.scss
@@ -38,3 +38,8 @@ trix-editor.trix-content[contenteditable="false"] {
   min-height: calc(3.5em + 2px);
   height: auto;
 }
+
+// hide the hidden field invalid messages
+.form-floating > .trix-hidden-field + .invalid-feedback {
+  display: none;
+}

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -38,7 +38,7 @@ class Episode < ApplicationRecord
 
   validates :podcast_id, :guid, presence: true
   validates :title, presence: true
-  validates :description, bytesize: {maximum: 4000}, if: :strict_validations
+  validates :description, bytesize: {maximum: 4000}, if: -> { strict_validations && description_changed? }
   validates :url, http_url: true
   validates :original_guid, presence: true, uniqueness: {scope: :podcast_id}, allow_nil: true
   alias_error_messages :item_guid, :original_guid

--- a/config/initializers/bootstrap_field_errors.rb
+++ b/config/initializers/bootstrap_field_errors.rb
@@ -4,7 +4,7 @@
 # wrapping them in a div that breaks bootstrap layouts
 ActionView::Base.field_error_proc = proc do |html_tag, instance|
   feedback = ""
-  if html_tag.match(/^<(input|textarea|select)/) && instance.error_message.present?
+  if html_tag.match(/^<(input|textarea|select|trix-editor)/) && instance.error_message.present?
     msg = instance.error_message.join(", ").capitalize
     feedback = "<div class=\"invalid-feedback\">#{msg}</div>"
   end
@@ -12,7 +12,7 @@ ActionView::Base.field_error_proc = proc do |html_tag, instance|
   if html_tag.match?(/class="(.*?)"/)
     (html_tag.sub(/class="(.*?)"/, 'class="\1 is-invalid"') + feedback).html_safe
   else
-    (html_tag.sub(/(\/>|>)/, 'class="is-invalid" \1') + feedback).html_safe
+    (html_tag.sub(/^(<[^ ]+) /, '\1 class="is-invalid" ') + feedback).html_safe
   end
 end
 

--- a/lib/trix_editor.rb
+++ b/lib/trix_editor.rb
@@ -26,7 +26,7 @@ module TrixEditorHelper
     }.merge(options)
 
     editor_tag = content_tag("trix-editor", "", attributes)
-    input_tag = hidden_field_tag(name, value, options.merge(id: attributes[:input]))
+    input_tag = hidden_field_tag(name, value, options.merge(id: attributes[:input], class: "trix-hidden-field"))
 
     input_tag + editor_tag + toolbar_tag
   end


### PR DESCRIPTION
Fix a couple issues with the trix editor and bootstrap-field-errors:

- [x] Fix regex so it doesn't botch adding the `is-invalid` class to the tag
- [x] Add invalid message below trix editor
- [x] Hide invalid message on the hidden field trix renders

![image](https://github.com/PRX/feeder.prx.org/assets/1410587/8b865a96-7467-475a-9199-4c379bbc9a97)
