### PR TITLE
fix(styles): anchor reboot selector

### DIFF
--- a/app/assets/stylesheets/shared/reboot.scss
+++ b/app/assets/stylesheets/shared/reboot.scss
@@ -2,7 +2,7 @@
 // Global Reboot Styles.
 //
 
-a {
+a:not([class]) {
   font-weight: $font-weight-bold;
   text-decoration: none;
 


### PR DESCRIPTION
Change selector for `<a>` tag reboot styles to apply to those not being styled by a class. This will prevent this reset from bleeding into styled anchors like menu item links.