### PR TITLE
Apple::Config only belongs to the private feed

### DIFF
--- a/app/models/apple/config.rb
+++ b/app/models/apple/config.rb
@@ -55,12 +55,7 @@ module Apple
         raise "Stopping build_apple_config" if $stdin.gets.chomp.downcase != "y"
       end
 
-      Apple::Config.new(
-        podcast: podcast,
-        public_feed: podcast.default_feed,
-        private_feed: find_or_build_private_feed(podcast),
-        key: key
-      )
+      Apple::Config.new(feed: find_or_build_private_feed(podcast), key: key)
     end
 
     def self.mark_as_delivered!(apple_publisher)

--- a/app/models/apple/config.rb
+++ b/app/models/apple/config.rb
@@ -104,9 +104,7 @@ module Apple
     end
 
     def publish_to_apple?
-      return false unless key&.valid?
-
-      public_feed.publish_to_apple?
+      !!key&.valid? && publish_enabled?
     end
 
     def build_publisher

--- a/app/models/apple/config.rb
+++ b/app/models/apple/config.rb
@@ -6,32 +6,23 @@ module Apple
     DEFAULT_TITLE = "Apple Delegated Delivery Subscriptions"
     DEFAULT_AUDIO_FORMAT = {"f" => "flac", "b" => 16, "c" => 2, "s" => 44100}.freeze
 
-    belongs_to :podcast, class_name: "Podcast"
-    belongs_to :public_feed, class_name: "Feed"
-    belongs_to :private_feed, class_name: "Feed"
-    belongs_to :key, class_name: "Apple::Key", optional: true
+    belongs_to :feed
+    belongs_to :key, class_name: "Apple::Key", optional: true, validate: true, autosave: true
 
-    delegate :title, to: :podcast, prefix: "podcast"
+    validate :podcast_has_one_apple_config
+    validate :not_default_feed
 
+    # backwards-compatible "key" getters
     delegate :provider_id, to: :key
     delegate :key_id, to: :key
     delegate :key_pem, to: :key
     delegate :key_pem_b64, to: :key
 
-    validates_presence_of :podcast
-    validates_presence_of :public_feed
-    validates_presence_of :private_feed
-
-    validates_associated :public_feed
-    validates_associated :private_feed
-
-    validates :podcast, uniqueness: true, allow_nil: false
-
-    validates :public_feed, uniqueness: {scope: :private_feed,
-                                         message: "can only have one config per public and private feed"}
-    validates :public_feed, exclusion: {in: ->(apple_credential) { [apple_credential.private_feed] }}
-
-    validate :feed_podcasts_match
+    # backwards-compatible associations
+    delegate :podcast, to: :feed, allow_nil: true
+    delegate :id, :title, to: :podcast, prefix: true, allow_nil: true
+    delegate :public_feed, to: :podcast, allow_nil: true
+    alias_method :private_feed, :feed
 
     def self.find_or_build_private_feed(podcast)
       if (existing = podcast.feeds.find_by(slug: DEFAULT_FEED_SLUG, title: DEFAULT_TITLE))
@@ -99,11 +90,16 @@ module Apple
       mark_as_delivered!(pub)
     end
 
-    def feed_podcasts_match
-      return unless public_feed.present? && private_feed.present?
+    def not_default_feed
+      if feed&.default?
+        errors.add(:feed, "cannot use default feed")
+      end
+    end
 
-      if (public_feed.podcast_id != podcast_id) || (private_feed.podcast_id != podcast_id)
-        errors.add(:public_feed, "must belong to the same podcast as the private feed")
+    def podcast_has_one_apple_config
+      all_feeds = Feed.where(podcast_id: feed.podcast_id).pluck(:id)
+      if Apple::Config.where(feed_id: all_feeds).where.not(id: id).any?
+        errors.add(:feed, "podcast already has an apple config")
       end
     end
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -25,13 +25,7 @@ class Feed < ApplicationRecord
   alias_attribute :tokens, :feed_tokens
   accepts_nested_attributes_for :feed_tokens, allow_destroy: true, reject_if: ->(ft) { ft[:token].blank? }
 
-  has_one :apple_config,
-    autosave: true,
-    class_name: "::Apple::Config",
-    dependent: :destroy,
-    foreign_key: :public_feed_id,
-    inverse_of: :public_feed,
-    validate: true
+  has_one :apple_config, class_name: "::Apple::Config", dependent: :destroy, autosave: true, validate: true
 
   has_many :feed_images, -> { order("created_at DESC") }, autosave: true, dependent: :destroy, inverse_of: :feed
   has_many :itunes_images, -> { order("created_at DESC") }, autosave: true, dependent: :destroy, inverse_of: :feed
