### PR TITLE
Feat/subscribe links json

### DIFF
--- a/app/controllers/podcast_engagement_controller.rb
+++ b/app/controllers/podcast_engagement_controller.rb
@@ -11,6 +11,7 @@ class PodcastEngagementController < ApplicationController
     respond_to do |format|
       if @podcast.save
         @podcast.publish!
+        @podcast.copy_subscribe_links
         format.html { redirect_to podcast_engagement_path(@podcast), notice: t(".notice") }
       else
         flash.now[:error] = t(".error")

--- a/app/models/concerns/podcast_subscribe_links.rb
+++ b/app/models/concerns/podcast_subscribe_links.rb
@@ -1,0 +1,42 @@
+require "active_support/concern"
+
+module PodcastSubscribeLinks
+  extend ActiveSupport::Concern
+
+  def build_subscribe_links_json
+    if subscribe_links.present?
+      {
+        version: "1.0.0",
+        links: subscribe_links&.map(&:as_json)
+      }.to_json
+    end
+  end
+
+  def subscribe_links_path
+    "#{base_published_url}/subscribelinks.json"
+  end
+
+  def copy_subscribe_links(options = {})
+    opts = default_options.merge(options)
+    opts[:body] = build_subscribe_links_json
+    opts[:bucket] = ENV["FEEDER_STORAGE_BUCKET"]
+    opts[:key] = "#{path}/subscribelinks.json"
+
+    @put_object = s3_client.put_object(opts)
+  end
+
+  def default_options
+    {
+      content_type: "application/rss+xml; charset=UTF-8",
+      cache_control: "max-age=60"
+    }
+  end
+
+  def s3_client
+    if Rails.env.test? || ENV["AWS_ACCESS_KEY_ID"].present?
+      Aws::S3::Client.new(stub_responses: true)
+    else
+      Aws::S3::Client.new
+    end
+  end
+end

--- a/app/models/concerns/podcast_subscribe_links.rb
+++ b/app/models/concerns/podcast_subscribe_links.rb
@@ -17,12 +17,14 @@ module PodcastSubscribeLinks
   end
 
   def copy_subscribe_links(options = {})
-    opts = default_options.merge(options)
-    opts[:body] = build_subscribe_links_json
-    opts[:bucket] = ENV["FEEDER_STORAGE_BUCKET"]
-    opts[:key] = "#{path}/subscribelinks.json"
+    if subscribe_links.present?
+      opts = default_options.merge(options)
+      opts[:body] = build_subscribe_links_json
+      opts[:bucket] = ENV["FEEDER_STORAGE_BUCKET"]
+      opts[:key] = "#{path}/subscribelinks.json"
 
-    @put_object = s3_client.put_object(opts)
+      @put_object = s3_client.put_object(opts)
+    end
   end
 
   def default_options

--- a/app/models/concerns/podcast_subscribe_links.rb
+++ b/app/models/concerns/podcast_subscribe_links.rb
@@ -29,7 +29,7 @@ module PodcastSubscribeLinks
 
   def default_options
     {
-      content_type: "application/rss+xml; charset=UTF-8",
+      content_type: "application/json; charset=UTF-8",
       cache_control: "max-age=60"
     }
   end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -285,4 +285,35 @@ class Podcast < ApplicationRecord
       }.to_json
     end
   end
+
+  def subscribe_links_path
+    "#{base_published_url}/subscribelinks.json"
+  end
+
+  def copy_subscribe_links(options = {})
+    opts = default_options.merge(options)
+    opts[:body] = build_subscribe_links_json
+    opts[:bucket] = ENV["FEEDER_STORAGE_BUCKET"]
+    opts[:key] = "#{path}/subscribelinks.json"
+
+    @put_object = s3_client.put_object(opts)
+  end
+
+  def default_options
+    {
+      content_type: "application/rss+xml; charset=UTF-8",
+      cache_control: "max-age=60"
+    }
+  end
+
+  def s3_client
+    if Rails.env.test? || ENV["AWS_ACCESS_KEY_ID"].present?
+      Aws::S3::Client.new(
+        credentials: Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"]),
+        region: ENV["AWS_REGION"]
+      )
+    else
+      Aws::S3::Client.new
+    end
+  end
 end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -16,6 +16,7 @@ class Podcast < ApplicationRecord
   include EmbedPlayerHelper
   include PodcastFilters
   include ReleaseEpisodes
