### PR TITLE
Fixes from testing megaphone in staging

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -85,6 +85,10 @@ class Feed < ApplicationRecord
     false
   end
 
+  def serve_drafts
+    false
+  end
+
   def publish_integration!
   end
 

--- a/app/models/feeds/megaphone_feed.rb
+++ b/app/models/feeds/megaphone_feed.rb
@@ -41,6 +41,10 @@ class Feeds::MegaphoneFeed < Feed
     super
   end
 
+  def serve_drafts
+    publish_integration?
+  end
+
   def publish_integration?
     publish_to_megaphone?
   end

--- a/app/models/megaphone/podcast.rb
+++ b/app/models/megaphone/podcast.rb
@@ -54,7 +54,7 @@ module Megaphone
       podcast = feed.podcast
       itunes_categories = feed.itunes_categories.present? ? feed.itunes_categories : podcast.itunes_categories
       {
-        title: feed.title || podcast.title,
+        title: podcast.title,
         subtitle: feed.subtitle || podcast.subtitle,
         summary: feed.description || podcast.description,
         itunes_categories: (itunes_categories || []).map(&:name),

--- a/app/representers/api/auth/feed_representer.rb
+++ b/app/representers/api/auth/feed_representer.rb
@@ -20,6 +20,7 @@ class Api::Auth::FeedRepresenter < Api::BaseRepresenter
   property :audio_format
   property :include_podcast_value
   property :include_donation_url
+  property :serve_drafts
 
   property :feed_image, decorator: Api::ImageRepresenter, class: FeedImage
   property :itunes_image, decorator: Api::ImageRepresenter, class: ITunesImage

--- a/test/models/megaphone/podcast_test.rb
+++ b/test/models/megaphone/podcast_test.rb
@@ -9,7 +9,7 @@ describe Megaphone::Podcast do
       podcast = Megaphone::Podcast.new_from_feed(feed)
       assert_not_nil podcast
       assert_not_nil podcast.config
-      assert_equal podcast.title, feed.title
+      assert_equal podcast.title, dt_podcast.title
       assert podcast.valid?
     end
   end

--- a/test/representers/api/auth/feed_representer_test.rb
+++ b/test/representers/api/auth/feed_representer_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 describe Api::Auth::FeedRepresenter do
   let(:podcast) { create(:podcast) }
   let(:feed) { create(:feed, podcast: podcast) }
+  let(:megaphone_feed) { create(:megaphone_feed, podcast: podcast) }
   let(:representer) { Api::Auth::FeedRepresenter.new(feed) }
   let(:json) { JSON.parse(representer.to_json) }
 
@@ -31,5 +32,12 @@ describe Api::Auth::FeedRepresenter do
     # API should always return the latest image of any status
     _(json["feedImage"]["altText"]).must_equal "d1"
     _(json["itunesImage"]["altText"]).must_equal "d3"
+  end
+
+  it "allows draft audio for megaphone feeds only" do
+    _(json["serveDrafts"]).must_equal false
+
+    mp_json = JSON.parse(Api::Auth::FeedRepresenter.new(megaphone_feed).to_json)
+    _(mp_json["serveDrafts"]).must_equal true
   end
 end


### PR DESCRIPTION
- [x] Support serveDrafts on auth feeds API
- [x] Podcast title for Megaphone podcast (not feed title)
- [x] Override attributes on update, prevent summary from repeating ad choices
- [x] Don't set pre_offset post_offset, sending as nil throws a 500 from MP API
- [x] Faraday responses have recursive attributes, only log json for headers