### PR TITLE
Nil out episode contents

### DIFF
--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -140,6 +140,7 @@ class EpisodesController < ApplicationController
       :clean_title,
       :subtitle,
       :summary,
+      :content,
       :description,
       :production_notes,
       :explicit_option,

--- a/app/views/episodes/_form_main.html.erb
+++ b/app/views/episodes/_form_main.html.erb
@@ -31,6 +31,7 @@
     <div class="card-body">
       <div class="form-floating">
         <%= form.hidden_field :summary, value: nil %>
+        <%= form.hidden_field :content, value: nil %>
         <%= form.trix_editor :description %>
       </div>
     </div>


### PR DESCRIPTION
Similar to #956.

Currently episodes coming from CMS Stories will have their [content attribute set](https://github.com/PRX/feeder.prx.org/blob/main/app/models/episode_story_handler.rb#L64) to the same as the description.  This is then rendered into the feed as `<content:encoded>`.

But when a show moves to the Feeder UI, the `ep.content` field gets stuck into a stale/old state.  This PR just nils out the field, so the `<content:encoded>` tag disappears.  Which shouldn't be a problem - it's only present on full episodes, and basically always redundant with `<description>`.