### PR TITLE
HOTFIX: Remove help icon underlines

### DIFF
--- a/app/assets/stylesheets/shared/form.scss
+++ b/app/assets/stylesheets/shared/form.scss
@@ -426,6 +426,7 @@ small {
 .prx-input-group-text {
   background: $white;
   color: $gray-600;
+  text-decoration: none;
 
   &:hover {
     text-decoration: none;


### PR DESCRIPTION
when we merged #1087 we overlooked the help icons which contains an underline. This fixes it forever. 

(I'll update in Augury too)