### PR TITLE
API episode feeds

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -39,7 +39,7 @@ class Api::EpisodesController < Api::BaseController
   end
 
   def list_scoped(res)
-    res.published
+    res.in_default_feed
   end
 
   def show
@@ -63,7 +63,7 @@ class Api::EpisodesController < Api::BaseController
       respond_with_error(HalApi::Errors::NotFound.new)
     elsif show_resource.deleted?
       respond_with_error(ResourceGone.new)
-    elsif !show_resource.published?
+    elsif !show_resource.in_default_feed?
       if EpisodePolicy.new(pundit_user, show_resource).update?
         redirect_to api_authorization_episode_path(api_version, show_resource.guid)
       else

--- a/app/models/concerns/episode_has_feeds.rb
+++ b/app/models/concerns/episode_has_feeds.rb
@@ -30,11 +30,11 @@ module EpisodeHasFeeds
   end
 
   def in_feed?(feed)
-    episodes_feeds.where(feed: feed).any?
+    published_by?(feed.episode_offset_seconds.to_i) && episodes_feeds.where(feed: feed).any?
   end
 
   def in_default_feed?
-    feeds.where(slug: nil).any?
+    published? && feeds.where(slug: nil).any?
   end
 
   def feed_slugs

--- a/app/models/concerns/episode_has_feeds.rb
+++ b/app/models/concerns/episode_has_feeds.rb
@@ -1,0 +1,49 @@
+require "active_support/concern"
+
+module EpisodeHasFeeds
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :episodes_feeds, dependent: :delete_all
+    has_many :feeds, through: :episodes_feeds
+
+    after_initialize :set_default_feeds, if: :new_record?
+    before_validation :set_default_feeds, if: :new_record?
+
+    # NOTE: this DOES NOT apply the display_episodes_count
+    scope :in_feed, ->(feed) do
+      Episode.joins(:episodes_feeds)
+        .where(episodes_feeds: {feed: feed})
+        .published_by(feed.episode_offset_seconds.to_i)
+    end
+
+    # NOTE: this DOES NOT apply the display_episodes_count
+    scope :in_default_feed, -> { joins(:feeds).where(feeds: {slug: nil}).published }
+  end
+
+  def set_default_feeds
+    if feeds.blank?
+      self.feeds = (podcast&.feeds || []).filter_map do |feed|
+        feed if feed.default? || feed.apple?
+      end
+    end
+  end
+
+  def in_feed?(feed)
+    episodes_feeds.where(feed: feed).any?
+  end
+
+  def in_default_feed?
+    feeds.where(slug: nil).any?
+  end
+
+  def feed_slugs
+    feeds.pluck(:slug).map { |s| s || "default" }
+  end
+
+  def feed_slugs=(slugs)
+    self.feeds = (podcast&.feeds || []).filter_map do |feed|
+      feed if slugs.try(:include?, feed.slug || "default")
+    end
+  end
+end

--- a/app/models/concerns/episode_has_feeds.rb
+++ b/app/models/concerns/episode_has_feeds.rb
@@ -10,14 +10,14 @@ module EpisodeHasFeeds
     after_initialize :set_default_feeds, if: :new_record?
     before_validation :set_default_feeds, if: :new_record?
 
-    # NOTE: this DOES NOT apply the display_episodes_count
+    # TODO: this doesn't filter by display_episodes_count
     scope :in_feed, ->(feed) do
       Episode.joins(:episodes_feeds)
         .where(episodes_feeds: {feed: feed})
         .published_by(feed.episode_offset_seconds.to_i)
     end
 
-    # NOTE: this DOES NOT apply the display_episodes_count
+    # TODO: this doesn't filter by display_episodes_count
     scope :in_default_feed, -> { joins(:feeds).where(feeds: {slug: nil}).published }
   end
 
@@ -29,10 +29,12 @@ module EpisodeHasFeeds
     end
   end
 
+  # TODO: this doesn't filter by display_episodes_count
   def in_feed?(feed)
     published_by?(feed.episode_offset_seconds.to_i) && episodes_feeds.where(feed: feed).any?
   end
 
+  # TODO: this doesn't filter by display_episodes_count
   def in_default_feed?
     published? && feeds.where(slug: nil).any?
   end

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -6,6 +6,7 @@ require "text_sanitizer"
 class Episode < ApplicationRecord
   include EpisodeAdBreaks
   include EpisodeFilters
+  include EpisodeHasFeeds
   include EpisodeMedia
   include PublishingStatus
   include TextSanitizer
