### PR TITLE
Add default values to the audio format selects

### DIFF
--- a/app/views/feeds/_form_audio_format.html.erb
+++ b/app/views/feeds/_form_audio_format.html.erb
@@ -23,7 +23,7 @@
 
         <div class="col-3 <%= display_bitdepth(feed) %>" data-toggle-field-target="field" field="wav flac">
           <div class="form-floating input-group">
-            <%= form.select :audio_bitdepth, options_for_select(audio_bitdepth_options, 32) %>
+            <%= form.select :audio_bitdepth, options_for_select(audio_bitdepth_options, 16) %>
             <%= form.label :audio_bitdepth %>
           </div>
         </div>

--- a/app/views/feeds/_form_audio_format.html.erb
+++ b/app/views/feeds/_form_audio_format.html.erb
@@ -16,28 +16,28 @@
 
         <div class="col-3 <%= display_bitrate(feed) %>" data-toggle-field-target="field" field="mp3 mp4">
           <div class="form-floating input-group">
-            <%= form.select :audio_bitrate, audio_bitrate_options %>
+            <%= form.select :audio_bitrate, options_for_select(audio_bitrate_options, 128) %>
             <%= form.label :audio_bitrate %>
           </div>
         </div>
 
         <div class="col-3 <%= display_bitdepth(feed) %>" data-toggle-field-target="field" field="wav flac">
           <div class="form-floating input-group">
-            <%= form.select :audio_bitdepth, audio_bitdepth_options %>
+            <%= form.select :audio_bitdepth, options_for_select(audio_bitdepth_options, 32) %>
             <%= form.label :audio_bitdepth %>
           </div>
         </div>
 
         <div class="col-3 <%= display_audio_format(feed) %>" data-toggle-field-target="field" field="mp3 wav flac mp4">
           <div class="form-floating input-group">
-            <%= form.select :audio_channel, audio_channel_options %>
+            <%= form.select :audio_channel, options_for_select(audio_channel_options, 2) %>
             <%= form.label :audio_channel %>
           </div>
         </div>
 
         <div class="col-3 <%= display_audio_format(feed) %>" data-toggle-field-target="field" field="mp3 wav flac mp4">
           <div class="form-floating input-group">
-            <%= form.select :audio_sample, audio_sample_options %>
+            <%= form.select :audio_sample, options_for_select(audio_sample_options, 44100) %>
             <%= form.label :audio_sample %>
           </div>
         </div>


### PR DESCRIPTION
resolves #1117 

This PR sets a default value for the audio format dropdowns. The issue was that with no default, the first choice in options is selected and it is the lowest quality option (sorting low to high). Adding a default value with a higher quality intends to reduce user error unintentionally selecting low quality options.