### PR TITLE
Use mp3 instead of flac for apple feeds

### DIFF
--- a/app/models/feeds/apple_subscription.rb
+++ b/app/models/feeds/apple_subscription.rb
@@ -111,7 +111,7 @@ class Feeds::AppleSubscription < Feed
       f: "mp3",
       b: [MIN_MP3_BITRATE, af[:b]].compact.max,
       c: MP3_CHANNELS.include?(af[:c]) ? af[:c] : MP3_CHANNELS.min,
-      s: [MIN_MP3_SAMPLERATE, af[:s]].compact.max,
+      s: [MIN_MP3_SAMPLERATE, af[:s]].compact.max
     }.with_indifferent_access
   end
 end

--- a/app/models/feeds/apple_subscription.rb
+++ b/app/models/feeds/apple_subscription.rb
@@ -1,8 +1,14 @@
 class Feeds::AppleSubscription < Feed
   DEFAULT_FEED_SLUG = "apple-delegated-delivery-subscriptions"
   DEFAULT_TITLE = "Apple Delegated Delivery Subscriptions"
-  DEFAULT_AUDIO_FORMAT = {"f" => "flac", "b" => 16, "c" => 2, "s" => 44100}.freeze
+  DEFAULT_AUDIO_FORMAT = {f: "mp3", b: 128, c: 2, s: 44100}.with_indifferent_access
   DEFAULT_ZONES = ["billboard", "sonic_id"]
+
+  # min apple settings (though forcing a higher bitrate for mono)
+  # https://podcasters.apple.com/support/893-audio-requirements
+  MIN_MP3_BITRATE = 64
+  MP3_CHANNELS = [1, 2]
+  MIN_MP3_SAMPLERATE = 44100
 
   after_initialize :set_defaults
 
@@ -20,13 +26,17 @@ class Feeds::AppleSubscription < Feed
   def set_defaults
     self.slug ||= DEFAULT_FEED_SLUG
     self.title ||= DEFAULT_TITLE
-    self.audio_format ||= DEFAULT_AUDIO_FORMAT
+    self.audio_format ||= guess_audio_format
     self.display_episodes_count ||= podcast&.default_feed&.display_episodes_count
     self.include_zones ||= DEFAULT_ZONES
     self.tokens = [FeedToken.new(label: DEFAULT_TITLE)] if tokens.empty?
     self.private = true
 
     super
+  end
+
+  def guess_audio_format
+    default_feed_audio_format || episode_audio_format || DEFAULT_AUDIO_FORMAT
   end
 
   def self.model_name
@@ -76,5 +86,32 @@ class Feeds::AppleSubscription < Feed
 
   def publish_to_apple?
     !!apple_config&.publish_to_apple?
+  end
+
+  def default_feed_audio_format
+    af = podcast&.default_feed&.audio_format
+    standardize_audio_format(af) if af && af[:f] == "mp3"
+  end
+
+  def episode_audio_format
+    episodes = podcast&.episodes&.published&.includes(:contents)&.limit(10)
+    contents = (episodes || []).map { |e| e.contents.first }.compact
+    mp3_contents = contents.select { |c| c.audio? && c.mime_type == "audio/mpeg" }
+
+    if mp3_contents.any?
+      max_bitrate = mp3_contents.map { |c| c.bit_rate.to_i }.max
+      max_channels = mp3_contents.map { |c| c.channels.to_i }.max
+      max_sample = mp3_contents.map { |c| c.sample_rate.to_i }.max
+      standardize_audio_format({b: max_bitrate, c: max_channels, s: max_sample})
+    end
+  end
+
+  def standardize_audio_format(af)
+    {
+      f: "mp3",
+      b: [MIN_MP3_BITRATE, af[:b]].compact.max,
+      c: MP3_CHANNELS.include?(af[:c]) ? af[:c] : MP3_CHANNELS.min,
+      s: [MIN_MP3_SAMPLERATE, af[:s]].compact.max,
+    }.with_indifferent_access
   end
 end

--- a/app/models/feeds/apple_subscription.rb
+++ b/app/models/feeds/apple_subscription.rb
@@ -27,7 +27,7 @@ class Feeds::AppleSubscription < Feed
     self.slug ||= DEFAULT_FEED_SLUG
     self.title ||= DEFAULT_TITLE
     self.audio_format ||= guess_audio_format
