### PR TITLE
Fix release memoized values

### DIFF
--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -76,6 +76,8 @@ module Apple
       @episodes = nil
       @episode_ids = nil
       @find_episode = nil
+      @apple_id_to_apple_json = nil
+      @guid_to_apple_json = nil
     end
 
     def podcast

--- a/test/models/apple/show_test.rb
+++ b/test/models/apple/show_test.rb
@@ -32,6 +32,8 @@ describe Apple::Show do
       apple_show.instance_variable_set(:@episodes, "foo")
       apple_show.instance_variable_set(:@episode_ids, "foo")
       apple_show.instance_variable_set(:@find_episode, "foo")
+      apple_show.instance_variable_set(:@apple_id_to_apple_json, "foo")
+      apple_show.instance_variable_set(:@guid_to_apple_json, "foo")
       apple_show.reload
       assert_nil apple_show.instance_variable_get(:@apple_episode_json)
       assert_nil apple_show.instance_variable_get(:@podcast_feeder_episodes)
@@ -39,6 +41,8 @@ describe Apple::Show do
       assert_nil apple_show.instance_variable_get(:@episodes)
       assert_nil apple_show.instance_variable_get(:@episode_ids)
       assert_nil apple_show.instance_variable_get(:@find_episode)
+      assert_nil apple_show.instance_variable_get(:@apple_id_to_apple_json)
+      assert_nil apple_show.instance_variable_get(:@guid_to_apple_json)
     end
   end
 
@@ -276,5 +280,32 @@ describe Apple::Show do
         apple_show.feed_published_url
       end
     end
+  end
+
+  describe "#guid_to_apple_json" do
+    it "should memoize the guid_to_apple_json without calling apple_episode_json" do
+      data = {"foo" => "bar"}
+
+      apple_show.instance_variable_set(:@guid_to_apple_json, data)
+
+      mock = Minitest::Mock.new
+      def mock.method_missing(*)
+        raise "apple_episode_json should not have been called!"
+      end
+
+      apple_show.stub(:apple_episode_json, mock) do
+        assert_equal "bar", apple_show.guid_to_apple_json("foo")
+      end
+    end
+
+    it "falls back to apple_episode_json when not memoized" do
+      apple_show.reload
+
+      data = {"attributes" => {"guid" => "foo", "data" => "frob"}}
+      apple_show.stub(:apple_episode_json, [data]) do
+        assert_equal apple_show.guid_to_apple_json("foo"), {"attributes"=>{"guid"=>"foo", "data"=>"frob"}}
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixes the case where the Apple badges can fall out of sync indicating a mismatch between remote and local state.

The Apple::Show does not release some memoized attributes causing the sync routine to ignore newly created episodes and to not poll the newly updated remote state.