### PR TITLE
Fix/ready transcripts

### DIFF
--- a/app/models/episode.rb
+++ b/app/models/episode.rb
@@ -365,7 +365,7 @@ class Episode < ApplicationRecord
     end
   end
 
-  def transcript?
-    transcript.present?
+  def ready_transcript
+    transcript if transcript&.status_complete?
   end
 end

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -114,4 +114,10 @@ class Transcript < ApplicationRecord
   def _retry=(_val)
     retry!
   end
+
+  # mime type required for rss - not necessarily the Porter detected mime_type we store
+  # https://github.com/Podcastindex-org/podcast-namespace/blob/main/docs/1.0.md#attributes
+  def rss_mime_type
+    MIME_TYPES[format&.to_sym]
+  end
 end

--- a/app/models/transcript.rb
+++ b/app/models/transcript.rb
@@ -1,11 +1,13 @@
 class Transcript < ApplicationRecord
   FORMATS = {
+    text: "text",
     html: "html",
     json: "json",
     vtt: "vtt",
     srt: "srt"
   }
   MIME_TYPES = {
+    text: "text/plain",
     html: "text/html",
     json: "application/json",
     vtt: "text/vtt",
@@ -28,7 +30,7 @@ class Transcript < ApplicationRecord
   validates :format, presence: true
 
   enum :status, [:started, :created, :processing, :complete, :error, :retrying, :cancelled, :invalid], prefix: true
-  enum :format, FORMATS, prefix: true, default: :json
+  enum :format, FORMATS, prefix: true, default: :text
 
   def published_url
     "#{episode.base_published_url}/#{transcript_path}"

--- a/app/views/episode_transcripts/transcripts/_new.html.erb
+++ b/app/views/episode_transcripts/transcripts/_new.html.erb
@@ -11,7 +11,7 @@
       <% data[:unsaved_target] = "changed" if transcript.marked_for_destruction? %>
 
       <%# NOTE: name is nil, so we don't submit the actual file to Rails %>
-      <%= form.file_field :transcript_file, class: cls, accept: ".html,.json,.srt,.vtt", name: nil, data: data %>
+      <%= form.file_field :transcript_file, class: cls, accept: ".txt,.html,.json,.srt,.vtt", name: nil, data: data %>
 
       <%# fake display field; real text area is opacity-0 on top of it %>
       <% invalid_msg = upload_invalid_messages(transcript) %>

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -159,10 +159,10 @@ xml.rss "xmlns:atom" => "http://www.w3.org/2005/Atom",
               url: ep.enclosure_url(@feed))
           end
 
-          if ep.transcript?
+          if ep.ready_transcript
             xml.podcast(:transcript,
-              type: Transcript::MIME_TYPES[ep.transcript.format.to_sym],
-              url: ep.transcript.url)
+              type: ep.ready_transcript.rss_mime_type,
+              url: ep.ready_transcript.url)
           end
 
           xml.content(:encoded) { xml.cdata!(episode_description(ep)) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -496,6 +496,7 @@ en:
         embed_player_iframe: Embeddable Player IFrame
       transcript:
         formats:
+          text: Plain Text
           html: HTML
           json: JSON
           vtt: WebVTT

--- a/test/models/episode_test.rb
+++ b/test/models/episode_test.rb
@@ -476,4 +476,21 @@ describe Episode do
       assert episode.apple_needs_delivery?
     end
   end
+
+  describe "#ready_transcript" do
+    let(:episode) { build_stubbed(:episode) }
+
+    it "checks for a complete transcript" do
+      assert_nil episode.ready_transcript
+
+      episode.build_transcript(status: "processing")
+      assert_nil episode.ready_transcript
+
+      episode.transcript.status = "invalid"
+      assert_nil episode.ready_transcript
+
+      episode.transcript.status = "complete"
+      refute_nil episode.ready_transcript
+    end
+  end
 end

--- a/test/models/transcript_test.rb
+++ b/test/models/transcript_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 describe Transcript do
-  let(:episode) { create(:episode) }
+  let(:episode) { build_stubbed(:episode) }
   let(:url) { "http://sample/url/transcript.html" }
   let(:transcript) { build_stubbed(:transcript, episode: episode) }
 
@@ -59,6 +59,23 @@ describe Transcript do
       transcript.copy_media
 
       assert_equal task, transcript.task
+    end
+  end
+
+  describe "rss_mime_type" do
+    it "returns the mime type for the transcript format" do
+      assert_equal "text/html", transcript.rss_mime_type
+
+      transcript.format = "json"
+      assert_equal "application/json", transcript.rss_mime_type
+
+      transcript.format = nil
+      assert_nil transcript.rss_mime_type
+
+      # pretend bad data got into the db somehow
+      transcript.stub(:format, "whatev") do
+        assert_nil transcript.rss_mime_type
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #1126.  Fixes #1127.

Encountered an invalid transcript in prod (an uploaded mp3), which was getting rendered into the RSS.

This copies the "ready_media" / "ready_image" pattern to a new `ready_transcript` method.

Also adds text file support, and makes that the default.  The spec is kind of ambiguous if text is supported, but we have users uploading text, so may as well allow it.