### PR TITLE
Retry on error_apple non-terminal error

### DIFF
--- a/app/models/publishing_pipeline_state.rb
+++ b/app/models/publishing_pipeline_state.rb
@@ -19,7 +19,7 @@ class PublishingPipelineState < ApplicationRecord
   scope :latest_failed_pipelines, -> {
                                     # Grab the latest attempted Publishing Item AND the latest failed Pub Item.
                                     # If that is a non-null intersection, then we have a current/latest+failed pipeline.
-                                    where(publishing_queue_item_id: PublishingQueueItem.latest_attempted.latest_failed.order(id: :asc).select(:id))
+                                    where(publishing_queue_item_id: PublishingQueueItem.latest_attempted.latest_failed.select(:id))
                                   }
 
   scope :latest_by_queue_item, -> {

--- a/app/models/publishing_pipeline_state.rb
+++ b/app/models/publishing_pipeline_state.rb
@@ -19,7 +19,7 @@ class PublishingPipelineState < ApplicationRecord
   scope :latest_failed_pipelines, -> {
                                     # Grab the latest attempted Publishing Item AND the latest failed Pub Item.
                                     # If that is a non-null intersection, then we have a current/latest+failed pipeline.
-                                    where(publishing_queue_item_id: PublishingQueueItem.latest_attempted.latest_failed.select(:id))
+                                    where(publishing_queue_item_id: PublishingQueueItem.latest_attempted.latest_failed.order(id: :asc).select(:id))
                                   }
 
   scope :latest_by_queue_item, -> {

--- a/app/models/publishing_pipeline_state.rb
+++ b/app/models/publishing_pipeline_state.rb
@@ -1,6 +1,6 @@
 class PublishingPipelineState < ApplicationRecord
   TERMINAL_STATUSES = [:complete, :error, :expired].freeze
-  TERMINAL_FAILURE_STATUSES = [:error, :expired].freeze
+  FAILURE_STATUSES = [:error, :expired, :error_apple].freeze
   UNIQUE_STATUSES = TERMINAL_STATUSES + [:created, :started]
 
   # Handle the max timout for a publishing pipeline: Pub RSS job + Pub Apple job + a few extra minutes of flight
@@ -173,8 +173,16 @@ class PublishingPipelineState < ApplicationRecord
     end
   end
 
+  def self.latest_failed_publishing_queue_items
+    PublishingQueueItem.where(id: latest_failed_pipelines.select(:publishing_queue_item_id).distinct)
+  end
+
+  def self.latest_failed_podcasts
+    Podcast.where(id: latest_failed_publishing_queue_items.select(:podcast_id).distinct)
+  end
+
   def self.retry_failed_pipelines!
-    Podcast.where(id: latest_failed_pipelines.select(:podcast_id).distinct).each do |podcast|
+    latest_failed_podcasts.each do |podcast|
       Rails.logger.tagged("PublishingPipeLineState.retry_failed_pipelines!", "Podcast:#{podcast.id}") do
         start_pipeline!(podcast)
       end

--- a/app/models/publishing_queue_item.rb
+++ b/app/models/publishing_queue_item.rb
@@ -8,7 +8,7 @@ class PublishingQueueItem < ApplicationRecord
                             latest_by_status(PublishingPipelineState::TERMINAL_STATUSES)
                           }
   scope :latest_failed, -> {
-                          latest_by_status(PublishingPipelineState::TERMINAL_FAILURE_STATUSES)
+                          latest_by_status(PublishingPipelineState::FAILURE_STATUSES)
                         }
 
   scope :latest_by_status, ->(status) {

--- a/test/models/publishing_pipeline_state_test.rb
+++ b/test/models/publishing_pipeline_state_test.rb
@@ -196,7 +196,7 @@ describe PublishingPipelineState do
 
       # Verify that the intermediate error is included in the latest failed pipelines
       assert_equal [podcast], PublishingPipelineState.latest_failed_podcasts
-      assert_equal ["created", "error_apple", "complete"], PublishingPipelineState.latest_failed_pipelines.where(podcast: podcast).map(&:status)
+      assert_equal ["created", "error_apple", "complete"], PublishingPipelineState.latest_failed_pipelines.where(podcast: podcast).order(id: :asc).map(&:status)
 
       # Create another publishing queue item and associated pipeline state
       pqi2 = PublishingQueueItem.ensure_queued!(podcast)

--- a/test/models/publishing_queue_item_test.rb
+++ b/test/models/publishing_queue_item_test.rb
@@ -94,6 +94,20 @@ describe PublishingQueueItem do
       assert_equal [pqi1].sort, PublishingQueueItem.latest_failed.where(podcast: podcast)
       assert_equal [].sort, PublishingQueueItem.latest_attempted.latest_failed.where(podcast: podcast)
     end
+
+    it "includes intermediate states like error_apple" do
+      pqi1 = PublishingPipelineState.create!(podcast: podcast, publishing_queue_item: PublishingQueueItem.create!(podcast: podcast)).publishing_queue_item
+      PublishingPipelineState.error_apple!(podcast)
+
+      assert_equal [pqi1].sort, PublishingQueueItem.latest_failed.where(podcast: podcast)
+      assert_equal [pqi1].sort, PublishingQueueItem.latest_attempted.latest_failed.where(podcast: podcast)
+      assert_equal [podcast], PublishingPipeLineState.latest_failed_podcasts
+
+      _pqi2 = PublishingPipelineState.create!(podcast: podcast, publishing_queue_item: PublishingQueueItem.create!(podcast: podcast)).publishing_queue_item
+
+      assert_equal [pqi1].sort, PublishingQueueItem.latest_failed.where(podcast: podcast)
+      assert_equal [].sort, PublishingQueueItem.latest_attempted.latest_failed.where(podcast: podcast)
+    end
   end
 
   describe ".all_unfinished_items" do

--- a/test/models/publishing_queue_item_test.rb
+++ b/test/models/publishing_queue_item_test.rb
@@ -101,7 +101,7 @@ describe PublishingQueueItem do
 
       assert_equal [pqi1].sort, PublishingQueueItem.latest_failed.where(podcast: podcast)
       assert_equal [pqi1].sort, PublishingQueueItem.latest_attempted.latest_failed.where(podcast: podcast)
-      assert_equal [podcast], PublishingPipeLineState.latest_failed_podcasts
+      assert_equal [podcast], PublishingPipelineState.latest_failed_podcasts
 
       _pqi2 = PublishingPipelineState.create!(podcast: podcast, publishing_queue_item: PublishingQueueItem.create!(podcast: podcast)).publishing_queue_item
 


### PR DESCRIPTION
Closes https://github.com/PRX/feeder.prx.org/issues/1134

This includes the intermediate `error_apple` in the list of retryable error states. Prior to this, we had only considered _terminal_ error states. With this PR, we will retry publishing pipelines having intermediate `error_apple` states and terminal `complete` (success) states.