### PR TITLE
Add exclude_tags ui to feeds

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -127,6 +127,7 @@ class FeedsController < ApplicationController
       :paid,
       :sonic_id,
       include_tags: [],
+      exclude_tags: [],
       itunes_category: [],
       itunes_subcategory: [],
       feed_tokens_attributes: %i[id label token _destroy],

--- a/app/views/feeds/_form.html.erb
+++ b/app/views/feeds/_form.html.erb
@@ -12,9 +12,9 @@
           <%= render "form_auth", podcast: podcast, feed: feed, form: form %>
         <% end %>
         <%= render "form_audio_format", podcast: podcast, feed: feed, form: form %>
+        <%= render "form_tags", podcast: podcast, feed: feed, form: form %>
         <% if feed.custom? %>
           <%= render "form_ad_zones", podcast: podcast, feed: feed, form: form %>
-          <%= render "form_tags", podcast: podcast, feed: feed, form: form %>
           <%= render "form_overrides", podcast: podcast, feed: feed, form: form %>
           <%= render "form_itunes_image", podcast: podcast, feed: feed, form: form %>
           <%= render "form_feed_image", podcast: podcast, feed: feed, form: form %>

--- a/app/views/feeds/_form_tags.html.erb
+++ b/app/views/feeds/_form_tags.html.erb
@@ -6,9 +6,13 @@
     </div>
 
     <div class="card-body">
-      <div class="form-floating input-group">
+      <div class="form-floating input-group mb-4">
         <%= form.tag_select :include_tags, feed.include_tags || [], {}, data: {allow_new: true, allow_clear: true} %>
         <%= form.label :include_tags %>
+      </div>
+      <div class="form-floating input-group">
+        <%= form.tag_select :exclude_tags, feed.exclude_tags || [], {}, data: {allow_new: true, allow_clear: true} %>
+        <%= form.label :exclude_tags %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
closes: #996 

- Adds Exclude Categories field to form_tags card on all feeds

To review:

- [ ] Add a new keyword to an episode or two
- [ ] Exclude that keyword from the Feed
- [ ] Ensure the episode(s) is(are) excluded from the feed link