### PR TITLE
Wrap subnav with authorization policy

### DIFF
--- a/app/views/layouts/_subnav.html.erb
+++ b/app/views/layouts/_subnav.html.erb
@@ -1,8 +1,8 @@
-<div class="prx-app-bar navbar justify-content-start align-items-stretch p-0 bg-white">
+<% if @podcast && policy(@podcast).show? %>
+  <div class="prx-app-bar navbar justify-content-start align-items-stretch p-0 bg-white">
 
-  <%= render "podcast_switcher/dropdown" %>
+    <%= render "podcast_switcher/dropdown" %>
 
-  <% if @podcast %>
     <nav class="prx-app-nav navbar-nav flex-row justifty-content-start">
       <% if @podcast.new_record? %>
         <%= active_link_to "Settings", main_app.new_podcast_path, class: "nav-link" %>
@@ -13,5 +13,5 @@
         <%= active_link_to "Feeds", main_app.podcast_feeds_path(@podcast), active: /\/feeds/, class: "nav-link" %>
       <% end %>
     </nav>
-  <% end %>
-</div>
+  </div>
+<% end %>


### PR DESCRIPTION
resolves #1103 

This PR addresses the issue of leaked authorized info of a podcast. Previously, a user could still see the navbar of a podcast that they did not have authorization for, and therefore could view the title of the podcast seen in the podcast switcher partial. This PR wraps the subnav in a policy in order prevent access to users who do not have view access to the selected podcast. Because the subnav is used across many other views, this should be consistent any layout that utilizes the subnav, including the `episodes` and `feeds` views.