### PR TITLE
Extract functional interface

### DIFF
--- a/app/models/apple/api.rb
+++ b/app/models/apple/api.rb
@@ -2,6 +2,8 @@
 
 module Apple
   class Api
+    API_BASE = "https://api.podcastsconnect.apple.com/v1/"
+
     ERROR_RETRIES = 3
     SUCCESS_CODES = [200, 201].freeze
     DEFAULT_BATCH_SIZE = 5
@@ -79,10 +81,6 @@ module Apple
       JWT.encode(jwt_payload, ec_key, "ES256", jwt_headers)
     end
 
-    def api_base
-      "https://api.podcastsconnect.apple.com/v1/"
-    end
-
     def list_shows
       get("shows")
     end
@@ -115,8 +113,12 @@ module Apple
       res.flatten
     end
 
+    def self.join_url(api_frag)
+      URI.join(API_BASE, api_frag)
+    end
+
     def join_url(api_frag)
-      URI.join(api_base, api_frag)
+      self.class.join_url(api_frag)
     end
 
     def local_api_retry_errors(tries: ERROR_RETRIES)

--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -384,16 +384,20 @@ module Apple
     end
 
     def publishing_state_bridge_params(state)
+      self.class.publishing_state_bridge_params(apple_id, state)
+    end
+
+    def self.publishing_state_bridge_params(apple_id, state)
       {
         request_metadata: {
           apple_episode_id: apple_id
         },
-        api_url: api.join_url("episodePublishingRequests").to_s,
-        api_parameters: publishing_state_parameters(state)
+        api_url: Apple::Api.join_url("episodePublishingRequests").to_s,
+        api_parameters: publishing_state_params(apple_id, state)
       }
     end
 
-    def publishing_state_parameters(state)
+    def self.publishing_state_params(apple_id, state)
       {
         data: {
           type: "episodePublishingRequests",
@@ -410,6 +414,10 @@ module Apple
           }
         }
       }
+    end
+
+    def publishing_state_parameters(state)
+      self.class.publishing_state_params(apple_id, state)
     end
 
     def apple?


### PR DESCRIPTION
Switches some helper methods to class methods, so it's easier to interact with the Apple::Episode episode state transitions.