@@ -173,9 +167,7 @@ class Feed < ApplicationRecord
   end
 
   def publish_to_apple?
-    apple_config.present? &&
-      apple_config.public_feed == self &&
-      apple_config.publish_enabled?
+    !!apple_config&.publish_to_apple?
   end
 
   def include_tags=(tags)

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -20,6 +20,7 @@ class Podcast < ApplicationRecord
   serialize :restrictions, JSON
 
   has_one :default_feed, -> { default }, class_name: "Feed", validate: true, autosave: true, inverse_of: :podcast
+  alias_method :public_feed, :default_feed
   has_one :apple_config, class_name: "::Apple::Config", validate: true, autosave: true, inverse_of: :podcast
 
   has_many :episodes, -> { order("published_at desc") }, dependent: :destroy

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -67,6 +67,19 @@ class Podcast < ApplicationRecord
     super || build_default_feed(podcast: self, private: false)
   end
 
+  def apple_config
+    if defined?(@apple_config)
+      @apple_config
+    else
+      @apple_config = Apple::Config.where(feed_id: feeds.pluck(:id)).first
+    end
+  end
+
+  def reload(options = nil)
+    remove_instance_variable(:@apple_config) if defined?(@apple_config)
+    super
+  end
+
   def explicit=(value)
     super Podcast::EXPLICIT_ALIASES.fetch(value, value)
   end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -21,7 +21,6 @@ class Podcast < ApplicationRecord
 
   has_one :default_feed, -> { default }, class_name: "Feed", validate: true, autosave: true, inverse_of: :podcast
   alias_method :public_feed, :default_feed
-  has_one :apple_config, class_name: "::Apple::Config", validate: true, autosave: true, inverse_of: :podcast
 
   has_many :episodes, -> { order("published_at desc") }, dependent: :destroy
   has_many :feeds, dependent: :destroy

--- a/db/migrate/20240410212602_simplify_apple_config_foreign_keys.rb
+++ b/db/migrate/20240410212602_simplify_apple_config_foreign_keys.rb
@@ -1,0 +1,32 @@
+class SimplifyAppleConfigForeignKeys < ActiveRecord::Migration[7.0]
+  def up
+    Apple::Config.find_each do |ac|
+      unless ac[:public_feed_id] == Podcast.find(ac[:podcast_id]).default_feed.id
+        raise "Apple::Config[#{ac.id} is not using the podcast.default_feed"
+      end
+    end
+
+    remove_column :apple_configs, :podcast_id
+    remove_column :apple_configs, :public_feed_id
+    rename_column :apple_configs, :private_feed_id, :feed_id
+  end
+
+  def down
+    add_column :apple_configs, :podcast_id, :integer
+    add_index :apple_configs, [:podcast_id], unique: true
+
+    add_reference :apple_configs, :public_feed, index: true
+    add_foreign_key :apple_configs, :feeds, column: :public_feed_id
+
+    rename_column :apple_configs, :feed_id, :private_feed_id
+
+    Apple::Config.find_each do |ac|
+      f = Feed.find(ac.private_feed_id)
+      ac.podcast_id = f.podcast.id
+      ac.public_feed_id = f.podcast.default_feed.id
+      ac.save!(validate: false)
+    end
+
+    change_column_null :apple_configs, :public_feed_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,24 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_06_213452) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_10_212602) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
 
   create_table "apple_configs", force: :cascade do |t|
-    t.bigint "public_feed_id", null: false
-    t.bigint "private_feed_id", null: false
+    t.bigint "feed_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "publish_enabled", default: false, null: false
     t.boolean "sync_blocks_rss", default: false, null: false
     t.bigint "key_id"
-    t.integer "podcast_id"
+    t.index ["feed_id"], name: "index_apple_configs_on_feed_id"
     t.index ["key_id"], name: "index_apple_configs_on_key_id"
-    t.index ["podcast_id"], name: "index_apple_configs_on_podcast_id", unique: true
-    t.index ["private_feed_id"], name: "index_apple_configs_on_private_feed_id"
-    t.index ["public_feed_id"], name: "index_apple_configs_on_public_feed_id"
   end
 
   create_table "apple_episode_delivery_statuses", force: :cascade do |t|
