### PR TITLE
Restrict uploads to 1GB

### DIFF
--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -37,6 +37,10 @@ export default class extends Controller {
     if (this.hasNonMp3WarningTarget && file.type !== "audio/mpeg") {
       this.modal = new bootstrap.Modal(this.nonMp3WarningTarget)
       this.modal.show()
+    } else if (file.size >= 1024 * 1024 * 1024) {
+      this.fileNameTargets.forEach((t) => (t.innerHTML = file.name))
+      this.fileSizeTargets.forEach((t) => (t.innerHTML = humanBytes(file.size)))
+      this.onError("File too large - upload less than 1GB")
     } else {
       this.uploadFile(file)
     }

--- a/app/javascript/controllers/upload_controller.js
+++ b/app/javascript/controllers/upload_controller.js
@@ -5,6 +5,7 @@ import sha256 from "sha256"
 import humanBytes from "util/humanBytes"
 
 export default class extends Controller {
+  static values = { fileSizeError: String }
   static outlets = ["disable"]
   static targets = [
     "field",
@@ -40,7 +41,7 @@ export default class extends Controller {
     } else if (file.size >= 1024 * 1024 * 1024) {
       this.fileNameTargets.forEach((t) => (t.innerHTML = file.name))
       this.fileSizeTargets.forEach((t) => (t.innerHTML = humanBytes(file.size)))
-      this.onError("File too large - upload less than 1GB")
+      this.onError(this.fileSizeErrorValue)
     } else {
       this.uploadFile(file)
     }

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -15,7 +15,7 @@ class MediaResource < ApplicationRecord
 
   before_validation :initialize_attributes, on: :create
 
-  validates :file_size, comparison: { less_than: 10000 }
+  validates :file_size, comparison: {less_than: 10000}
   validates :original_url, presence: true
   validates :medium, inclusion: {in: %w[audio video]}, if: :status_complete?
 

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -15,7 +15,7 @@ class MediaResource < ApplicationRecord
 
   before_validation :initialize_attributes, on: :create
 
-  validates :file_size, comparison: {less_than: 10000}
+  validates :file_size, comparison: {less_than: 1.gigabyte}
   validates :original_url, presence: true
   validates :medium, inclusion: {in: %w[audio video]}, if: :status_complete?
 

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -15,7 +15,7 @@ class MediaResource < ApplicationRecord
 
   before_validation :initialize_attributes, on: :create
 
-  validates :file_size, comparison: {less_than: 1.gigabyte}
+  validates :file_size, comparison: {less_than: 1.gigabyte}, allow_nil: true
   validates :original_url, presence: true
   validates :medium, inclusion: {in: %w[audio video]}, if: :status_complete?
 

--- a/app/models/media_resource.rb
+++ b/app/models/media_resource.rb
@@ -15,8 +15,8 @@ class MediaResource < ApplicationRecord
 
   before_validation :initialize_attributes, on: :create
 
+  validates :file_size, comparison: { less_than: 10000 }
   validates :original_url, presence: true
-
   validates :medium, inclusion: {in: %w[audio video]}, if: :status_complete?
 
   after_create :replace_resources!

--- a/app/views/episode_media/media/_new.html.erb
+++ b/app/views/episode_media/media/_new.html.erb
@@ -1,4 +1,8 @@
-<div class="col-12 mb-4" data-controller="upload" data-upload-disable-outlet="form" data-morph="false">
+<div class="col-12 mb-4"
+     data-controller="upload"
+     data-upload-disable-outlet="form"
+     data-upload-file-size-error-value="<%= t("activerecord.errors.models.media_resource.attributes.file_size.less_than") %>"
+     data-morph="false">
 
   <%# step 0: destroying media (will be nulled out if we actually replace it) %>
   <%= form.hidden_field :id, data: {upload_target: "replace"} %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,6 +309,8 @@ en:
               taken: Must be unique
         media_resource:
           attributes:
+            file_size:
+              less_than: File too large - upload less than 1GB
             medium:
               format: "%{message}"
             original_url:


### PR DESCRIPTION
Saw a prod issue where someone uploaded a video larger than our postgres 4-byte integer column `file_size` could hold.  (Max is 2147483647... which is like ~2GB).

This PR restricts uploads to 1GB, which you'd think would be plenty.  Largest file in prod is just under 1GB right now.

![image](https://github.com/user-attachments/assets/3752333f-0928-4396-a97c-222088b6cd4a)