-    self.display_episodes_count ||= podcast&.default_feed&.display_episodes_count
+    self.display_episodes_count ||= podcast&.default_feed&.display_episodes_count if new_record?
     self.include_zones ||= DEFAULT_ZONES
     self.tokens = [FeedToken.new(label: DEFAULT_TITLE)] if tokens.empty?
     self.private = true

--- a/app/models/feeds/apple_subscription.rb
+++ b/app/models/feeds/apple_subscription.rb
@@ -94,8 +94,8 @@ class Feeds::AppleSubscription < Feed
   end
 
   def episode_audio_format
-    episodes = podcast&.episodes&.published&.includes(:contents)&.limit(10)
-    contents = (episodes || []).map { |e| e.contents.first }.compact
+    episodes = podcast&.episodes&.published&.includes(:contents)&.limit(10) || []
+    contents = episodes.map { |e| e.contents.first }.compact
     mp3_contents = contents.select { |c| c.audio? && c.mime_type == "audio/mpeg" }
 
     if mp3_contents.any?

--- a/app/views/feeds/_form.html.erb
+++ b/app/views/feeds/_form.html.erb
@@ -12,6 +12,7 @@
           <%= render "form_audio_format", podcast: podcast, feed: feed, form: form %>
         <% elsif apple_feed?(feed) %>
           <%= render "form_apple_config", podcast: podcast, feed: feed, form: form %>
+          <%= render "form_audio_format", podcast: podcast, feed: feed, form: form %>
           <%= render "form_ad_zones", podcast: podcast, feed: feed, form: form %>
         <% else %> <%# custom feeds %>
           <%= render "form_main", podcast: podcast, feed: feed, form: form %>

--- a/app/views/feeds/_form_apple_config.html.erb
+++ b/app/views/feeds/_form_apple_config.html.erb
@@ -28,7 +28,16 @@
           <%= key_fields.hidden_field :key_id, data: {apple_key_target: "key"} %>
         <% end %>
       <% end %>
+
       <%= form.hidden_field :type, value: "Feeds::AppleSubscription" %>
+
+      <div class="col-6 mb-4">
+        <div class="form-floating input-group">
+          <%= form.number_field :display_episodes_count %>
+          <%= form.label :display_episodes_count %>
+          <%= field_help_text t(".help.display_episodes_count") %>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -771,6 +771,8 @@ en:
       title: Apple Subscriptions
       description: In order to publish episodes through Apple's Podcast Connect API, ensure you've delegated access to the PRX account in Podcast Connect.
       guide_link: Check out our guide to step you through the setup.
+      help:
+        display_episodes_count: You can optionally limit the number of episodes that Paid Subscribers will see in Apple Podcasts. Leave this field blank to include all.
     form_audio_format:
       title: Audio Format
       help:

--- a/test/models/feed/apple_subscription_test.rb
+++ b/test/models/feed/apple_subscription_test.rb
@@ -1,12 +1,12 @@
 require "test_helper"
 
 describe Feeds::AppleSubscription do
-  let(:podcast) { create(:podcast) }
-  let(:feed_1) { podcast.default_feed }
+  let(:podcast) { create(:podcast, default_feed: default_feed) }
+  let(:default_feed) { build(:default_feed, audio_format: nil) }
   let(:apple_feed) { build(:apple_feed, podcast: podcast) }
 
   describe "#set_defaults" do
-    let(:default_feed) { build_stubbed(:feed, display_episodes_count: 99) }
+    let(:default_feed) { build_stubbed(:feed, display_episodes_count: 99, audio_format: nil) }
     let(:podcast) { build_stubbed(:podcast, default_feed: default_feed) }
 
     it "sets default values for apple subscription feeds" do
@@ -29,7 +29,7 @@ describe Feeds::AppleSubscription do
         podcast: podcast,
         slug: "foo",
         title: "bar",
-        audio_format: {f: "baz"},
+        audio_format: {f: "flac"},
         display_episodes_count: 88,
         include_zones: ["something"],
         private: false,
@@ -38,7 +38,7 @@ describe Feeds::AppleSubscription do
 
       assert_equal "foo", f.slug
       assert_equal "bar", f.title
