### PR TITLE
Optimistic locking

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  rescue_from ActiveRecord::StaleObjectError, with: :render_stale_edit
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   default_form_builder FeederFormBuilder
@@ -48,10 +47,6 @@ class ApplicationController < ActionController::Base
         render "errors/no_access", layout: "plain"
       end
     end
-  end
-
-  def render_stale_edit(exception)
-    render :edit, status: :conflict
   end
 
   def user_not_authorized(exception = nil)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  rescue_from ActiveRecord::StaleObjectError, with: :render_stale_edit
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   default_form_builder FeederFormBuilder
@@ -47,6 +48,10 @@ class ApplicationController < ActionController::Base
         render "errors/no_access", layout: "plain"
       end
     end
+  end
+
+  def render_stale_edit(exception)
+    render :edit, status: :conflict
   end
 
   def user_not_authorized(exception = nil)

--- a/app/controllers/episode_media_controller.rb
+++ b/app/controllers/episode_media_controller.rb
@@ -49,6 +49,8 @@ class EpisodeMediaController < ApplicationController
         format.html { render :show, status: :unprocessable_entity }
       end
     end
+  rescue ActiveRecord::StaleObjectError
+    render :show, status: :conflict
   end
 
   private
@@ -61,6 +63,7 @@ class EpisodeMediaController < ApplicationController
 
   def episode_params
     nilify params.fetch(:episode, {}).permit(
+      :lock_version,
       :medium,
       :ad_breaks,
       contents_attributes: %i[id position original_url file_size _destroy _retry],

--- a/app/controllers/episode_media_controller.rb
+++ b/app/controllers/episode_media_controller.rb
@@ -58,6 +58,7 @@ class EpisodeMediaController < ApplicationController
   def set_episode
     @episode = Episode.find_by_guid!(params[:episode_id])
     @episode.strict_validations = true
+    @episode.locking_enabled = true
     @podcast = @episode.podcast
   end
 

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -84,6 +84,8 @@ class EpisodesController < ApplicationController
         format.html { render :edit, status: :unprocessable_entity }
       end
     end
+  rescue ActiveRecord::StaleObjectError
+    render :edit, status: :conflict
   end
 
   # DELETE /episodes/1

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -110,6 +110,7 @@ class EpisodesController < ApplicationController
   def set_episode
     @episode = Episode.find_by_guid!(params[:id])
     @episode.strict_validations = true
+    @episode.locking_enabled = true
   end
 
   def set_podcast

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -136,6 +136,7 @@ class EpisodesController < ApplicationController
 
   def episode_params
     nilify(params.fetch(:episode, {}).permit(
+      :lock_version,
       :title,
       :clean_title,
       :subtitle,

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -59,6 +59,8 @@ class FeedsController < ApplicationController
         end
       end
     end
+  rescue ActiveRecord::StaleObjectError
+    render :show, status: :conflict
   end
 
   # DELETE /feeds/1
@@ -103,6 +105,7 @@ class FeedsController < ApplicationController
 
   def nilified_feed_params
     nilify params.fetch(:feed, {}).permit(
+      :lock_version,
       :file_name,
       :title,
       :subtitle,

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -96,6 +96,7 @@ class FeedsController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_feed
     @feed = Feed.find(params[:id])
+    @feed.locking_enabled = true
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/podcast_engagement_controller.rb
+++ b/app/controllers/podcast_engagement_controller.rb
@@ -26,6 +26,7 @@ class PodcastEngagementController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_podcast
     @podcast = Podcast.find(params[:podcast_id])
+    @podcast.locking_enabled = true
     authorize @podcast
   end
 

--- a/app/controllers/podcast_engagement_controller.rb
+++ b/app/controllers/podcast_engagement_controller.rb
@@ -17,6 +17,8 @@ class PodcastEngagementController < ApplicationController
         format.html { render :show, status: :unprocessable_entity }
       end
     end
+  rescue ActiveRecord::StaleObjectError
+    render :show, status: :conflict
   end
 
   private
@@ -32,6 +34,7 @@ class PodcastEngagementController < ApplicationController
   ### TODO include params for socmed and podcast apps
   def podcast_engagement_params
     nilify params.fetch(:podcast, {}).permit(
+      :lock_version,
       :donation_url,
       :payment_pointer
     )

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -100,6 +100,7 @@ class PodcastsController < ApplicationController
 
   def set_podcast
     @podcast = Podcast.find(params[:id])
+    @podcast.locking_enabled = true
   end
 
   def published_episodes(date_range)

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -76,6 +76,8 @@ class PodcastsController < ApplicationController
         format.html { render :edit, status: :unprocessable_entity }
       end
     end
+  rescue ActiveRecord::StaleObjectError
+    render :edit, status: :conflict
   end
 
   # DELETE /podcasts/1
@@ -107,6 +109,7 @@ class PodcastsController < ApplicationController
 
   def podcast_params
     nilify params.fetch(:podcast, {}).permit(
+      :lock_version,
       :title,
       :prx_account_uri,
       :link,

--- a/app/javascript/controllers/toggle_value_controller.js
+++ b/app/javascript/controllers/toggle_value_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["field"]
+  static values = { next: String }
+
+  toggle() {
+    const prev = this.fieldTarget.value
+    this.fieldTarget.value = this.nextValue
+    this.nextValue = prev
+  }
+}

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -12,6 +12,12 @@ class ApplicationRecord < ActiveRecord::Base
     @@error_message_aliases
   end
 
+  def locking_enabled?
+    !!(super && @locking_enabled)
+  end
+
+  attr_writer :locking_enabled
+
   def stale?
     try(:lock_version_changed?) || false
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,4 +11,8 @@ class ApplicationRecord < ActiveRecord::Base
   def error_message_aliases
     @@error_message_aliases
   end
+
+  def stale?
+    try(:lock_version_changed?) || false
+  end
 end

--- a/app/views/episode_media/_form.html.erb
+++ b/app/views/episode_media/_form.html.erb
@@ -35,4 +35,5 @@
 
   <% end %>
 
+  <%= render "layouts/stale_record_modal", form: form, discard_path: episode_media_path(episode) %>
 <% end %>

--- a/app/views/episode_media/_form_status.html.erb
+++ b/app/views/episode_media/_form_status.html.erb
@@ -2,6 +2,7 @@
   <div class="card-header-primary">
     <h2 class="card-title h5"><%= t(".title") %></h2>
   </div>
+  <%= render "layouts/stale_record_field", form: form %>
   <div class="card-footer d-flex align-items-center">
 
     <p class="status-text flex-grow-1"><strong><%= t(".updated_at_hint") %></strong> <br><%= l(episode.updated_at) %></p>

--- a/app/views/episodes/_form.html.erb
+++ b/app/views/episodes/_form.html.erb
@@ -23,5 +23,5 @@
 
   <%= render "confirm_destroy", episode: episode %>
 
-  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_episode_path(episode) %>
+  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_episode_path(episode) if episode.persisted? %>
 <% end %>

--- a/app/views/episodes/_form.html.erb
+++ b/app/views/episodes/_form.html.erb
@@ -21,5 +21,7 @@
     </div>
   </div>
 
+  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_episode_path(episode) %>
+
   <%= render "confirm_destroy", episode: episode %>
 <% end %>

--- a/app/views/episodes/_form.html.erb
+++ b/app/views/episodes/_form.html.erb
@@ -21,7 +21,7 @@
     </div>
   </div>
 
-  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_episode_path(episode) %>
-
   <%= render "confirm_destroy", episode: episode %>
+
+  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_episode_path(episode) %>
 <% end %>

--- a/app/views/episodes/_form_status.html.erb
+++ b/app/views/episodes/_form_status.html.erb
@@ -43,9 +43,9 @@
         </p>
       </div>
     <% end %>
-
-    <%= render "layouts/stale_record_field", form: form %>
   </div>
+
+  <%= render "layouts/stale_record_field", form: form %>
 
   <div class="card-footer d-flex align-items-center justify-content-between">
     <% if episode.persisted? %>

--- a/app/views/episodes/_form_status.html.erb
+++ b/app/views/episodes/_form_status.html.erb
@@ -43,6 +43,8 @@
         </p>
       </div>
     <% end %>
+
+    <%= render "layouts/stale_record_field", form: form %>
   </div>
 
   <div class="card-footer d-flex align-items-center justify-content-between">

--- a/app/views/feeds/_form.html.erb
+++ b/app/views/feeds/_form.html.erb
@@ -30,4 +30,6 @@
   </div>
 
   <%= render "confirm_destroy", podcast: podcast, feed: feed %>
+
+  <%= render "layouts/stale_record_modal", form: form, discard_path: podcast_feed_path(podcast, feed) %>
 <% end %>

--- a/app/views/feeds/_form.html.erb
+++ b/app/views/feeds/_form.html.erb
@@ -31,5 +31,5 @@
 
   <%= render "confirm_destroy", podcast: podcast, feed: feed %>
 
-  <%= render "layouts/stale_record_modal", form: form, discard_path: podcast_feed_path(podcast, feed) %>
+  <%= render "layouts/stale_record_modal", form: form, discard_path: podcast_feed_path(podcast, feed) if feed.persisted? %>
 <% end %>

--- a/app/views/feeds/_form_status.html.erb
+++ b/app/views/feeds/_form_status.html.erb
@@ -2,6 +2,9 @@
   <div class="card-header-primary">
     <h2 class="card-title h5"><%= t(".title") %></h2>
   </div>
+
+  <%= render "layouts/stale_record_field", form: form %>
+
   <div class="card-footer d-flex align-items-center">
     <% if feed.persisted? %>
       <p class="status-text flex-grow-1"><strong><%= t(".updated_at_hint") %></strong> <br><%= local_time_ago(feed.updated_at) %></p>

--- a/app/views/layouts/_stale_record_field.html.erb
+++ b/app/views/layouts/_stale_record_field.html.erb
@@ -1,11 +1,13 @@
-<% if form.object.lock_version_changed? %>
-  <div class="col-12 mt-4 mb-2" data-controller="toggle-value" data-toggle-value-next-value="<%= form.object.lock_version_was %>">
+<% if form.object.stale? %>
+  <div class="card-footer" data-controller="toggle-value" data-toggle-value-next-value="<%= form.object.lock_version_was %>">
     <div class="form-check">
       <%= form.hidden_field :lock_version, data: {toggle_value_target: "field"} %>
       <input id="stale_record_overwrite" class="form-check-input is-invalid" type="checkbox" data-action="toggle-value#toggle">
       <div class="d-flex align-items-center">
-        <label for="stale_record_overwrite" class="form-check-label text-danger fw-bold"><%= t(".label") %></label>
-        <span class="text-danger ms-1"><%= t(".aside") %></span>
+        <label for="stale_record_overwrite" class="form-check-label text-danger">
+          <b><%= t(".label") %></b>
+          <span class="text-danger ms-1"><%= t(".aside") %></span>
+        </label>
       </div>
     </div>
   </div>

--- a/app/views/layouts/_stale_record_field.html.erb
+++ b/app/views/layouts/_stale_record_field.html.erb
@@ -1,0 +1,14 @@
+<% if form.object.lock_version_changed? %>
+  <div class="col-12 mt-4 mb-2" data-controller="toggle-value" data-toggle-value-next-value="<%= form.object.lock_version_was %>">
+    <div class="form-check">
+      <%= form.hidden_field :lock_version, data: {toggle_value_target: "field"} %>
+      <input id="stale_record_overwrite" class="form-check-input is-invalid" type="checkbox" data-action="toggle-value#toggle">
+      <div class="d-flex align-items-center">
+        <label for="stale_record_overwrite" class="form-check-label text-danger fw-bold"><%= t(".label") %></label>
+        <span class="text-danger ms-1"><%= t(".aside") %></span>
+      </div>
+    </div>
+  </div>
+<% else %>
+  <%= form.hidden_field :lock_version %>
+<% end %>

--- a/app/views/layouts/_stale_record_modal.html.erb
+++ b/app/views/layouts/_stale_record_modal.html.erb
@@ -1,4 +1,4 @@
-<% if form.object.lock_version_changed? %>
+<% if form.object.stale? %>
   <div class="modal hide" id="stale-record" tabindex="-1" aria-labelledby="stale-record-title" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">

--- a/app/views/layouts/_stale_record_modal.html.erb
+++ b/app/views/layouts/_stale_record_modal.html.erb
@@ -3,14 +3,14 @@
     <div class="modal-dialog modal-dialog-centered">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="stale-record-title"><%= t(".title") %></h5>
+          <h5 class="modal-title fw-bold" id="stale-record-title"><%= t(".title") %></h5>
         </div>
         <div class="modal-body">
           <p><%= t ".body_html", model: form.object.model_name.human, ago: local_time_ago(form.object.updated_at) %></p>
         </div>
         <div class="modal-footer">
           <%= link_to t(".discard"), discard_path, class: "btn btn-discard-changed", data: {action: "unsaved#discard", unsaved_target: "discard"} %>
-          <button type="button" class="btn btn-danger" data-bs-dismiss="modal"><%= t(".continue") %></button>
+          <button type="button" class="btn btn-warning" data-bs-dismiss="modal"><%= t(".continue") %></button>
         </div>
       </div>
     </div>

--- a/app/views/layouts/_stale_record_modal.html.erb
+++ b/app/views/layouts/_stale_record_modal.html.erb
@@ -1,0 +1,21 @@
+<% if form.object.lock_version_changed? %>
+  <div class="modal hide" id="stale-record" tabindex="-1" aria-labelledby="stale-record-title" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="stale-record-title"><%= t(".title") %></h5>
+        </div>
+        <div class="modal-body">
+          <p><%= t ".body_html", model: form.object.model_name.human, ago: local_time_ago(form.object.updated_at) %></p>
+        </div>
+        <div class="modal-footer">
+          <%= link_to t(".discard"), discard_path, class: "btn btn-discard-changed", data: {action: "unsaved#discard", unsaved_target: "discard"} %>
+          <button type="button" class="btn btn-danger" data-bs-dismiss="modal"><%= t(".continue") %></button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <%# click hidden button to immediately show modal %>
+  <button type="button" class="d-none" data-bs-toggle="modal" data-bs-target="#stale-record" data-controller="click" data-click-immediate-value="true"></button>
+<% end %>

--- a/app/views/podcast_engagement/_form.html.erb
+++ b/app/views/podcast_engagement/_form.html.erb
@@ -20,4 +20,5 @@
     </div>
   </div>
 
+  <%= render "layouts/stale_record_modal", form: form, discard_path: podcast_engagement_path(podcast) %>
 <% end %>

--- a/app/views/podcast_engagement/_form_status.html.erb
+++ b/app/views/podcast_engagement/_form_status.html.erb
@@ -2,6 +2,9 @@
   <div class="card-header-primary">
     <h2 class="card-title h5"><%= t(".title") %></h2>
   </div>
+
+  <%= render "layouts/stale_record_field", form: form %>
+
   <div class="card-footer d-flex align-items-center">
 
     <p class="status-text flex-grow-1"><strong><%= t(".updated_at_hint") %></strong> <br><%= local_time_ago(podcast.updated_at) %></p>

--- a/app/views/podcasts/_form.html.erb
+++ b/app/views/podcasts/_form.html.erb
@@ -20,5 +20,5 @@
 
   <%= render "confirm_destroy", podcast: podcast %>
 
-  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_podcast_path(podcast) %>
+  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_podcast_path(podcast) if podcast.persisted? %>
 <% end %>

--- a/app/views/podcasts/_form.html.erb
+++ b/app/views/podcasts/_form.html.erb
@@ -19,4 +19,6 @@
   </div>
 
   <%= render "confirm_destroy", podcast: podcast %>
+
+  <%= render "layouts/stale_record_modal", form: form, discard_path: edit_podcast_path(podcast) %>
 <% end %>

--- a/app/views/podcasts/_form_status.html.erb
+++ b/app/views/podcasts/_form_status.html.erb
@@ -2,6 +2,9 @@
   <div class="card-header-primary">
     <h2 class="card-title h5"><%= t(".title") %></h2>
   </div>
+
+  <%= render "layouts/stale_record_field", form: form %>
+
   <div class="card-footer d-flex align-items-center">
     <% if podcast.persisted? %>
       <p class="status-text flex-grow-1"><strong><%= t(".updated_at_hint") %></strong> <br><%= local_time_ago(podcast.updated_at) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -913,6 +913,14 @@ en:
       privacy: Privacy
       status: Status
       terms: Terms
+    stale_record_field:
+      aside: (Not Recommended)
+      label: Overwrite
+    stale_record_modal:
+      body_html: While you were sleeping, someone else updated this %{model} <b>%{ago}</b>.</br></br>You can either discard your changes and make them again in a fresh form, or continue editing at your own risk.
+      continue: Continue Editing
+      discard: Discard changes
+      title: Woh - someone else updated this!
   podcasts:
     confirm_destroy:
       <<: *form_status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -917,10 +917,10 @@ en:
       aside: (Not Recommended)
       label: Overwrite
     stale_record_modal:
-      body_html: While you were sleeping, someone else updated this %{model} <b>%{ago}</b>.</br></br>You can either discard your changes and make them again in a fresh form, or continue editing at your own risk.
+      body_html: Another user updated this %{model} <b>%{ago}</b>.</br></br>You can either discard your changes and make them again in a fresh form, or continue editing at your own risk.
       continue: Continue Editing
       discard: Discard changes
-      title: Woh - someone else updated this!
+      title: Warning! Another user has updated this form.
   podcasts:
     confirm_destroy:
       <<: *form_status

--- a/db/migrate/20240424214558_add_locking_columns.rb
+++ b/db/migrate/20240424214558_add_locking_columns.rb
@@ -1,0 +1,7 @@
+class AddLockingColumns < ActiveRecord::Migration[7.0]
+  def change
+    add_column :episodes, :lock_version, :integer
+    add_column :feeds, :lock_version, :integer
+    add_column :podcasts, :lock_version, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_10_212602) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_24_214558) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -164,6 +164,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_10_212602) do
     t.integer "segment_count"
     t.text "production_notes"
     t.integer "medium"
+    t.integer "lock_version"
     t.index ["guid"], name: "index_episodes_on_guid", unique: true
     t.index ["keyword_xid"], name: "index_episodes_on_keyword_xid", unique: true
     t.index ["original_guid", "podcast_id"], name: "index_episodes_on_original_guid_and_podcast_id", unique: true, where: "((deleted_at IS NULL) AND (original_guid IS NOT NULL))"
@@ -228,6 +229,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_10_212602) do
     t.boolean "include_donation_url", default: true
     t.text "exclude_tags"
     t.datetime "deleted_at", precision: nil
