### PR TITLE
Fix unarchived episodes published

### DIFF
--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -114,14 +114,12 @@ module Apple
       # These episodes are no longer in the private feed.
       poll_episodes!(episodes_to_archive)
       archive!(episodes_to_archive)
-      show.reload
 
       # Un-archive episodes that are re-published.
       # These episodes are in the private feed.
       # Unarchived episodes are converted to "DRAFTING" state.
       poll_episodes!(episodes_to_unarchive)
       unarchive!(episodes_to_unarchive)
-      show.reload
 
       # Calculate the episodes_to_sync based on the current state of the private feed
       deliver_and_publish!(episodes_to_sync)

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -237,6 +237,57 @@ describe Apple::Publisher do
           assert_equal [], apple_publisher.episodes_to_unarchive.map(&:feeder_id)
         end
       end
+
+      describe "archived episodes with media already delivered to apple" do
+        let(:apple_episode_api_response) {
+          build(:apple_episode_api_response,
+            apple_hosted_audio_state: Apple::Episode::AUDIO_ASSET_SUCCESS,
+            publishing_state: "ARCHIVED",
+            apple_episode_id: "123")
+        }
+
+        let(:apple_episode) { build(:uploaded_apple_episode, show: apple_publisher.show, feeder_episode: episode, api: apple_api) }
+
+        it "includes the unarchived episode in the episodes to sync" do
+          assert apple_episode.audio_asset_state_success?
+          assert apple_episode.archived?
+          assert apple_episode.has_delivery?
+
+          assert_equal [apple_episode.feeder_id], apple_publisher.episodes_to_unarchive.map(&:feeder_id)
+          # we can't sync archived episodes
+          assert_equal [], apple_publisher.episodes_to_sync.map(&:feeder_id)
+
+          unarchiver = ->(eps) do
+            eps.map do |ep|
+              sl = ep.apple_sync_log
+              attrs = sl.api_response
+              attrs["api_response"]["val"]["data"]["attributes"]["publishingState"] = "DRAFTING"
+              sl.update!(api_response: attrs)
+              sl
+            end
+          end
+
+          # assert that this includes our unarchived episode
+          deliver_and_publish = ->(eps) do
+            assert_equal [apple_episode.feeder_id], eps.map(&:feeder_id)
+            true
+          end
+
+          # eliminate calls to the apple api
+          apple_publisher.show.stub(:sync!, []) do
+            apple_publisher.stub(:poll_episodes!, []) do
+              # 1) episodes are unarchived
+              apple_publisher.stub(:unarchive!, unarchiver) do
+                # 2) then the unarchived episodes are passed in ready to have
+                # media uploaded and episode published)
+                apple_publisher.stub(:deliver_and_publish!, deliver_and_publish) do
+                  apple_publisher.publish!
+                end
+              end
+            end
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Fixes the case where a fully delivered episode is unpublished and then republished but left in a remote `DRAFTING` state. In this case the default `episodes_to_sync` params were being calculated prior to the unarchiving of an episode. Since `ARCHIVED` episodes are not published, the main delivery routine was skipping these unarchived episodes.