### PR TITLE
Non-mp3s in default feed

### DIFF
--- a/app/javascript/controllers/disable_controller.js
+++ b/app/javascript/controllers/disable_controller.js
@@ -17,14 +17,14 @@ export default class extends Controller {
     if (disable) {
       this.uploadCount++
     } else {
-      this.uploadCount--
+      this.uploadCount = Math.max(0, this.uploadCount - 1)
     }
     this.submitButtons().forEach((el) => {
       if (this.uploadCount > 0) {
         el.disabled = true
         el.dataset.disableOriginal = el.dataset.disableOriginal || el.value
         el.value = el.dataset.uploadWith || el.value
-      } else {
+      } else if (el.disabled) {
         el.disabled = false
         el.value = el.dataset.disableOriginal
       }

--- a/app/views/episode_media/media/_new.html.erb
+++ b/app/views/episode_media/media/_new.html.erb
@@ -15,6 +15,7 @@
       <%= form.file_field :media_file, class: cls, accept: "video/*", name: nil, data: data %>
     <% else %>
       <%= form.file_field :media_file, class: cls, accept: "audio/*", name: nil, data: data %>
+      <%= render "episode_media/media/non_mp3_warning", episode: episode %>
     <% end %>
 
     <%# fake display field; real text area is opacity-0 on top of it %>

--- a/app/views/episode_media/media/_non_mp3_warning.html.erb
+++ b/app/views/episode_media/media/_non_mp3_warning.html.erb
@@ -1,0 +1,18 @@
+<% if episode.podcast.default_feed.audio_format.blank? %>
+  <div class="modal" tabindex="-1" data-upload-target="nonMp3Warning">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title"><%= t(".title") %></h5>
+        </div>
+        <div class="modal-body" data-turbo=false>
+          <%= t(".body_html", href: podcast_feeds_path(episode.podcast_id)) %>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-light" data-action="upload#modalCancel"><%= t(".cancel") %></button>
+          <button type="button" class="btn btn-danger" data-action="upload#modalContinue"><%= t(".continue") %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -633,6 +633,11 @@ en:
         stereo: Stereo
       new:
         hint: Upload a file or drag it here
+      non_mp3_warning:
+        body_html: Looks like you're uploading a non-MP3 file - this can cause problems for Spotify and other apps.<br/><br/>You can either cancel and upload an MP3, or add an MP3 format to your <a href="%{href}" target="_blank">Default Feed</a>.
+        cancel: Cancel
+        continue: Continue
+        title: Woh there!
       processing:
         hint: Processing
     segmenter:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -634,10 +634,10 @@ en:
       new:
         hint: Upload a file or drag it here
       non_mp3_warning:
-        body_html: Looks like you're uploading a non-MP3 file - this can cause problems for Spotify and other apps.<br/><br/>You can either cancel and upload an MP3, or add an MP3 format to your <a href="%{href}" target="_blank">Default Feed</a>.
-        cancel: Cancel
-        continue: Continue
-        title: Woh there!
+        body_html: It appears you're uploading a file that isn't in MP3 format. We recommend configuring the Audio Format for your <a href="%{href}" target="_blank">Default Feed</a> to MP3 to ensure your episode is accessible on all platforms.<br/><br/>Once you've set a default format, your file will be automatically converted to the chosen file type and quality.
+        cancel: Cancel Upload
+        continue: Continue Upload
+        title: MP3 Not Provided
       processing:
         hint: Processing
     segmenter:


### PR DESCRIPTION
Fixes #1002.

When you upload a non-mp3 (really, a non-`audio/mpeg` format) file and have no `default_feed.audio_format`... we warn you.  Exact wording TBD.

Pretty easy to game the system by changing your `.wav` file extension.  But I think this is enough to prevent accidentally publishing WAVs into the public RSS.

![image](https://github.com/PRX/feeder.prx.org/assets/1410587/05e83838-590e-4589-a277-ea4d347737bb)
