### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem "paranoia"
 gem "sanitize"
 
 # monitoring/logging
+gem "logger"
 gem "lograge"
 gem "newrelic_rpm"
 gem "ougai"
@@ -72,6 +73,7 @@ gem "aws-sdk-s3"
 gem "csv"
 gem "excon"
 gem "faraday", "~> 0.17.4"
+gem "fiddle"
 gem "hyperresource"
 gem "net-http"
 gem "parallel"
@@ -80,6 +82,7 @@ group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]
   gem "dotenv-rails", "~> 2.0"
   gem "erb_lint", require: false
+  gem "ostruct"
   gem "pry"
   gem "pry-byebug"
   gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,6 +205,7 @@ GEM
       loofah (>= 2.3.1)
       sax-machine (>= 1.0)
     ffi (1.15.5)
+    fiddle (1.1.2)
     fuzzyurl (0.2.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -260,6 +261,7 @@ GEM
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     local_time (2.1.0)
+    logger (1.6.1)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -520,6 +522,7 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.10.0)
       opentelemetry-api (~> 1.0)
+    ostruct (0.6.0)
     ougai (1.9.1)
       oj (~> 3.10)
     ougai-formatters-customizable (1.0.1)
@@ -527,7 +530,7 @@ GEM
     parallel (1.24.0)
     paranoia (2.6.3)
       activerecord (>= 5.1, < 7.2)
-    parser (3.3.3.0)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
     pg (1.5.4)
@@ -760,6 +763,7 @@ DEPENDENCIES
   factory_bot_rails
   faraday (~> 0.17.4)
   feedjira
+  fiddle
   hal_api-rails (~> 1.2.2)
   hiredis (~> 0.6.3)
   hyperresource
@@ -767,6 +771,7 @@ DEPENDENCIES
   jbuilder
   kaminari
   local_time
+  logger
   lograge
   loofah
   minitest-around
@@ -778,6 +783,7 @@ DEPENDENCIES
   opentelemetry-exporter-otlp
   opentelemetry-instrumentation-all
   opentelemetry-sdk
+  ostruct
   ougai
   ougai-formatters-customizable
   parallel


### PR DESCRIPTION
Fix some deprecation warnings related to the ruby 3.3.5 upgrade.

- Update `parser/current` so erb-lint doesn't warn
- Add some gems explicitly to the Gemfile, since they'll be remove from ruby core in 3.5.  (Updating Rails may fix a few of these later, but this works for now).