### PR TITLE
Remove Unused Columns

### DIFF
--- a/app/models/apple/podcast_delivery.rb
+++ b/app/models/apple/podcast_delivery.rb
@@ -73,12 +73,6 @@ module Apple
       end
 
       # Don't create deliveries for containers that already have deliveries.
-      # An alternative workflow would be to swap out the existing delivery and
-      # upload different audio.
-      #
-      # The overall publishing workflow dependes on the assumption that there is
-      # a delivery present. If we don't create a delivery here, we short-circuit
-      # subsequent steps (no uploads, no audio linking).
       episodes = select_episodes_for_delivery(episodes)
       podcast_containers = episodes.map(&:podcast_container)
 

--- a/db/migrate/20241105154932_drop_unused_podcast_container_cols.rb
+++ b/db/migrate/20241105154932_drop_unused_podcast_container_cols.rb
@@ -1,0 +1,8 @@
+class DropUnusedPodcastContainerCols < ActiveRecord::Migration[7.2]
+  def change
+    remove_column :apple_podcast_containers, :source_url, :string
+    remove_column :apple_podcast_containers, :source_filename, :string
+    remove_column :apple_podcast_containers, :source_size, :bigint
+    remove_column :apple_podcast_containers, :enclosure_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_02_215949) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_05_154932) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -57,10 +57,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_02_215949) do
     t.datetime "updated_at", null: false
     t.string "vendor_id", null: false
     t.string "apple_episode_id", null: false
-    t.string "source_url"
-    t.string "source_filename"
-    t.bigint "source_size"
-    t.text "enclosure_url"
     t.integer "source_fetch_count", default: 0, null: false
     t.index ["episode_id"], name: "index_apple_podcast_containers_on_episode_id", unique: true
     t.index ["external_id"], name: "index_apple_podcast_containers_on_external_id", unique: true


### PR DESCRIPTION
Removes state columns that were superseded by the Apple::EpisodeDeliveryStatus model (https://github.com/PRX/feeder.prx.org/pull/901)