### PR TITLE
Integrations interface

### DIFF
--- a/app/models/apple/episode.rb
+++ b/app/models/apple/episode.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Apple
-  class Episode
+  class Episode < Integrations::Base::Episode
     include Apple::ApiWaiting
     include Apple::ApiResponse
     attr_accessor :show,
@@ -219,6 +219,14 @@ module Apple
       @show = show
       @feeder_episode = feeder_episode
       @api = api || Apple::Api.from_env
+    end
+
+    def synced_with_integration?
+      synced_with_apple?
+    end
+
+    def integration_new?
+      apple_new?
     end
 
     def api_response

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Apple
-  class Publisher
+  class Publisher < Integrations::Base::Publisher
     PUBLISH_CHUNK_LEN = 25
 
     attr_reader :public_feed,
@@ -33,52 +33,6 @@ module Apple
 
     def podcast
       public_feed.podcast
-    end
-
-    def filter_episodes_to_sync(eps)
-      # Reject episodes if the audio is marked as uploaded/complete
-      # or if the episode is a video
-      eps
-        .reject(&:synced_with_apple?)
-        .reject(&:video_content_type?)
-    end
-
-    def episodes_to_sync
-      # only look at the private delegated delivery feed
-      filter_episodes_to_sync(show.apple_private_feed_episodes)
-    end
-
-    def filter_episodes_to_archive(eps)
-      eps_in_private_feed = Set.new(show.apple_private_feed_episodes)
-
-      # Episodes to archive can include:
-      # - episodes that are now excluded from the feed
-      # - episodes that are deleted or unpublished
-      # - episodes that have fallen off the end of the feed (Feed#display_episodes_count)
-      eps
-        .reject { |ep| eps_in_private_feed.include?(ep) }
-        .reject(&:apple_new?)
-        .reject(&:archived?)
-    end
-
-    def episodes_to_archive
-      # look at the global list of episodes, not just the private feed
-      filter_episodes_to_archive(show.podcast_episodes)
-    end
-
-    def filter_episodes_to_unarchive(eps)
-      eps.filter(&:archived?)
-    end
-
-    def episodes_to_unarchive
-      # only look at the private delegated delivery feed
-      filter_episodes_to_unarchive(show.apple_private_feed_episodes)
-    end
-
-    def only_episodes_with_apple_state(eps)
-      # Only select episodes that have an remote apple state,
-      # as determined by the sync log
-      eps.reject(&:apple_new?)
     end
 
     def poll_all_episodes!

--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Apple
-  class Show
+  class Show < Integrations::Base::Show
     include Apple::ApiResponse
 
     attr_reader :public_feed,
@@ -165,55 +165,8 @@ module Apple
       self.class.get_show(api, apple_id)
     end
 
-    # In the case where there are duplicate guids in the feeds, we want to make
-    # sure that the most "current" episode is the one that maps to the remote state.
-    def sort_by_episode_properties(eps)
-      # Sort the episodes by:
-      # 1. Non-deleted episodes first
-      # 2. Published episodes first
-      # 3. Published date most recent first
-      # 4. Created date most recent first
-      eps =
-        eps.sort_by do |e|
-          [
-            e.deleted_at.nil? ? 1 : -1,
-            e.published_at.present? ? 1 : -1,
-            e.published_at || e.created_at,
-            e.created_at
-          ]
-        end
-
-      # return sorted list, reversed
-      # modeling a priority queue -- most important first
-      eps.reverse
-    end
-
-    def podcast_feeder_episodes
-      @podcast_feeder_episodes ||=
-        podcast.episodes
-          .reset
-          .with_deleted
-          .group_by(&:item_guid)
-          .values
-          .map { |eps| sort_by_episode_properties(eps) }
-          .map(&:first)
-    end
-
-    # All the episodes -- including deleted and unpublished
-    def podcast_episodes
-      @podcast_episodes ||= podcast_feeder_episodes.map { |e| Apple::Episode.new(api: api, show: self, feeder_episode: e) }
-    end
-
-    # Does not include deleted episodes
-    def episodes
-      raise "Missing apple show id" unless apple_id.present?
-
-      @episodes ||= begin
-        feed_episode_ids = Set.new(private_feed.feed_episodes.feed_ready.map(&:id))
-
-        podcast_episodes
-          .filter { |e| feed_episode_ids.include?(e.feeder_episode.id) }
-      end
+    def build_integration_episode(feeder_episode)
+      Apple::Episode.new(api: api, show: self, feeder_episode: feeder_episode)
     end
 
     def apple_private_feed_episodes

--- a/app/models/integrations/base/episode.rb
+++ b/app/models/integrations/base/episode.rb
@@ -1,0 +1,40 @@
+module Integrations
+  module Base
+    class Episode
+      attr_reader :feeder_episode
+
+      def initialize(feeder_episode)
+        @feeder_episode = feeder_episode
+      end
+
+      def synced_with_integration?
+        raise NotImplementedError, "Subclasses must implement synced_with_integration?"
+      end
+
+      def integration_new?
+        raise NotImplementedError, "Subclasses must implement integration_new?"
+      end
+
+      def archived?
+        raise NotImplementedError, "Subclasses must implement archived?"
+      end
+
+      def video_content_type?
+        feeder_episode.video_content_type?
+      end
+
+      # Delegate methods to feeder_episode
+      def method_missing(method_name, *arguments, &block)
+        if feeder_episode.respond_to?(method_name)
+          feeder_episode.send(method_name, *arguments, &block)
+        else
+          super
+        end
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        feeder_episode.respond_to?(method_name) || super
+      end
+    end
+  end
+end