+    t.integer "lock_version"
     t.index ["podcast_id", "slug"], name: "index_feeds_on_podcast_id_and_slug", unique: true, where: "(slug IS NOT NULL)"
     t.index ["podcast_id"], name: "index_feeds_on_podcast_id"
     t.index ["podcast_id"], name: "index_feeds_on_podcast_id_default", unique: true, where: "(slug IS NULL)"
@@ -355,6 +357,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_10_212602) do
     t.text "restrictions"
     t.string "payment_pointer"
     t.string "donation_url"
+    t.integer "lock_version"
     t.index ["path"], name: "index_podcasts_on_path", unique: true
     t.index ["prx_uri"], name: "index_podcasts_on_prx_uri", unique: true
     t.index ["source_url"], name: "index_podcasts_on_source_url", unique: true, where: "((deleted_at IS NULL) AND (source_url IS NOT NULL))"

--- a/test/controllers/episodes_controller_test.rb
+++ b/test/controllers/episodes_controller_test.rb
@@ -71,6 +71,11 @@ class EpisodesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "optimistically locks updating episodes" do
+    patch episode_url(episode), params: {episode: {lock_version: episode.lock_version - 1}}
+    assert_response :conflict
+  end
+
   test "should destroy episode" do
     assert episode
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -71,6 +71,11 @@ class FeedsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "optimistically locks updating feeds" do
+    patch podcast_feed_url(podcast, feed), params: {feed: {lock_version: feed.lock_version - 1}}
+    assert_response :conflict
+  end
+
   test "should destroy feed" do
     assert podcast
     assert feed

--- a/test/controllers/podcasts_controller_test.rb
+++ b/test/controllers/podcasts_controller_test.rb
@@ -77,6 +77,11 @@ class PodcastsControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  test "optimistically locks updating podcasts" do
+    patch podcast_url(podcast), params: {podcast: {lock_version: podcast.lock_version - 1}}
+    assert_response :conflict
+  end
+
   test "should destroy podcast" do
     assert podcast
 


### PR DESCRIPTION
Closes #1000.

Adds optimistic locking to _UI updates only_.  This avoids locking a bunch of browser-forms every time an async worker callback touches a record.  (Turns out, rails `lock_version`s bubble up, along with the updated_at timestamps we use to break caches).

If a user updates a form and it's been edited by someone else in the interim, throw up a warning.  Which lets them either discard their changes or manually confirm they want to overwrite.

Added to the pages:

- [x] Podcast
- [x] Podcast -> Engagement Settings
- [x] Feed 
- [x] Episode
- [x] Episode -> Media Files

![image](https://github.com/PRX/feeder.prx.org/assets/1410587/da63340d-4984-499e-abc2-326ee7f3ab08)