### PR TITLE
Render processing view for stalled uploads

### DIFF
--- a/app/views/episode_media/media/_media.html.erb
+++ b/app/views/episode_media/media/_media.html.erb
@@ -2,8 +2,6 @@
   <% if policy(media).create? %>
     <%= render "episode_media/media/new", form: form, episode: episode, media: media %>
   <% end %>
-<% elsif upload_stalled?(media) %>
-  <%= render "episode_media/media/error", form: form, episode: episode, media: media, retryable: true %>
 <% elsif upload_processing?(media) %>
   <%= render "episode_media/media/processing", form: form, episode: episode, media: media %>
 <% elsif upload_complete?(media) %>

--- a/app/views/episode_media/media/_processing.html.erb
+++ b/app/views/episode_media/media/_processing.html.erb
@@ -8,7 +8,11 @@
       <div class="text-secondary mx-2 overflow-hidden text-truncate"><%= media.file_name %></div>
       <small class="text-muted flex-grow-1">(<%= t(".hint") %>)</small>
 
-      <% if media.file_size.present? %>
+      <% if upload_stalled?(media) %>
+        <%= link_to episode_media_path(media.episode, uploads_retry_params(form)), method: :put, class: "btn btn-sm btn-warning" do %>
+          <span class="material-icons">restart_alt</span> Retry
+        <% end %>
+      <% elsif media.file_size.present? %>
         <small class="text-muted">(<%= number_to_human_size(media.file_size) %>)</small>
       <% end %>
     </div>
@@ -21,6 +25,10 @@
 
     <label><%= episode_media_label(episode, media) %></label>
   </div>
+
+  <% if upload_stalled?(media) %>
+    <small class="text-muted"><%= t(".still_processing") %></small>
+  <% end %>
 
   <%# just keep polling until the file finishes processing %>
   <%= link_to "", request.fullpath, class: "d-none", data: {controller: "polling"} %>

--- a/app/views/episode_media/media/_processing.html.erb
+++ b/app/views/episode_media/media/_processing.html.erb
@@ -8,12 +8,13 @@
       <div class="text-secondary mx-2 overflow-hidden text-truncate"><%= media.file_name %></div>
       <small class="text-muted flex-grow-1">(<%= t(".hint") %>)</small>
 
+      <% if media.file_size.present? %>
+        <small class="text-muted">(<%= number_to_human_size(media.file_size) %>)</small>
+      <% end %>
       <% if upload_stalled?(media) %>
-        <%= link_to episode_media_path(media.episode, uploads_retry_params(form)), method: :put, class: "btn btn-sm btn-warning" do %>
+        <%= link_to episode_media_path(media.episode, uploads_retry_params(form)), method: :put, class: "btn btn-sm btn-warning ms-2" do %>
           <span class="material-icons">restart_alt</span> Retry
         <% end %>
-      <% elsif media.file_size.present? %>
-        <small class="text-muted">(<%= number_to_human_size(media.file_size) %>)</small>
       <% end %>
     </div>
 

--- a/app/views/episode_transcripts/transcripts/_form.html.erb
+++ b/app/views/episode_transcripts/transcripts/_form.html.erb
@@ -2,10 +2,8 @@
   <% if policy(transcript).create? %>
     <%= render "episode_transcripts/transcripts/new", form: form, transcript: transcript %>
   <% end %>
-<% elsif upload_stalled?(transcript) %>
-  <%= render "episode_transcripts/transcripts/error", form: form, transcript: transcript, delete_path: delete_path, retry_path: retry_path %>
 <% elsif upload_processing?(transcript) %>
-  <%= render "episode_transcripts/transcripts/processing", form: form, transcript: transcript, delete_path: delete_path %>
+  <%= render "episode_transcripts/transcripts/processing", form: form, transcript: transcript, delete_path: delete_path, retry_path: retry_path %>
 <% elsif upload_complete?(transcript) %>
   <%= render "episode_transcripts/transcripts/complete", form: form, transcript: transcript, delete_path: delete_path %>
 <% else %>

--- a/app/views/episode_transcripts/transcripts/_processing.html.erb
+++ b/app/views/episode_transcripts/transcripts/_processing.html.erb
@@ -11,6 +11,11 @@
       <% if transcript.file_size.present? %>
         <small class="text-muted">(<%= number_to_human_size(transcript.file_size) %>)</small>
       <% end %>
+      <% if upload_stalled?(transcript) %>
+         <%= link_to retry_path, method: :put, class: "btn btn-sm btn-warning ms-2" do %>
+          <span class="material-icons">restart_alt</span> <%= t(".retry") %>
+        <% end %>
+      <% end %>
     </div>
 
     <% if policy(transcript).destroy? %>
