### PR TITLE
Feat/add first rss publish to episodes

### DIFF
--- a/db/migrate/20250318202734_add_first_rss_published_at_to_episodes.rb
+++ b/db/migrate/20250318202734_add_first_rss_published_at_to_episodes.rb
@@ -1,0 +1,5 @@
+class AddFirstRssPublishedAtToEpisodes < ActiveRecord::Migration[7.2]
+  def change
+    add_column :episodes, :first_rss_published_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_20_170043) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_18_202734) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -163,6 +163,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_20_170043) do
     t.string "categories", array: true
     t.string "enclosure_override_url"
     t.boolean "enclosure_override_prefix"
+    t.datetime "first_rss_published_at", precision: nil
     t.index ["categories"], name: "index_episodes_on_categories", using: :gin
     t.index ["guid"], name: "index_episodes_on_guid", unique: true
     t.index ["keyword_xid"], name: "index_episodes_on_keyword_xid", unique: true


### PR DESCRIPTION
This PR addresses the first task on #1154 , which is to record a timestamp when an episode is published to the default feed rss for the first time.