### PR TITLE
Fix/mega fixes 2

### DIFF
--- a/app/models/megaphone/publisher.rb
+++ b/app/models/megaphone/publisher.rb
@@ -53,7 +53,7 @@ module Megaphone
       # if after all those checks, still incomplete? throw an error
       if episodes.size > 0
         msg = "Megaphone::Publisher.check_status_episodes! timed out on: #{episodes.map(&:id)}"
-        Logger.error(msg)
+        Rails.logger.error(msg)
         raise msg
       end
     end

--- a/test/models/megaphone/episode_test.rb
+++ b/test/models/megaphone/episode_test.rb
@@ -84,9 +84,14 @@ describe Megaphone::Episode do
 
       assert_equal arrangement_url, episode.background_audio_file_url
       assert media_episode.sync_log(:megaphone).external_id
-      assert media_episode.episode_delivery_status(:megaphone)
+      status = media_episode.episode_delivery_status(:megaphone)
+      assert status
       # we saved the background audio url to mp, so it is uploaded
-      assert media_episode.episode_delivery_status(:megaphone).uploaded
+      assert status.uploaded
+      assert_equal status.source_filename, "audio_#{media_episode.media_version_id}.flac"
+      assert_equal status.source_size, 1000000
+      assert_equal status.source_media_version_id, media_episode.media_version_id
+
       # but we still need to see if it has been fully processed
       refute media_episode.episode_delivery_status(:megaphone).delivered
 
@@ -110,7 +115,8 @@ describe Megaphone::Episode do
         {
           "originalFilename": "#{arrangement_filename}",
           "audioFileProcessing": false,
-          "audioFileStatus": "success"
+          "audioFileStatus": "success",
+          "audioFileUpdatedAt": "#{(DateTime.now + 5.minutes).utc.iso8601}"
         }
       JSON
 


### PR DESCRIPTION
- [x] source atributes weren't getting saved correctly to the delivery status
- [x] source file name can't be used for comparison b/c of how megaphone saves original filename via api
- [x] bad log statement on error in asset checking