+  include PodcastSubscribeLinks
 
   acts_as_paranoid
 
@@ -274,46 +275,6 @@ class Podcast < ApplicationRecord
       true
     else
       super
-    end
-  end
-
-  def build_subscribe_links_json
-    if subscribe_links.present?
-      {
-        version: "1.0.0",
-        links: subscribe_links&.map(&:as_json)
-      }.to_json
-    end
-  end
-
-  def subscribe_links_path
-    "#{base_published_url}/subscribelinks.json"
-  end
-
-  def copy_subscribe_links(options = {})
-    opts = default_options.merge(options)
-    opts[:body] = build_subscribe_links_json
-    opts[:bucket] = ENV["FEEDER_STORAGE_BUCKET"]
-    opts[:key] = "#{path}/subscribelinks.json"
-
-    @put_object = s3_client.put_object(opts)
-  end
-
-  def default_options
-    {
-      content_type: "application/rss+xml; charset=UTF-8",
-      cache_control: "max-age=60"
-    }
-  end
-
-  def s3_client
-    if Rails.env.test? || ENV["AWS_ACCESS_KEY_ID"].present?
-      Aws::S3::Client.new(
-        credentials: Aws::Credentials.new(ENV["AWS_ACCESS_KEY_ID"], ENV["AWS_SECRET_ACCESS_KEY"]),
-        region: ENV["AWS_REGION"]
-      )
-    else
-      Aws::S3::Client.new
     end
   end
 end

--- a/app/models/podcast.rb
+++ b/app/models/podcast.rb
@@ -281,19 +281,8 @@ class Podcast < ApplicationRecord
     if subscribe_links.present?
       {
         version: "1.0.0",
-        links: subscribe_link_data
+        links: subscribe_links&.map(&:as_json)
       }.to_json
-    end
-  end
-
-  def subscribe_link_data
-    if subscribe_links.present?
-      subscribe_links.map do |slink|
-        {
-          href: slink.href,
-          text: I18n.t("helpers.label.podcast.subscribe_link.#{slink.platform}")
-        }
-      end
     end
   end
 end

--- a/app/models/subscribe_link.rb
+++ b/app/models/subscribe_link.rb
@@ -130,4 +130,11 @@ class SubscribeLink < ApplicationRecord
   def bin_to_hex(str)
     str.each_byte.map { |b| b.to_s(16) }.join
   end
+
+  def as_json
+    {
+      href: href,
+      text: I18n.t("helpers.label.podcast.subscribe_link.#{platform}")
+    }
+  end
 end

--- a/app/views/podcasts/show.rss.builder
+++ b/app/views/podcasts/show.rss.builder
@@ -106,6 +106,10 @@ xml.rss "xmlns:atom" => "http://www.w3.org/2005/Atom",
       xml.podcast :guid, @podcast.guid
     end
 
+    if @podcast.subscribe_links.present?
+      xml.podcast :follow, url: @podcast.subscribe_links_path
+    end
+
     @episodes.each_with_index do |ep, index|
       xml.item do
         xml.guid(ep.item_guid, isPermaLink: !!ep.is_perma_link)

--- a/test/models/concerns/podcast_subscribe_links_test.rb
+++ b/test/models/concerns/podcast_subscribe_links_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class PodcastSubscribeLinksTest < ActiveSupport::TestCase
+  let(:podcast) { create(:podcast) }
+  let(:podcast_2) { create(:podcast) }
+  let(:apple_link) { SubscribeLink.create(platform: "apple", podcast: podcast, external_id: "12345") }
+
+  before do
+    assert apple_link
+  end
+
+  describe ".build_subscribe_links_json" do
+    it "builds a json only if links are present" do
+      refute_nil podcast.build_subscribe_links_json
+      assert_nil podcast_2.build_subscribe_links_json
+    end
+  end
+
+  describe ".copy_subscribe_links" do
+    it "saves only if links are present" do
+      refute_nil podcast.copy_subscribe_links
+      assert_nil podcast_2.copy_subscribe_links
+    end
+  end
+end

