### PR TITLE
Warn producers when new draft episodes exist

### DIFF
--- a/app/views/episodes/_existing_drafts.html.erb
+++ b/app/views/episodes/_existing_drafts.html.erb
@@ -1,0 +1,19 @@
+<div class="modal hide" id="existing-drafts" tabindex="-1" aria-labelledby="existing-drafts-title" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="fw-bold modal-title" id="existing-drafts-title"><%= t(".title") %></h5>
+      </div>
+      <div class="modal-body">
+        <p><%= t(".message").html_safe %></p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" data-bs-dismiss="modal"><%= t(".dismiss") %></button>
+        <%= link_to t(".episodes"), podcast_episodes_path(podcast), class: "btn btn-success" %>
+      </div>
+    </div>
+  </div>
+</div>
+
+<%# click hidden button to immediately show modal %>
+<button type="button" class="d-none" data-bs-toggle="modal" data-bs-target="#existing-drafts" data-controller="click" data-click-immediate-value="true"></button>

--- a/app/views/episodes/new.html.erb
+++ b/app/views/episodes/new.html.erb
@@ -6,4 +6,6 @@
 
 <% if action_name == "new" && !@podcast.complete && @podcast.episodes.after(Time.now).none? %>
   <%= render "missing_drafts", podcast: @podcast %>
+<% elsif action_name == "new" && @podcast.episodes.after(Time.now).before(3.days.from_now).any? %>
+  <%= render "existing_drafts", podcast: @podcast %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -523,7 +523,7 @@ en:
       episodes: Back to Episodes
       dismiss: Proceed with a new draft
       message: Please consider using the draft that already exists on this published date as there may be an ad targeted specifically to the scheduled episode draft.
-      title: Consider using the existing episode draft for this date
+      title: An episode draft for this date already exists
     form:
       confirm: Discard unsaved changes?
     form_distribution:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -519,6 +519,11 @@ en:
         asc: A-Z
         calendar: Calendar
         recent: Recent Activity
+    existing_drafts:
+      episodes: Back to Episodes
+      dismiss: Proceed with a new draft
+      message: Please consider using the draft that already exists on this published date as there may be an ad targeted specifically to the scheduled episode draft.
+      title: Consider using the existing episode draft for this date
     form:
       confirm: Discard unsaved changes?
     form_distribution:


### PR DESCRIPTION
Closes #992 

Adds a modal that warns producers there's an existing draft and they should use that.

- [ ] Create an episode draft for today or tomorrow
- [ ] Create a new episode
- [ ] Confirm you see this modal

![Screenshot 2024-04-17 at 11 51 14 AM](https://github.com/PRX/feeder.prx.org/assets/369739/12380057-06b9-4b7d-bad7-6f34136aa977)

