### PR TITLE
Remove the noImp decorator in enclosure builder

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -242,7 +242,6 @@ module Apple
 
     def enclosure_url
       url = EnclosureUrlBuilder.new.base_enclosure_url(podcast, feeder_episode, private_feed)
-      url = EnclosureUrlBuilder.mark_no_imp(url)
       EnclosureUrlBuilder.mark_authorized(url, show.private_feed)
     end
 

--- a/app/models/enclosure_url_builder.rb
+++ b/app/models/enclosure_url_builder.rb
@@ -17,12 +17,6 @@ class EnclosureUrlBuilder
     add_query_param(enclosure_url, "auth", token)
   end
 
-  # Marks the url as a `noImp`
-  # Used by Dovetail to skip the impression tracking
-  def self.mark_no_imp(enclosure_url)
-    add_query_param(enclosure_url, "noImp", "1")
-  end
-
   def podcast_episode_url(podcast, episode, feed = nil)
     feed ||= podcast.default_feed
     prefix = feed.try(:enclosure_prefix)

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -56,12 +56,6 @@ describe Apple::Episode do
   end
 
   describe "#enclosure_url" do
-    it "should add a noImp query param" do
-      assert_match(/noImp=1/, apple_episode.enclosure_url)
-    end
-  end
-
-  describe "#enclosure_url" do
     it "should add auth query param" do
       assert_match(/auth=/, apple_episode.enclosure_url)
     end

--- a/test/models/apple/episode_test.rb
+++ b/test/models/apple/episode_test.rb
@@ -62,8 +62,8 @@ describe Apple::Episode do
   end
 
   describe "#enclosure_url" do
-    it "should add a noImp query param" do
-      assert_match(/noImp=1/, apple_episode.enclosure_url)
+    it "should add auth query param" do
+      assert_match(/auth=/, apple_episode.enclosure_url)
     end
   end
 

--- a/test/models/enclosure_url_builder_test.rb
+++ b/test/models/enclosure_url_builder_test.rb
@@ -131,16 +131,6 @@ describe EnclosureUrlBuilder do
   end
 
   describe "a set of class methods to mark (annotate) enclosure urls" do
-    describe ".mark_no_imp" do
-      it "should add a noImp query param" do
-        assert_equal "http://example.com?noImp=1", EnclosureUrlBuilder.mark_no_imp("http://example.com")
-      end
-
-      it "should preserve existing query params" do
-        assert_equal "http://example.com?foo=bar&noImp=1", EnclosureUrlBuilder.mark_no_imp("http://example.com?foo=bar")
-      end
-    end
-
     describe ".mark_authorized" do
       let(:private_feed) { create(:private_feed, podcast: podcast) }
       let(:feed_tok) { private_feed.tokens.first }


### PR DESCRIPTION
Delegated delivery:

- Removes the `noImp` query param to enable impression logging in Dovetail
- in conjunction with https://github.com/PRX/prx-podagent/pull/43 to enable filtering as a bot