--- a/test/models/concerns/podcast_subscribe_links_test.rb
+++ b/test/models/concerns/podcast_subscribe_links_test.rb
@@ -9,14 +9,14 @@ class PodcastSubscribeLinksTest < ActiveSupport::TestCase
     assert apple_link
   end
 
-  describe ".build_subscribe_links_json" do
+  describe "#build_subscribe_links_json" do
     it "builds a json only if links are present" do
       refute_nil podcast.build_subscribe_links_json
       assert_nil podcast_2.build_subscribe_links_json
     end
   end
 
-  describe ".copy_subscribe_links" do
+  describe "#copy_subscribe_links" do
     it "saves only if links are present" do
       refute_nil podcast.copy_subscribe_links
       assert_nil podcast_2.copy_subscribe_links

--- a/test/models/subscribe_link_test.rb
+++ b/test/models/subscribe_link_test.rb
@@ -1,8 +1,12 @@
 require "test_helper"
 
 describe SubscribeLink do
-  let(:podcast) { create(:podcast) }
+  let(:podcast) { create(:podcast, guid: "abcdefghij") }
   let(:apple_link) { SubscribeLink.create(platform: "apple", podcast: podcast, external_id: "12345") }
+  let(:unique_link) { SubscribeLink.create(platform: "spotify", podcast: podcast, external_id: "99999") }
+  let(:feed_link) { SubscribeLink.create(platform: "antenna", podcast: podcast, external_id: podcast.public_url) }
+  let(:guid_link) { SubscribeLink.create(platform: "castamatic", podcast: podcast, external_id: podcast.guid) }
+  let(:podindex_link) { SubscribeLink.create(platform: "fountain", podcast: podcast, external_id: "5678") }
 
   describe "#valid?" do
     it "requires a currently supported platform" do
@@ -26,6 +30,43 @@ describe SubscribeLink do
       apple_2 = SubscribeLink.create(platform: "apple", podcast: podcast, external_id: "12345")
       assert apple_link.valid?
       refute apple_2.valid?
+    end
+  end
+
+  describe ".href" do
+    it "substitutes appleID variable using the external id for apple platforms" do
+      assert_equal apple_link.href, "https://podcasts.apple.com/podcast/id12345"
+    end
+
+    it "substitutes uniquePlatformID variable using the external id for unique platforms" do
+      assert_equal unique_link.href, "https://open.spotify.com/99999"
+    end
+
+    it "substitutes feedURL variable using the external id for feed platforms, and encodes it as necessary" do
+      assert_equal feed_link.href, "https://antennapod.org/deeplink/subscribe?url=http://feeds.feedburner.com/thornmorris"
+
+      base64_link = SubscribeLink.create(platform: "youtube_feed", podcast: podcast, external_id: podcast.public_url)
+      assert_equal base64_link.href, "https://music.youtube.com/library/podcasts?addrssfeed=#{Base64.encode64("http://feeds.feedburner.com/thornmorris")}"
+
+      encodeuri_link = SubscribeLink.create(platform: "breez", podcast: podcast, external_id: podcast.public_url)
+      assert_equal encodeuri_link.href, "https://breez.link/p?feedURL=#{CGI.escape("http://feeds.feedburner.com/thornmorris")}"
+
+      hex_link = SubscribeLink.create(platform: "podguru_feed", podcast: podcast, external_id: podcast.public_url)
+      assert_equal hex_link.href, "https://app.podcastguru.io/podcast/X#{hex_link.bin_to_hex("http://feeds.feedburner.com/thornmorris")}"
+    end
+
+    it "substitutes podcastGUID variable using the external id for guid platforms" do
+      assert_equal guid_link.href, "https://castamatic.com/guid/abcdefghij"
+    end
+
+    it "substitutes podcastIndexShowID variable using the external id for pod index platforms" do
+      assert_equal podindex_link.href, "https://fountain.fm/show/5678"
+    end
+  end
+
+  describe ".as_json" do
+    it "returns a hash including an href and the text of the platform" do
+      assert_equal apple_link.as_json, {href: "https://podcasts.apple.com/podcast/id12345", text: "Apple Podcasts"}
     end
   end
 end


### PR DESCRIPTION
resolves #1055 

This PR resolves the Subscribe Links feature by adding the backend components. A podcast's Subscribe Links are converted into a JSON string, uploaded, and a link to that file is saved to the podcast's RSS.