@@ -25,8 +26,6 @@ class Episode < ApplicationRecord
 
   belongs_to :podcast, -> { with_deleted }, touch: true
 
-  has_many :episodes_feeds, dependent: :delete_all
-  has_many :feeds, through: :episodes_feeds
   has_many :episode_imports
   has_many :contents, -> { order("position ASC, created_at DESC") }, autosave: true, dependent: :destroy, inverse_of: :episode
   has_many :media_versions, -> { order("created_at DESC") }, dependent: :destroy
@@ -53,8 +52,6 @@ class Episode < ApplicationRecord
   validates :segment_count, numericality: {only_integer: true, greater_than: 0, less_than_or_equal_to: MAX_SEGMENT_COUNT}, allow_nil: true
   validate :validate_media_ready, if: :strict_validations
 
-  after_initialize :set_default_feeds, if: :new_record?
-  before_validation :set_default_feeds, if: :new_record?
   before_validation :set_defaults, :set_external_keyword, :sanitize_text
 
   after_save :publish_updated, if: ->(e) { e.published_at_previously_changed? }
@@ -140,24 +137,6 @@ class Episode < ApplicationRecord
       images.build(img.attributes.compact)
     else
       img.update_image(image)
-    end
-  end
-
-  def set_default_feeds
-    if feed_ids.blank?
-      self.feed_ids = podcast&.feeds&.filter_map do |feed|
-        feed.id if feed.default? || feed.apple?
-      end
-    end
-  end
-
-  def feed_slugs
-    feeds.pluck(:slug).map { |s| s || "default" }
-  end
-
-  def feed_slugs=(slugs)
-    self.feeds = podcast&.feeds&.filter_map do |feed|
-      feed if slugs.try(:include?, feed.slug || "default")
     end
   end
 

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -151,6 +151,16 @@ class Episode < ApplicationRecord
     end
   end
 
+  def feed_slugs
+    feeds.pluck(:slug).map { |s| s || "default" }
+  end
+
+  def feed_slugs=(slugs)
+    self.feeds = podcast&.feeds&.filter_map do |feed|
+      feed if slugs.try(:include?, feed.slug || "default")
+    end
+  end
+
   def set_defaults
     guid
     self.segment_count ||= 1 if new_record? && strict_validations

--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -110,6 +110,10 @@ class Episode < ApplicationRecord
     !published_at.nil? && published_at <= Time.now
   end
 
+  def published_by?(offset)
+    !published_at.nil? && published_at <= Time.now - offset
+  end
+
   def draft?
     published_at.nil?
   end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -46,6 +46,7 @@ class Feed < ApplicationRecord
   validates :include_zones, placement_zones: true
   validates :audio_format, audio_format: true
   validates :title, presence: true, unless: :default?
+  validates :episode_offset_seconds, numericality: {equal_to: 0}, allow_nil: true, if: :default?
   validates :url, http_url: true
   validates :new_feed_url, http_url: true
   validates :enclosure_prefix, http_url: true

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -41,7 +41,7 @@ class Feed < ApplicationRecord
 
   validates :slug, uniqueness: {scope: :podcast_id}, if: :podcast_id?
   validates_format_of :slug, allow_nil: true, with: /\A[0-9a-zA-Z_-]+\z/
-  validates_format_of :slug, without: /\A(images|\w{8}-\w{4}-\w{4}-\w{4}-\w{12})\z/
+  validates_format_of :slug, without: /\A(default|images|\w{8}-\w{4}-\w{4}-\w{4}-\w{12})\z/
   validates :file_name, presence: true, format: {with: /\A[0-9a-zA-Z_.-]+\z/}
   validates :include_zones, placement_zones: true
   validates :audio_format, audio_format: true

--- a/app/representers/api/auth/episode_representer.rb
+++ b/app/representers/api/auth/episode_representer.rb
@@ -1,5 +1,6 @@
 class Api::Auth::EpisodeRepresenter < Api::EpisodeRepresenter
   property :deleted_at, writeable: false
+  property :feed_slugs
 
   collection :media,
     decorator: Api::Auth::MediaResourceRepresenter,

--- a/test/controllers/api/episodes_controller_test.rb
+++ b/test/controllers/api/episodes_controller_test.rb
@@ -53,6 +53,12 @@ describe Api::EpisodesController do
     assert_response 404
   end
 
+  it "should return not found resources not in the default feed" do
+    episode.update(feeds: [])
+    get(:show, params: {api_version: "v1", format: "json", id: episode.guid})
+    assert_response 404
+  end
+
   it "should list" do
     refute_nil episode.id
     refute_nil episode_deleted.id

