### PR TITLE
API endpoints for old CMS data

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -52,6 +52,11 @@ class Api::EpisodesController < Api::BaseController
       raise HalApi::Errors::NotFound.new if resource.nil?
 
       @episode = resource
+    elsif params[:story_id]
+      resource = Episode.find_by(prx_uri: "/api/v1/stories/#{params[:story_id]}")
+      raise HalApi::Errors::NotFound.new if resource.nil?
+
+      @episode = resource
     end
 
     super

--- a/app/controllers/api/podcasts_controller.rb
+++ b/app/controllers/api/podcasts_controller.rb
@@ -43,6 +43,17 @@ class Api::PodcastsController < Api::BaseController
 
   private
 
+  def show_resource
+    if params[:series_id]
+      resource = Podcast.find_by(prx_uri: "/api/v1/series/#{params[:series_id]}")
+      raise HalApi::Errors::NotFound.new if resource.nil?
+
+      @podcast = resource
+    end
+
+    super
+  end
+
   def find_base
     super.with_deleted
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,9 @@ Rails.application.routes.draw do
       resources :episodes, except: [:new, :edit]
       resources :feeds, only: [:index]
 
+      get "comatose/series/:series_id", to: "podcasts#show"
+      get "comatose/stories/:story_id", to: "episodes#show"
+
       root to: "base#entrypoint"
       match "*any", via: [:options], to: "base#options"
 


### PR DESCRIPTION
Adds endpoints to lookup by `prx_uri`:

```
/api/v1/comatose/series/1234
/api/v1/comatose/stories/5678
```