### PR TITLE
Normal font weight for trix editor anchor text

### DIFF
--- a/app/assets/stylesheets/shared/trix-custom.scss
+++ b/app/assets/stylesheets/shared/trix-custom.scss
@@ -9,6 +9,10 @@ trix-toolbar span.trix-button-group--file-tools {
 trix-editor.trix-content {
   border: 1px solid $input-border-color;
 
+  a {
+    font-weight: normal;
+  }
+
   blockquote,
   div,
   h1,


### PR DESCRIPTION
After:
<img width="297" alt="image" src="https://github.com/user-attachments/assets/e40afe13-675a-4418-bd15-4b87524d990b" />