--- a/test/models/concerns/episode_has_feeds_test.rb
+++ b/test/models/concerns/episode_has_feeds_test.rb
@@ -48,6 +48,12 @@ class EpisodeHasFeedsTest < ActiveSupport::TestCase
       assert episode.in_feed?(f1)
       refute episode.in_feed?(f2)
       refute episode.in_feed?(f3)
+
+      episode.published_at = 1.minute.from_now
+      refute episode.in_feed?(f1)
+
+      f1.episode_offset_seconds = -61
+      assert episode.in_feed?(f1)
     end
   end
 
@@ -55,6 +61,10 @@ class EpisodeHasFeedsTest < ActiveSupport::TestCase
     it "checks if an episode is in the default feed" do
       assert episode.in_default_feed?
 
+      episode.published_at = nil
+      refute episode.in_default_feed?
+
+      episode.published_at = 1.minute.ago
       episode.feeds = [f2]
       refute episode.in_default_feed?
     end

--- a/test/models/concerns/episode_has_feeds_test.rb
+++ b/test/models/concerns/episode_has_feeds_test.rb
@@ -1,0 +1,91 @@
+require "test_helper"
+
+class EpisodeHasFeedsTest < ActiveSupport::TestCase
+  let(:podcast) { create(:podcast) }
+  let(:f1) { podcast.default_feed }
+  let(:f2) { create(:feed, podcast: podcast, slug: "feed2") }
+  let(:f3) { create(:feed, podcast: podcast, slug: "feed3") }
+  let(:episode) { create(:episode, podcast: podcast) }
+
+  before { assert [f1, f2, f3] }
+
+  describe ".in_feed" do
+    it "returns episodes in a feed" do
+      e2 = create(:episode, podcast: podcast, feeds: [f2])
+      e3 = create(:episode, podcast: podcast, feeds: [f2])
+      assert_equal [e2, e3], Episode.in_feed(f2).order(id: :asc)
+
+      # only includes published
+      e2.update(published_at: 1.hour.from_now)
+      assert_equal [e3], Episode.in_feed(f2).order(id: :asc)
+
+      # does apply offsets
+      f2.episode_offset_seconds = -3601
+      assert_equal [e2, e3], Episode.in_feed(f2).order(id: :asc)
+
+      # does NOT apply limits
+      f2.display_episodes_count = 1
+      assert_equal [e2, e3], Episode.in_feed(f2).order(id: :asc)
+    end
+  end
+
+  describe ".in_default_feed" do
+    it "returns episodes in the default feed" do
+      assert_equal [episode], Episode.in_default_feed
+
+      # unpublished episodes not in default feed
+      episode.update(published_at: 1.hour.from_now)
+      assert_empty Episode.in_default_feed
+
+      # or episodes in other feeds
+      episode.update(published_at: 1.hour.ago, feeds: [])
+      assert_empty Episode.in_default_feed
+    end
+  end
+
+  describe "#in_feed?" do
+    it "checks if an episode is in a feed" do
+      assert episode.in_feed?(f1)
+      refute episode.in_feed?(f2)
+      refute episode.in_feed?(f3)
+    end
+  end
+
+  describe "#in_default_feed?" do
+    it "checks if an episode is in the default feed" do
+      assert episode.in_default_feed?
+
+      episode.feeds = [f2]
+      refute episode.in_default_feed?
+    end
+  end
+
+  describe "#set_default_feeds" do
+    it "sets default feeds on new episodes" do
+      # saved episodes get default+apple feeds
+      f3.update(type: "Feeds::AppleSubscription")
+      assert_equal [f1.id, f3.id], episode.feeds.map(&:id).sort
+
+      # new episodes initialized with defaults
+      e2 = podcast.episodes.new
+      assert_equal [f1.id, f3.id], e2.feeds.map(&:id).sort
+
+      # UNLESS episode already has feeds
+      e2 = podcast.episodes.new(feeds: [f2])
+      assert_equal [f2.id], e2.feeds.map(&:id)
+    end
+  end
+
+  describe "#feed_slugs" do
+    it "gets and sets feeds based on their slugs" do
+      assert_equal [f1], episode.feeds
+      assert_equal ["default"], episode.feed_slugs
+
+      episode.feed_slugs = ["default", "whatev", "feed3"]
+      assert_equal [f1, f3], episode.feeds
+
+      episode.feed_slugs = ["feed3"]
+      assert_equal [f3], episode.feeds
+    end
+  end
+end