--- a/app/models/integrations/base/episode_set_operations.rb
+++ b/app/models/integrations/base/episode_set_operations.rb
@@ -1,0 +1,56 @@
+module Integrations
+  module Base
+    module EpisodeSetOperations
+      # In the case where there are duplicate guids in the feeds, we want to make
+      # sure that the most "current" episode is the one that maps to the remote state.
+      def sort_by_episode_properties(eps)
+        # Sort the episodes by:
+        # 1. Non-deleted episodes first
+        # 2. Published episodes first
+        # 3. Published date most recent first
+        # 4. Created date most recent first
+        eps =
+          eps.sort_by do |e|
+            [
+              e.deleted_at.nil? ? 1 : -1,
+              e.published_at.present? ? 1 : -1,
+              e.published_at || e.created_at,
+              e.created_at
+            ]
+          end
+
+        # return sorted list, reversed
+        # modeling a priority queue -- most important first
+        eps.reverse
+      end
+
+      def filter_episodes_to_sync(eps)
+        # Reject episodes if the audio is marked as uploaded/complete
+        # or if the episode is a video
+        eps
+          .reject(&:synced_with_integration?)
+          .reject(&:video_content_type?)
+      end
+
+      def filter_episodes_to_archive(eps, eps_in_feed)
+        # Episodes to archive can include:
+        # - episodes that are now excluded from the feed
+        # - episodes that are deleted or unpublished
+        # - episodes that have fallen off the end of the feed (Feed#display_episodes_count)
+        eps
+          .reject { |ep| eps_in_feed.include?(ep) }
+          .reject(&:integration_new?)
+          .reject(&:archived?)
+      end
+
+      def filter_episodes_to_unarchive(eps)
+        eps.filter(&:archived?)
+      end
+
+      # Only select episodes that have an remote integration state
+      def only_episodes_with_integration_state(eps)
+        eps.reject(&:integration_new?)
+      end
+    end
+  end
+end

--- a/app/models/integrations/base/publisher.rb
+++ b/app/models/integrations/base/publisher.rb
@@ -1,0 +1,29 @@
+module Integrations
+  module Base
+    class Publisher
+      include EpisodeSetOperations
+
+      attr_reader :show
+
+      def initialize(show:)
+        @show = show
+      end
+
+      def episodes_to_sync
+        filter_episodes_to_sync(show.episodes)
+      end
+
+      def episodes_to_archive
+        filter_episodes_to_archive(show.podcast_episodes, Set.new(show.episodes))
+      end
+
+      def episodes_to_unarchive
+        filter_episodes_to_unarchive(show.episodes)
+      end
+
+      def publish!
+        raise NotImplementedError, "Subclasses must implement publish!"
+      end
+    end
+  end
+end

--- a/app/models/integrations/base/show.rb
+++ b/app/models/integrations/base/show.rb
@@ -1,0 +1,50 @@
+module Integrations
+  module Base
+    class Show
+      include EpisodeSetOperations
+
+      attr_reader :feed
+
+      def initialize(public_feed:, private_feed:)
+        @public_feed = public_feed
+        @private_feed = private_feed
+      end
+
+      def podcast
+        private_feed.podcast
+      end
+
+      def podcast_feeder_episodes
+        @podcast_feeder_episodes ||=
+          podcast.episodes
+            .reset
+            .with_deleted
+            .group_by(&:item_guid)
+            .values
+            .map { |eps| sort_by_episode_properties(eps) }
+            .map(&:first)
+      end
+
+      # All the episodes -- including deleted and unpublished
+      def podcast_episodes
+        @podcast_episodes ||= podcast_feeder_episodes.map { |e| build_integration_episode(e) }
+      end
+
+      # Does not include deleted episodes
+      def episodes
+        @episodes ||= begin
+          feed_episode_ids = Set.new(private_feed.feed_episodes.feed_ready.map(&:id))
+
+          podcast_episodes
+            .filter { |e| feed_episode_ids.include?(e.feeder_episode.id) }
+        end
+      end
+
+      private
+
+      def build_integration_episode(feeder_episode)
+        raise NotImplementedError, "Subclasses must implement create_integration_episode"
+      end
+    end
+  end
+end

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -38,10 +38,10 @@ describe Apple::Publisher do
 
     it "should only return episodes that have an apple state" do
       episode.stub(:apple_new?, true) do
-        assert_equal apple_publisher.only_episodes_with_apple_state([episode]), []
+        assert_equal apple_publisher.only_episodes_with_integration_state([episode]), []
       end
       episode.stub(:apple_new?, false) do
-        assert_equal apple_publisher.only_episodes_with_apple_state([episode]), [episode]
+        assert_equal apple_publisher.only_episodes_with_integration_state([episode]), [episode]
       end
     end
   end


### PR DESCRIPTION
Sets up a new interface that hopes to bring coupling across integration interfaces.  This focuses on two major points of contact:

1) The set operations on the episodes, addresses episodes that are rolling through their CRUD lifecycle
2) The relationship between feeds and the integration. The approach here is to use the same pattern as the Delegated Delivery integration and focus on the private+default feeds