### PR TITLE
Hide episode offset field from default feed view

### DIFF
--- a/app/views/feeds/_form_main.html.erb
+++ b/app/views/feeds/_form_main.html.erb
@@ -51,13 +51,15 @@
   </div>
 </div>
 
-<div class="col-6 mb-4">
-  <div class="form-floating input-group">
-    <%= form.select :episode_offset_seconds, episode_offset_options, include_blank: true %>
-    <%= form.label :episode_offset_seconds %>
-    <%= field_help_text t(".help.episode_offset_seconds") %>
+<% unless feed.default? %>
+  <div class="col-6 mb-4">
+    <div class="form-floating input-group">
+      <%= form.select :episode_offset_seconds, episode_offset_options, include_blank: true %>
+      <%= form.label :episode_offset_seconds %>
+      <%= field_help_text t(".help.episode_offset_seconds") %>
+    </div>
   </div>
-</div>
+<% end %>
 
 <div class="col-6 mb-4">
   <div class="form-floating input-group">


### PR DESCRIPTION
resolves #1096 

This PR hides the Episode Offset field from the default feed view. This is because we don't want a user to have the option of setting an offset for the default feed. The ticket suggests possibly adding a validation, but [one already exists](https://github.com/PRX/feeder.prx.org/blob/d269a3d51c2c976a61232b1909a22eaa31ede776/app/models/feed.rb#L51) and the [testing for it](https://github.com/PRX/feeder.prx.org/blob/d269a3d51c2c976a61232b1909a22eaa31ede776/test/models/feed_test.rb#L194) seems logical and no additions seem to be needed.