--- a/test/models/concerns/release_episodes_test.rb
+++ b/test/models/concerns/release_episodes_test.rb
@@ -4,6 +4,7 @@ class ReleaseEpisodesTest < ActiveSupport::TestCase
   let(:episode) { create(:episode, published_at: 30.minutes.from_now) }
   let(:podcast) { episode.podcast }
   let(:feed) { podcast.default_feed }
+  # let(:feed) { create(:feed, podcast: podcast, slug: "the-feed") }
 
   describe ".to_release" do
     it "returns episodes/podcasts that need release" do
@@ -26,7 +27,7 @@ class ReleaseEpisodesTest < ActiveSupport::TestCase
     end
 
     it "handles negative feed offsets" do
-      feed.update!(episode_offset_seconds: -300)
+      feed.update!(slug: "slug", episode_offset_seconds: -300)
       assert_empty Episode.to_release
       assert_empty Podcast.to_release
 
@@ -41,7 +42,7 @@ class ReleaseEpisodesTest < ActiveSupport::TestCase
     end
 
     it "handles positive feed offsets" do
-      feed.update!(episode_offset_seconds: 300)
+      feed.update!(slug: "slug", episode_offset_seconds: 300)
       assert_empty Episode.to_release
       assert_empty Podcast.to_release
 

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -276,26 +276,6 @@ describe Episode do
     end
   end
 
-  describe "#feed_slugs" do
-    it "gets and sets feeds based on their slugs" do
-      e1 = build_stubbed(:episode)
-      f1 = e1.podcast.default_feed
-      f2 = build_stubbed(:feed, slug: "feed2")
-      f3 = build_stubbed(:feed, slug: "feed3")
-
-      e1.podcast.stub(:feeds, [f1, f2, f3]) do
-        assert_equal [], e1.feeds
-        assert_equal [], e1.feed_slugs
-
-        e1.feed_slugs = ["default", "whatev", "feed3"]
-        assert_equal [f1, f3], e1.feeds
-
-        e1.feed_slugs = ["feed3"]
-        assert_equal [f3], e1.feeds
-      end
-    end
-  end
-
   describe "#medium=" do
     it "marks existing content for destruction on change" do
       refute episode.contents.first.marked_for_destruction?

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -276,6 +276,26 @@ describe Episode do
     end
   end
 
+  describe "#feed_slugs" do
+    it "gets and sets feeds based on their slugs" do
+      e1 = build_stubbed(:episode)
+      f1 = e1.podcast.default_feed
+      f2 = build_stubbed(:feed, slug: "feed2")
+      f3 = build_stubbed(:feed, slug: "feed3")
+
+      e1.podcast.stub(:feeds, [f1, f2, f3]) do
+        assert_equal [], e1.feeds
+        assert_equal [], e1.feed_slugs
+
+        e1.feed_slugs = ["default", "whatev", "feed3"]
+        assert_equal [f1, f3], e1.feeds
+
+        e1.feed_slugs = ["feed3"]
+        assert_equal [f3], e1.feeds
+      end
+    end
+  end
+
   describe "#medium=" do
     it "marks existing content for destruction on change" do
       refute episode.contents.first.marked_for_destruction?

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -190,6 +190,22 @@ describe Feed do
       feed2.title = "new feed"
       assert feed2.valid?
     end
+
+    it "does not allow episode offsets on default" do
+      feed1.episode_offset_seconds = 5
+      assert feed1.default?
+      assert feed1.invalid?
+
+      feed1.episode_offset_seconds = 0
+      assert feed1.valid?
+
+      feed1.episode_offset_seconds = nil
+      assert feed1.valid?
+
+      # non-default feeds can have offsets
+      feed2.episode_offset_seconds = 5
+      assert feed2.valid?
+    end
   end
 
   describe "#published_url" do

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -161,6 +161,9 @@ describe Feed do
     it "restricts some slugs already used in S3" do
       assert feed1.valid?
 
+      feed1.slug = "default"
+      refute feed1.valid?
+
       feed1.slug = "images"
       refute feed1.valid?
 


### PR DESCRIPTION
After #1019.

Closes https://github.com/PRX/internal/issues/1104.  Should QA that castle API scraping still works.  But I think it will.

- [x] Adds a feed getter/setter to the _authorized_ Episode API.  Default feeds are returned as `default`, and others are their slugs:
    ```
    {
      feedSlugs: ["default", "apple-sub-feed", "some-other-feed"]
    }
    ```
- [x] Change episode API to be the default_feeds

Fallout: apply display_episodes_count to API results.