### PR TITLE
Lock podcast until timestamp

### DIFF
--- a/app/models/concerns/release_episodes.rb
+++ b/app/models/concerns/release_episodes.rb
@@ -17,8 +17,8 @@ module ReleaseEpisodes
     WHERE e.published_at IS NOT NULL
     AND e.deleted_at IS NULL
     AND f.deleted_at IS NULL
-    and p.deleted_at IS NULL
-    AND p.locked != TRUE
+    AND p.deleted_at IS NULL
+    AND (p.locked_until IS NULL OR p.locked_until < NOW())
   SQL
 
   # the most recent time we've called podcast.publish!

--- a/app/models/concerns/release_episodes.rb
+++ b/app/models/concerns/release_episodes.rb
@@ -10,7 +10,10 @@ module ReleaseEpisodes
       e.id AS episode_id,
       e.podcast_id AS podcast_id,
       f.id AS feed_id,
-      e.published_at + MAKE_INTERVAL(secs => COALESCE(f.episode_offset_seconds, 0)) AS publish_time
+      GREATEST(
+        e.published_at + MAKE_INTERVAL(secs => COALESCE(f.episode_offset_seconds, 0)),
+        e.created_at
+      ) AS publish_time
     FROM episodes e
     LEFT JOIN feeds f USING (podcast_id)
     LEFT JOIN podcasts p ON (p.id = e.podcast_id)

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -165,8 +165,12 @@ class Podcast < ApplicationRecord
     self[:locked_until] = val.present? ? "3000-01-01" : nil
   end
 
-  def locked?
+  def locked
     locked_until.present? && locked_until > Time.now
+  end
+
+  def locked?
+    locked
   end
 
   def publish!

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -161,6 +161,14 @@ class Podcast < ApplicationRecord
     self[:categories] = sanitize_categories(cats, false).presence
   end
 
+  def locked=(val)
+    self[:locked_until] = val.present? ? "3000-01-01" : nil
+  end
+
+  def locked?
+    locked_until.present? && locked_until > Time.now
+  end
+
   def publish!
     if locked?
       Rails.logger.warn "Podcast #{id} is locked, skipping publish", {podcast_id: id}

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -161,6 +161,7 @@ class Podcast < ApplicationRecord
     self[:categories] = sanitize_categories(cats, false).presence
   end
 
+  # publish locking getters/setters, for backwards compatibility in podcast API
   def locked=(val)
     self[:locked_until] = val.present? ? "3000-01-01" : nil
   end

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -52,11 +52,7 @@ class PodcastImport < ApplicationRecord
   # keep podcast locked 1 minute for every 150 episode, so we're not publishing
   # on every single media-processed callback
   def unlock_podcast_later!
-    lock_minutes = episode_imports.count / 150
-    if lock_minutes > 0
-      podcast.update!(locked_until: Time.now + lock_minutes.minutes)
-    else
-      podcast.update!(locked_until: nil)
-    end
+    lock_minutes = (episode_imports.count / 150.0).ceil
+    podcast.update!(locked_until: Time.now + lock_minutes.minutes)
   end
 end

--- a/app/models/podcast_import.rb
+++ b/app/models/podcast_import.rb
@@ -38,7 +38,7 @@ class PodcastImport < ApplicationRecord
         status_importing!
       end
 
-      unlock_podcast! if done?
+      unlock_podcast_later! if done?
     end
   end
 
@@ -49,7 +49,14 @@ class PodcastImport < ApplicationRecord
     PodcastImportJob.perform_later(self)
   end
 
-  def unlock_podcast!
-    podcast.update!(locked: false)
+  # keep podcast locked 1 minute for every 150 episode, so we're not publishing
+  # on every single media-processed callback
+  def unlock_podcast_later!
+    lock_minutes = episode_imports.count / 150
+    if lock_minutes > 0
+      podcast.update!(locked_until: Time.now + lock_minutes.minutes)
+    else
+      podcast.update!(locked_until: nil)
+    end
   end
 end