-      assert_equal ({"f" => "baz"}), f.audio_format
+      assert_equal "flac", f.audio_format[:f]
       assert_equal 88, f.display_episodes_count
       assert_equal ["something"], f.include_zones
       assert_equal true, f.private
@@ -49,12 +49,34 @@ describe Feeds::AppleSubscription do
     end
   end
 
+  describe "#guess_audio_format" do
+    it "uses the default feed format" do
+      default_feed.audio_format = {f: "mp3", b: 192, c: 1, s: 48000}
+      assert_equal default_feed.audio_format, apple_feed.guess_audio_format
+    end
+
+    it "uses the max episode format" do
+      c1 = build(:content, mime_type: "audio/mpeg", bit_rate: 192, channels: 1, sample_rate: 22050)
+      c2 = build(:content, mime_type: "audio/mpeg", bit_rate: 64, channels: 2, sample_rate: 44100)
+      c3 = build(:content, mime_type: "audio/wav", bit_rate: 16, channels: 1, sample_rate: 48000)
+      create(:episode, podcast: podcast, contents: [c1])
+      create(:episode, podcast: podcast, contents: [c2])
+      create(:episode, podcast: podcast, contents: [c3])
+
+      assert_nil default_feed.audio_format
+      assert_equal ({f: "mp3", b: 192, c: 2, s: 44100}).with_indifferent_access, apple_feed.guess_audio_format
+    end
+
+    it "falls back to the default format" do
+      assert_equal Feeds::AppleSubscription::DEFAULT_AUDIO_FORMAT, apple_feed.guess_audio_format
+    end
+  end
+
   describe "#valid?" do
     it "cannot change the default properties once saved" do
       apple_feed.title = "new apple feed"
       apple_feed.slug = "new-apple-slug"
       apple_feed.file_name = "new_file.xml"
-      apple_feed.audio_format = {f: "flac", b: 16, c: 2, s: 44100}
       assert apple_feed.valid?
       apple_feed.save!
 
@@ -71,11 +93,6 @@ describe Feeds::AppleSubscription do
       apple_feed.file_name = "changed_file_name.xml"
       refute apple_feed.valid?
       apple_feed.file_name = "new_file.xml"
-      assert apple_feed.valid?
-
-      apple_feed.audio_format = {f: "wav", b: 128, c: 2, s: 44100}
-      refute apple_feed.valid?
-      apple_feed.audio_format = {f: "flac", b: 16, c: 2, s: 44100}
       assert apple_feed.valid?
     end
 
@@ -105,7 +122,7 @@ describe Feeds::AppleSubscription do
       assert apple_feed.apple_config.valid?
 
       apple_feed.save!
-      assert_equal feed_1, apple_feed.apple_config.public_feed
+      assert_equal default_feed, apple_feed.apple_config.public_feed
     end
   end
 
@@ -113,7 +130,7 @@ describe Feeds::AppleSubscription do
     it "returns true if the feed has apple credentials" do
       apple_feed.save!
 
-      refute feed_1.publish_to_apple?
+      refute default_feed.publish_to_apple?
       assert apple_feed.publish_to_apple?
     end
 
@@ -124,8 +141,8 @@ describe Feeds::AppleSubscription do
     end
 
     it "returns false if the feed is not an Apple Subscription feed" do
-      refute_equal feed_1.type, "Feeds::AppleSubscription"
-      refute feed_1.publish_to_apple?
+      refute_equal default_feed.type, "Feeds::AppleSubscription"
+      refute default_feed.publish_to_apple?
     end
   end
 end

--- a/test/models/feed/apple_subscription_test.rb
+++ b/test/models/feed/apple_subscription_test.rb
@@ -64,7 +64,7 @@ describe Feeds::AppleSubscription do
       create(:episode, podcast: podcast, contents: [c3])
 
       assert_nil default_feed.audio_format
-      assert_equal ({f: "mp3", b: 192, c: 2, s: 44100}).with_indifferent_access, apple_feed.guess_audio_format
+      assert_equal ({"f" => "mp3", "b" => 192, "c" => 2, "s" => 44100}), apple_feed.guess_audio_format
     end
 
     it "falls back to the default format" do


### PR DESCRIPTION
Turns out, Apple relaxed their requirements for paid subscribers.

This adds a utility `.guess_audio_format` to check the default_feed and episodes for the highest quality mp3 format they use.

Also closes #1121 .