### PR TITLE
Re-enable turbo on the submit but direct it to the whole page

### DIFF
--- a/app/views/podcast_planner/_form_draft.html.erb
+++ b/app/views/podcast_planner/_form_draft.html.erb
@@ -25,7 +25,7 @@
           <%= t(".title.calendar") %>
         </h5>
 
-        <button type="submit" class="btn btn-primary position-relative" disabled data-planner-target="button" data-turbo="false">
+        <button type="submit" class="btn btn-primary position-relative" disabled data-planner-target="button" data-turbo-frame="_top">
           <span class="prx-invisible-busy">
             <%= t(".label.create") %>
             <span data-planner-target="count"><%= @planner.dates&.count.to_i %></span>


### PR DESCRIPTION
resolves #1095 

This PR resolves the issue of the submit button on the Planner not disabling fully after submit, causing request issues. The solution re-enables turbo on the submit button, but makes it target the whole page (`_top`) instead of just within the context of its turbo frame.