--- a/db/migrate/20240821135645_add_locked_until.rb
+++ b/db/migrate/20240821135645_add_locked_until.rb
@@ -5,7 +5,8 @@ class AddLockedUntil < ActiveRecord::Migration[7.1]
   end
 
   def down
-    Podcast.where(locked_until: ..Time.now).update_all(locked: true)
+    add_column :podcasts, :locked, :boolean, default: false
+    Podcast.where(locked_until: Time.now..).update_all(locked: true)
     remove_column :podcasts, :locked_until
   end
 end

--- a/db/migrate/20240821135645_add_locked_until.rb
+++ b/db/migrate/20240821135645_add_locked_until.rb
@@ -2,6 +2,7 @@ class AddLockedUntil < ActiveRecord::Migration[7.1]
   def up
     add_column :podcasts, :locked_until, :timestamp
     Podcast.where(locked: true).update_all(locked_until: "3000-01-01")
+    remove_column :podcasts, :locked
   end
 
   def down

--- a/db/migrate/20240821135645_add_locked_until.rb
+++ b/db/migrate/20240821135645_add_locked_until.rb
@@ -1,0 +1,11 @@
+class AddLockedUntil < ActiveRecord::Migration[7.1]
+  def up
+    add_column :podcasts, :locked_until, :timestamp
+    Podcast.where(locked: true).update_all(locked_until: "3000-01-01")
+  end
+
+  def down
+    Podcast.where(locked_until: ..Time.now).update_all(locked: true)
+    remove_column :podcasts, :locked_until
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -358,7 +358,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_135645) do
     t.datetime "published_at", precision: nil
     t.datetime "source_updated_at", precision: nil
     t.boolean "serial_order", default: false
-    t.boolean "locked", default: false
     t.boolean "itunes_block", default: false
     t.text "restrictions"
     t.string "payment_pointer"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_26_182801) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_21_135645) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -36,7 +36,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_26_182801) do
     t.text "enclosure_url"
     t.integer "source_fetch_count", default: 0
     t.bigint "source_media_version_id"
-    t.index ["episode_id", "created_at", "delivered", "id"], name: "index_apple_episode_delivery_statuses_on_episode_id_created_at"
+    t.index ["episode_id", "created_at"], name: "index_apple_episode_delivery_statuses_on_episode_id_created_at", include: ["delivered", "id"]
     t.index ["episode_id"], name: "index_apple_episode_delivery_statuses_on_episode_id"
   end
 
@@ -149,8 +149,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_26_182801) do
     t.string "feedburner_orig_link"
     t.string "feedburner_orig_enclosure_link"
     t.boolean "is_perma_link"
-    t.string "keyword_xid"
     t.datetime "source_updated_at", precision: nil
+    t.string "keyword_xid"
     t.integer "season_number"
     t.integer "episode_number"
     t.string "itunes_type", default: "full"
@@ -365,6 +365,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_26_182801) do
     t.string "donation_url"
     t.integer "lock_version", default: 0, null: false
     t.string "categories", array: true
+    t.datetime "locked_until", precision: nil
     t.index ["categories"], name: "index_podcasts_on_categories", using: :gin
     t.index ["path"], name: "index_podcasts_on_path", unique: true
     t.index ["prx_uri"], name: "index_podcasts_on_prx_uri", unique: true

--- a/test/models/concerns/release_episodes_test.rb
+++ b/test/models/concerns/release_episodes_test.rb
@@ -79,9 +79,14 @@ class ReleaseEpisodesTest < ActiveSupport::TestCase
       assert_empty Podcast.to_release
 
       feed.update!(deleted_at: nil)
-      podcast.update!(locked: true)
+      podcast.update!(locked_until: Time.now + 1.minute)
       assert_empty Episode.to_release
       assert_empty Podcast.to_release
