### PR TITLE
Touches the updated_at timestamp with each sync

### DIFF
--- a/app/models/sync_log.rb
+++ b/app/models/sync_log.rb
@@ -38,7 +38,7 @@ class SyncLog < ApplicationRecord
       feeder_id: feeder_id,
       external_id: external_id
     )
-    sync_log.update!(api_response: api_response)
+    sync_log.update!(api_response: api_response, updated_at: Time.now.utc)
     sync_log
   end
 end

--- a/test/models/sync_log_test.rb
+++ b/test/models/sync_log_test.rb
@@ -37,10 +37,20 @@ describe SyncLog do
 
     it "updates an existing record" do
       s = SyncLog.create!(integration: :apple, feeder_type: :feeds, feeder_id: 123, external_id: 456, api_response: {foo: "bar"})
+
+      # Store the original updated_at
+      original_updated_at = s.updated_at
+
+      # Time travel to simulate passage of time
+      travel 1.minute
+
       assert_no_difference "SyncLog.count" do
         SyncLog.log!(integration: :apple, feeder_type: :feeds, feeder_id: 123, external_id: 456, api_response: {foo: "baz"})
       end
-      assert_equal s.reload.api_response, {foo: "baz"}.as_json
+
+      s.reload
+      assert_equal s.api_response, {foo: "baz"}.as_json
+      assert_not_equal original_updated_at, s.updated_at, "updated_at should be explicitly updated"
     end
   end
 end


### PR DESCRIPTION
Closes [#1212](https://github.com/PRX/feeder.prx.org/issues/1212)

Makes sure that the sync log's timestamp is updated with each "sync" of the remote state. Helpful for debugging.