### PR TITLE
Guard against delivering already delivered episodes

### DIFF
--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -91,8 +91,11 @@ module Apple
             upload_media!(eps)
           end
 
-          process_and_deliver!(eps)
+          eps.filter(&:apple_needs_delivery?).tap do |eps|
+            process_and_deliver!(eps)
+          end
 
+          publish_drafting!(eps)
           raise_delivery_processing_errors(eps)
         end
       end
@@ -128,7 +131,6 @@ module Apple
 
       mark_as_delivered!(eps)
 
-      publish_drafting!(eps)
       reset_asset_wait!(eps)
     end
 


### PR DESCRIPTION
Fixes an issue where an episode is marked drafting async via the podcasts connect API and then is stuck in redelivery because of missing remote podcasts delivery file resources (which are typically pruned after a month).

This PR builds on #1150 by guarding against re-delivery (probing for file processing, waiting on asset state) for episodes that have simply had their drafting status toggled. This leverages the new top level _uploaded_ and _delivered_ state that landed with #1150 (merged via the megaphone branch), and makes sure that for episodes marked uploaded and delivered that no attempt to "re-deliver" is made.