### PR TITLE
Add duration validation and test

### DIFF
--- a/app/models/uncut.rb
+++ b/app/models/uncut.rb
@@ -1,5 +1,6 @@
 class Uncut < MediaResource
   validates :medium, inclusion: {in: %w[audio]}, if: :status_complete?
+  validates :duration, numericality: {greater_than: 0}, if: :status_complete?
   validate :validate_segmentation
 
   before_validation :set_defaults

--- a/test/models/uncut_test.rb
+++ b/test/models/uncut_test.rb
@@ -24,7 +24,7 @@ describe Uncut do
 
       uncut.segmentation[0] = [0.5, 1]
       uncut.segmentation[2] = [3.5, nil]
-      episode.contents[0].update(status: "complete", medium: "audio")
+      episode.contents[0].update!(status: "complete", medium: "audio", duration: 1)
       uncut.slice_contents
 
       assert_equal 5, episode.contents.size
@@ -48,6 +48,18 @@ describe Uncut do
       refute uncut.valid?
 
       uncut.medium = "audio"
+      assert uncut.valid?
+    end
+
+    it "must have a duration greater than 0 when complete" do
+      assert uncut.valid?
+      assert uncut.status_created?
+
+      uncut.duration = 0
+      uncut.status = "complete"
+      refute uncut.valid?
+
+      uncut.duration = 100
       assert uncut.valid?
     end
   end


### PR DESCRIPTION
resolves #1073 

This PR adds a validation for the `duration` attribute of the `Uncut` model. There was an issue in which Porter somehow returned a nil duration in an `Inspect` task, and caused a bug in the audio segmenter that utilizes the `duration` attribute. Validation and testing was added to the `Uncut` model specifically (instead of `MediaResource` or `Content`) because we want to address the issue in the audio segmenter, and not for any `"video"` media at this time.