+
+      # locked_until in the past DOES get released
+      podcast.update!(locked_until: Time.now - 1.minute)
+      assert_equal [episode], Episode.to_release
+      assert_equal [podcast], Podcast.to_release
     end
   end
 

--- a/test/models/concerns/release_episodes_test.rb
+++ b/test/models/concerns/release_episodes_test.rb
@@ -1,10 +1,9 @@
 require "test_helper"
 
 class ReleaseEpisodesTest < ActiveSupport::TestCase
-  let(:episode) { create(:episode, published_at: 30.minutes.from_now) }
+  let(:episode) { create(:episode, published_at: 30.minutes.from_now, created_at: 10.days.ago) }
   let(:podcast) { episode.podcast }
   let(:feed) { podcast.default_feed }
-  # let(:feed) { create(:feed, podcast: podcast, slug: "the-feed") }
 
   describe ".to_release" do
     it "returns episodes/podcasts that need release" do
@@ -87,6 +86,24 @@ class ReleaseEpisodesTest < ActiveSupport::TestCase
       podcast.update!(locked_until: Time.now - 1.minute)
       assert_equal [episode], Episode.to_release
       assert_equal [podcast], Podcast.to_release
+    end
+
+    it "handles episodes created after their published_at timestamp" do
+      episode.update!(created_at: 1.hour.ago, published_at: 1.day.ago)
+
+      # no queue items - it needs release
+      assert_equal [episode], Episode.to_release
+      assert_equal [podcast], Podcast.to_release
+
+      # queue item < ep.created_at also needs release
+      PublishingQueueItem.create!(podcast: podcast, created_at: 61.minutes.ago)
+      assert_equal [episode], Episode.to_release
+      assert_equal [podcast], Podcast.to_release
+
+      # queue item > ep.created_at and we're good
+      PublishingQueueItem.create!(podcast: podcast, created_at: 59.minutes.ago)
+      assert_empty Episode.to_release
+      assert_empty Podcast.to_release
     end
   end
 

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -26,7 +26,7 @@ describe PodcastImport do
       assert import.status_importing?
     end
 
-    it "unlocks the podcast when done" do
+    it "unlocks the podcast later when done" do
       podcast.update(locked: true)
       refute_nil podcast.locked_until
       import.episode_imports.create(status: "importing")
@@ -39,8 +39,9 @@ describe PodcastImport do
 
       import.status_from_episodes!
       assert import.done?
-      refute podcast.reload.locked?
-      assert_nil podcast.locked_until
+      assert podcast.reload.locked?
+      assert podcast.locked_until > Time.now
+      assert podcast.locked_until < 2.minutes.from_now
     end
   end
 

--- a/test/models/podcast_import_test.rb
+++ b/test/models/podcast_import_test.rb
@@ -52,7 +52,8 @@ describe PodcastImport do
 
       import.stub(:episode_imports, 78.times) do
         import.unlock_podcast_later!
-        assert_nil podcast.locked_until
+        assert podcast.locked_until > Time.now
+        assert podcast.locked_until < 2.minutes.from_now
       end
 
       import.stub(:episode_imports, 3000.times) do


### PR DESCRIPTION
We've been getting some large (multiple thousands) RSS imports lately.

After #1066 and #1067, we seem to get through the initial "import" without clogging the workers.

But now, the thousands of Porter callbacks seem to be clogging the publish queue.  Yesterday, I ended up setting `locked = true` on a Podcast and terminating hundreds of `SELECT pg_advisory_lock(1, 9999)` statements in postgres before the workers unblocked (they were processing < 1 job a minute... and maybe just timing out?)

This works around any contention in that publishing queue advisory lock, by delaying unlocking the podcast for 1 minute per 150 episodes.  The `ReleaseEpisodesJob` cron will pick the Podcast up and call `.publish!` once we get past the `podcast.locked_until` timestamp.