@@ -21,6 +26,10 @@
 
     <label><%= t(".transcript_file") %></label>
   </div>
+
+  <% if upload_stalled?(transcript) %>
+    <small class="text-muted"><%= t(".still_processing") %></small>
+  <% end %>
 
   <%# just keep polling until the file finishes processing %>
   <%= link_to "", request.fullpath, class: "d-none", data: {controller: "polling"} %>

--- a/app/views/images/_form.html.erb
+++ b/app/views/images/_form.html.erb
@@ -2,10 +2,8 @@
   <% if policy(image).create? %>
     <%= render "images/new", form: form, image: image %>
   <% end %>
-<% elsif upload_stalled?(image) %>
-  <%= render "images/error", form: form, image: image, delete_path: delete_path, retry_path: retry_path %>
 <% elsif upload_processing?(image) %>
-  <%= render "images/processing", form: form, image: image, delete_path: delete_path %>
+  <%= render "images/processing", form: form, image: image, delete_path: delete_path, retry_path: retry_path %>
 <% elsif upload_complete?(image) %>
   <%= render "images/complete", form: form, image: image, delete_path: delete_path %>
 <% else %>

--- a/app/views/images/_processing.html.erb
+++ b/app/views/images/_processing.html.erb
@@ -22,10 +22,20 @@
         <% if image.size.present? %>
           <small class="text-muted">(<%= number_to_human_size(image.size) %>)</small>
         <% end %>
+
+        <% if upload_stalled?(image) %>
+          <%= link_to retry_path, method: :put, class: "btn btn-sm btn-warning ms-2" do %>
+            <span class="material-icons">restart_alt</span> <%= t("images.label.retry") %>
+          <% end %>
+        <% end %>
       </div>
 
       <label><%= t("images.label.image_file") %></label>
     </div>
+
+    <% if upload_stalled?(image) %>
+      <small class="text-muted"><%= t(".still_processing") %></small>
+    <% end %>
 
     <%# just keep polling until the file finishes processing %>
     <%= link_to "", request.fullpath, class: "d-none", data: {controller: "polling"} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,8 @@ defaults:
     destroy: &destroy
       success: "%{model} deleted successfully."
       failure: "There was a problem deleting the %{model}."
+  uploads:
+    still_processing: &still_processing Processing is taking longer than expected. Thank you for your patience. You can continue waiting or retry.
 
 en:
   # general config
@@ -649,7 +651,7 @@ en:
         title: MP3 Not Provided
       processing:
         hint: Processing
-        still_processing: Processing is taking longer than expected. Thank you for waiting.
+        still_processing: *still_processing
     segmenter:
       modal:
         label:
@@ -732,6 +734,7 @@ en:
         <<: *transcript_labels
         loading: Loading...
         processing: Processing
+        still_processing: *still_processing
       complete:
         <<: *transcript_labels
       error:
@@ -882,6 +885,8 @@ en:
       size: Size
       status: Status
       upload: Upload a file or drag it here
+    processing:
+      still_processing: *still_processing
     title:
       episode_image: Cover Image
       feed_image: Thumbnail Image

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -649,7 +649,7 @@ en:
         title: MP3 Not Provided
       processing:
         hint: Processing
-        still_processing: Your file is still being processed. Thank you for waiting.
+        still_processing: Processing is taking longer than expected. Thank you for waiting.
     segmenter:
       modal:
         label:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -649,6 +649,7 @@ en:
         title: MP3 Not Provided
       processing:
         hint: Processing
+        still_processing: Your file is still being processed. Thank you for waiting.
     segmenter:
       modal:
         label:


### PR DESCRIPTION
resolves #1094 

This PR solves a "hidden timeout" issue users were experiencing, by rendering a "still processing" message for "stalled" uploads. The solution i chose to solve for this was to opt for rendering the `_processing` partial instead of the `_error` partial for the `upload_stalled?` user conditional flow. I did this because i saw that the only difference between `upload_processing?` and `upload_stalled?` was the `retryable` condition. Therefore, a "stalled" upload should still be processing. A side benefit to using the `_processing` partial is that it continually polls the server, whereas the `_error` partial does not; if a "stalled" upload eventually completed, the `_error` view wouldn't refresh on its own to a `_complete` view, whereas the `_processing` view does.

Within the `_processing` partial, i added the `retry` button that is conditionally present in the `_error` partial, as well as a small (conditional) message underneath the field that notifies the user if the processing is taking longer than expected. This way, we keep the functionality for a user to choose to retry.

@cavis for functional review
@brandonhundt for language review