### PR TITLE
Manage bad delegated delivery api key warnings

### DIFF
--- a/app/models/apple/asset_state_timeout_error.rb
+++ b/app/models/apple/asset_state_timeout_error.rb
@@ -13,11 +13,11 @@ module Apple
       episodes.map(&:feeder_id)
     end
 
-    def raise_publishing_error?
+    def raise_publishing_error?(*)
       %i[error fatal].include?(log_level)
     end
 
-    def log_level
+    def log_level(*)
       case attempts
       when 0..4
         :warn

--- a/test/models/apple/api_error_test.rb
+++ b/test/models/apple/api_error_test.rb
@@ -11,4 +11,42 @@ describe Apple::ApiError do
       assert_equal exception.message, "message\nHTTP resp code:200\nbody"
     end
   end
+
+  describe ".for_response" do
+    it "returns a regular ApiError for normal errors" do
+      response = OpenStruct.new(code: 404, body: '{"errors":[{"status": "404", "code": "NOT_FOUND"}]}')
+      exception = Apple::ApiError.for_response("Apple API Error", response)
+
+      assert_instance_of Apple::ApiError, exception
+      assert_equal "Apple API Error\nHTTP resp code:404\n{\"errors\":[{\"status\": \"404\", \"code\": \"NOT_FOUND\"}]}", exception.message
+    end
+
+    it "returns an ApiPermissionError for API key permission errors" do
+      permission_error_body = {
+        errors: [
+          {
+            id: "88258fa2-8d8c-46ff-b3a6-80a650ef9ed4",
+            status: "403",
+            code: "FORBIDDEN_ERROR",
+            title: "This request is forbidden for security reasons",
+            detail: "The API key in use does not allow this request"
+          }
+        ]
+      }.to_json
+
+      response = OpenStruct.new(code: 403, body: permission_error_body)
+      exception = Apple::ApiError.for_response("Apple API Error", response)
+
+      assert_instance_of Apple::ApiPermissionError, exception
+      assert exception.message.include?("Apple API permission error")
+    end
+
+    it "handles invalid JSON responses" do
+      response = OpenStruct.new(code: 500, body: "<html>Internal Server Error</html>")
+      exception = Apple::ApiError.for_response("Apple API Error", response)
+
+      assert_instance_of Apple::ApiError, exception
+      assert_equal "Apple API Error\nHTTP resp code:500\n<html>Internal Server Error</html>", exception.message
+    end
+  end
 end

--- a/test/models/publishing_pipeline_state_test.rb
+++ b/test/models/publishing_pipeline_state_test.rb
@@ -339,7 +339,9 @@ describe PublishingPipelineState do
           private_feed.stub(:publish_integration!, ->(*args) { raise Apple::AssetStateTimeoutError.new([episode]) }) do
             podcast.stub(:feeds, [private_feed]) do
               pqi = PublishingQueueItem.ensure_queued!(podcast)
-              PublishingPipelineState.attempt!(podcast, perform_later: false)
+              assert_raises(Apple::RetryPublishingError) do
+                PublishingPipelineState.attempt!(podcast, perform_later: false)
+              end
             end
           end
         end


### PR DESCRIPTION
closes #1193 

This PR handles a new type of error in the publishing flow described in #1193. This authorization error cannot be recovered from automatically, so for now the approach is use the existing ops-errors as a message queue to have support folks help address it with the user. But, we don't want this to swamp the ops-error channel with a never-ending deluge of errors, so a backoff / short-circuit seems appropriate: release a burst of errors and then level off at an error every 8 hours.

The job error semantics follow the AssetTimeoutError. We repeatedly try the publishing routine, but unlike the AssetTimeoutError that counts up and then starts erroring, this will start erroring and exponentially back off.

This also tries to flatten the error handling in the PublishFeedJob, combining and removing duped calls and handlers. 