@@ -451,8 +447,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_06_213452) do
     t.index ["status"], name: "index_tasks_on_status"
   end
 
-  add_foreign_key "apple_configs", "feeds", column: "private_feed_id"
-  add_foreign_key "apple_configs", "feeds", column: "public_feed_id"
+  add_foreign_key "apple_configs", "feeds"
   add_foreign_key "apple_episode_delivery_statuses", "episodes"
   add_foreign_key "episode_imports", "podcast_imports"
   add_foreign_key "feed_images", "feeds"

--- a/test/factories/apple_config_factory.rb
+++ b/test/factories/apple_config_factory.rb
@@ -3,12 +3,6 @@ FactoryBot.define do
     publish_enabled { true }
     sync_blocks_rss { true }
     key { build(:apple_key) }
-    podcast
-
-    # set up the private and public feeds
-    before(:create) do |apple_config, evaluator|
-      apple_config.public_feed ||= create(:feed, podcast: evaluator.podcast)
-      apple_config.private_feed ||= create(:feed, podcast: evaluator.podcast)
-    end
+    feed
   end
 end

--- a/test/jobs/publish_apple_job_test.rb
+++ b/test/jobs/publish_apple_job_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 describe PublishAppleJob do
   let(:episode) { create(:episode, prx_uri: "/api/v1/stories/87683") }
   let(:podcast) { episode.podcast }
-  let(:feed) { create(:feed, podcast: podcast, slug: "adfree") }
+  let(:feed) { podcast.default_feed }
   let(:private_feed) { create(:private_feed, podcast: podcast) }
-  let(:apple_config) { create(:apple_config, podcast: podcast, public_feed: feed, private_feed: private_feed) }
+  let(:apple_config) { create(:apple_config, feed: private_feed) }
 
   describe "publishing to apple" do
     it "does not publish to apple unless publish_enabled?" do

--- a/test/models/apple/config_test.rb
+++ b/test/models/apple/config_test.rb
@@ -2,66 +2,41 @@ require "test_helper"
 
 describe Apple::Config do
   describe "#valid?" do
-    it "requires both a public and private feed" do
-      pub_f = create(:feed)
-      priv_f = create(:feed)
-
-      c1 = build(:apple_config, public_feed: pub_f, private_feed: priv_f)
-      assert c1.valid?
-
-      c2 = build(:apple_config, public_feed: nil, private_feed: priv_f)
-      refute c2.valid?
-
-      c3 = build(:apple_config, public_feed: pub_f, private_feed: nil)
-      refute c3.valid?
-    end
-
-    it "is unique to a public and private feed" do
-      podcast1 = create(:podcast)
-      podcast2 = create(:podcast)
-      f1 = create(:feed, podcast: podcast1)
-      f2 = create(:feed, podcast: podcast1)
-      f3 = create(:feed, podcast: podcast2)
-      f4 = create(:feed, podcast: podcast2)
-
-      c1 = create(:apple_config, podcast: podcast1, public_feed: f1, private_feed: f2)
-      assert c1.valid?
-
-      c2 = build(:apple_config, podcast: podcast1, public_feed: f1, private_feed: f2)
-      refute c2.valid?
-
-      c3 = build(:apple_config, podcast: podcast1, public_feed: f1, private_feed: f3)
-      refute c3.valid?
-
-      c4 = build(:apple_config, podcast: podcast2, public_feed: f4, private_feed: f2)
-      refute c4.valid?
-
-      c5 = build(:apple_config, podcast: podcast1, public_feed: f1, private_feed: f1)
-      refute c5.valid?
-
-      c6 = build(:apple_config, podcast: podcast2, public_feed: f3, private_feed: f4)
-      assert c6.valid?
-
-      c7 = build(:apple_config, podcast: podcast2, public_feed: f4, private_feed: f3)
-      assert c7.valid?
-
-      c7 = build(:apple_config, podcast: podcast2, public_feed: f4, private_feed: f4)
-      refute c7.valid?
-    end
-
     it "is unique to a podcast" do
       podcast = create(:podcast)
       f1 = create(:feed, podcast: podcast)
-      f2 = create(:feed, podcast: podcast)
-      f3 = create(:feed, podcast: podcast)
-      f4 = create(:feed, podcast: podcast)
-
-      c1 = create(:apple_config, podcast: podcast, public_feed: f1, private_feed: f2)
+      c1 = create(:apple_config, feed: f1)
       assert c1.valid?
 
