### PR TITLE
Make sure parent/child classes don't all share the same aliases

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -2,14 +2,22 @@ class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
   include HalApi::RepresentedModel
 
-  @@error_message_aliases = {}
-
   def self.alias_error_messages(to_field, from_field)
-    @@error_message_aliases[to_field.to_s] = from_field.to_s
+    aliases = self.error_message_aliases
+    aliases[to_field.to_s] = from_field.to_s
+    class_variable_set(:@@error_message_aliases, aliases)
+  end
+
+  def self.error_message_aliases
+    if class_variable_defined?(:@@error_message_aliases)
+      class_variable_get(:@@error_message_aliases)
+    else
+      {}
+    end
   end
 
   def error_message_aliases
-    @@error_message_aliases
+    self.class.error_message_aliases
   end
 
   def locking_enabled?

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,7 +3,7 @@ class ApplicationRecord < ActiveRecord::Base
   include HalApi::RepresentedModel
 
   def self.alias_error_messages(to_field, from_field)
-    aliases = self.error_message_aliases
+    aliases = error_message_aliases
     aliases[to_field.to_s] = from_field.to_s
     class_variable_set(:@@error_message_aliases, aliases)
   end


### PR DESCRIPTION
Whoops - every model was sharing the same error message aliases.