-      c2 = build(:apple_config, podcast: podcast, public_feed: f3, private_feed: f4)
+      f2 = create(:feed, podcast: podcast)
+      c2 = build(:apple_config, feed: f2)
       refute c2.valid?
-      assert_equal ["has already been taken"], c2.errors[:podcast]
+      assert_equal ["podcast already has an apple config"], c2.errors[:feed]
+
+      # can't have 2 on same feed either
+      c3 = build(:apple_config, feed: f1)
+      refute c3.valid?
+      assert_equal ["podcast already has an apple config"], c2.errors[:feed]
     end
+
+    it "cannot be the default feed" do
+      podcast = create(:podcast)
+      c1 = build(:apple_config, feed: podcast.default_feed)
+      refute c1.valid?
+      assert_equal ["cannot use default feed"], c1.errors[:feed]
+    end
+  end
+
+  it "delegates associations" do
+    podcast = build_stubbed(:podcast)
+    public_feed = podcast.default_feed
+    private_feed = build_stubbed(:private_feed, podcast: podcast)
+    config = build_stubbed(:apple_config, feed: private_feed)
+
+    assert_equal podcast, config.podcast
+    assert_equal podcast.id, config.podcast_id
+    assert_equal podcast.title, config.podcast_title
+    assert_equal public_feed, config.public_feed
+    assert_equal private_feed, config.private_feed
   end
 end

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 describe Apple::Episode do
   let(:podcast) { create(:podcast) }
 
-  let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+  let(:public_feed) { podcast.default_feed }
   let(:private_feed) { create(:private_feed, podcast: podcast) }
 
   let(:apple_config) { build(:apple_config) }

--- a/test/models/apple/podcast_container_test.rb
+++ b/test/models/apple/podcast_container_test.rb
@@ -8,7 +8,7 @@ class Apple::PodcastContainerTest < ActiveSupport::TestCase
 
   let(:apple_config) { build(:apple_config) }
   let(:apple_api) { Apple::Api.from_apple_config(apple_config) }
-  let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+  let(:public_feed) { podcast.default_feed }
   let(:private_feed) { create(:private_feed, podcast: podcast) }
   let(:apple_show) { Apple::Show.new(api: apple_api, public_feed: public_feed, private_feed: private_feed) }
 

--- a/test/models/apple/podcast_delivery_file_test.rb
+++ b/test/models/apple/podcast_delivery_file_test.rb
@@ -71,7 +71,7 @@ class ApplePodcastDeliveryFileTest < ActiveSupport::TestCase
       }
       let(:podcast) { create(:podcast) }
 
-      let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+      let(:public_feed) { podcast.default_feed }
       let(:private_feed) { create(:feed, podcast: podcast, private: true, tokens: [FeedToken.new]) }
 
       let(:apple_config) { build(:apple_config) }

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 describe Apple::Publisher do
   let(:podcast) { create(:podcast) }
-  let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+  let(:public_feed) { podcast.default_feed }
   let(:private_feed) { create(:feed, podcast: podcast, private: true) }
   let(:apple_config) { build(:apple_config) }
   let(:apple_api) { Apple::Api.from_apple_config(apple_config) }
@@ -49,7 +49,7 @@ describe Apple::Publisher do
   describe "#filter_episodes_to_sync" do
     let(:podcast) { create(:podcast) }
 
-    let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+    let(:public_feed) { podcast.default_feed }
     let(:private_feed) { create(:private_feed, podcast: podcast) }
 
     let(:apple_config) { build(:apple_config) }
@@ -98,9 +98,9 @@ describe Apple::Publisher do
 
   describe "Archive and Unarchive flows" do
     let(:podcast) { create(:podcast) }
-    let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+    let(:public_feed) { podcast.default_feed }
     let(:private_feed) { create(:private_feed, podcast: podcast) }
-    let(:apple_config) { create(:apple_config, podcast: podcast, public_feed: public_feed, private_feed: private_feed) }
+    let(:apple_config) { create(:apple_config, feed: private_feed) }
     let(:episode) { create(:episode, podcast: podcast) }
     let(:apple_episode_api_response) { build(:apple_episode_api_response, apple_episode_id: "123") }
     let(:apple_publisher) { apple_config.build_publisher }

--- a/test/models/apple/show_test.rb
+++ b/test/models/apple/show_test.rb
@@ -5,9 +5,9 @@ require "test_helper"
 describe Apple::Show do
   let(:podcast) { create(:episode).podcast }
   let(:apple_api) { Apple::Api.from_apple_config(apple_config) }
-  let(:public_feed) { create(:feed, podcast: podcast, private: false) }
+  let(:public_feed) { podcast.default_feed }
   let(:private_feed) { create(:private_feed, podcast: podcast) }
-  let(:apple_config) { build(:apple_config, podcast: podcast, public_feed: public_feed, private_feed: private_feed) }
+  let(:apple_config) { build(:apple_config, feed: private_feed) }
   let(:apple_show) { Apple::Show.connect_existing("123", apple_config) }
 
   before do
@@ -158,7 +158,7 @@ describe Apple::Show do
   end
 
   describe ".connect_existing" do
-    let(:apple_config) { create(:apple_config, podcast: podcast, public_feed: public_feed, private_feed: private_feed) }
+    let(:apple_config) { create(:apple_config, feed: private_feed) }
 
     it "should take in the apple show id an apple credentials object" do
       apple_config.save!
@@ -256,7 +256,7 @@ describe Apple::Show do
 
     it "returns an authed url if private" do
       assert_equal apple_show.feed_published_url,
-        "https://p.prxu.org/#{public_feed.podcast.path}/#{public_feed.slug}/feed-rss.xml?auth=" + public_feed.tokens.first.token
+        "https://p.prxu.org/#{public_feed.podcast.path}/feed-rss.xml?auth=" + public_feed.tokens.first.token
     end
 
     it "raises an error when there is no token" do

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -326,28 +326,27 @@ describe Feed do
 
   describe "#apple_configs" do
     it "has apple credentials" do
-      creds = create(:apple_config, podcast: podcast, public_feed: feed1, private_feed: feed2)
-      assert_equal feed1.apple_config, creds
-      assert_equal feed1.apple_config.private_feed, feed2
+      creds = create(:apple_config, feed: feed2)
+      assert_equal creds, feed2.apple_config
+      assert_equal feed1, feed2.apple_config.public_feed
     end
   end
 
   describe "#publish_to_apple?" do
     it "returns true if the feed has apple credentials" do
-      create(:apple_config, podcast: podcast, public_feed: feed1, private_feed: feed2, publish_enabled: true)
-      assert feed1.publish_to_apple?
-      refute feed2.publish_to_apple?
+      create(:apple_config, feed: feed2, publish_enabled: true)
+      refute feed1.publish_to_apple?
+      assert feed2.publish_to_apple?
     end
 
     it "returns false if the creds are not marked publish_enabled?" do
-      create(:apple_config, podcast: podcast, public_feed: feed1, private_feed: feed2, publish_enabled: false)
-      refute feed1.publish_to_apple?
+      create(:apple_config, feed: feed2, publish_enabled: false)
+      refute feed2.publish_to_apple?
     end
 
     it "returns false if the feed does not have apple credentials" do
-      feed1.podcast.apple_config&.destroy
-      refute feed1.podcast.apple_config
-      refute feed1.publish_to_apple?
+      refute feed2.apple_config
+      refute feed2.publish_to_apple?
     end
   end
 end

--- a/test/models/imports/podcast_rss_import_test.rb
+++ b/test/models/imports/podcast_rss_import_test.rb
@@ -149,9 +149,9 @@ describe PodcastRssImport do
 
     it "looks for an owner" do
       owner = OpenStruct.new(name: "n", email: "e")
-      importer.owner(nil).must_equal({})
-      importer.owner([]).must_equal({})
-      importer.owner([owner]).must_equal({"name" => "n", "email" => "e"})
+      _(importer.owner(nil)).must_equal({})
+      _(importer.owner([])).must_equal({})
+      _(importer.owner([owner])).must_equal({"name" => "n", "email" => "e"})
     end
 
     it "can make a good guess for an enclosure prefix" do


### PR DESCRIPTION
Our Apple::Config schema is fighting a bit with the formbuilder/UI.  Since it shows up on the _private_ Feed form UI.  But only the `public_feed has_one :apple_config`.  And there are 3 foreign keys to populate/validate.

This simplifies down to a single assocation: `private_feed has_one :apple_config`.  And then I alias/delegate everything else when possible, to keep interfaces the same.

Should definitely QA this one carefully.  Because it makes me nervous!