### PR TITLE
Set from megaphone podcast ad tags from organization tag options

### DIFF
--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -166,7 +166,7 @@ class FeedsController < ApplicationController
       feed_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry],
       itunes_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry],
       apple_config_attributes: [:id, :publish_enabled, :sync_blocks_rss, {key_attributes: %i[id provider_id key_id key_pem_b64]}],
-      megaphone_config_attributes: [:id, :publish_enabled, :sync_blocks_rss, :token, :network_id, :network_name, :organization_id]
+      megaphone_config_attributes: [:id, :publish_enabled, :sync_blocks_rss, :token, :network_id, :network_name, :organization_id, advertising_tags: []]
     )
   end
 

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -166,7 +166,7 @@ class FeedsController < ApplicationController
       feed_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry],
       itunes_images_attributes: %i[id original_url size alt_text caption credit _destroy _retry],
       apple_config_attributes: [:id, :publish_enabled, :sync_blocks_rss, {key_attributes: %i[id provider_id key_id key_pem_b64]}],
-      megaphone_config_attributes: [:id, :publish_enabled, :sync_blocks_rss, :network_id, :network_name, :token]
+      megaphone_config_attributes: [:id, :publish_enabled, :sync_blocks_rss, :token, :network_id, :network_name, :organization_id]
     )
   end
 

--- a/app/models/feeds/megaphone_feed.rb
+++ b/app/models/feeds/megaphone_feed.rb
@@ -75,4 +75,11 @@ class Feeds::MegaphoneFeed < Feed
   def mark_as_not_delivered!(episode)
     episode.episode_delivery_status(:megaphone, true).mark_as_not_delivered!
   end
+
+  def advertising_tag_options
+    return [] unless persisted? && config.valid?
+    Megaphone::OrganizationTag.list_by_feed(self).map do |tag|
+      [tag.value, tag.label]
+    end
+  end
 end

--- a/app/models/megaphone/api.rb
+++ b/app/models/megaphone/api.rb
@@ -58,11 +58,11 @@ module Megaphone
 
     def result(request, response)
       data = incoming_body_filter(response.body)
-      if data[:items].present? && data[:items].is_a?(Array)
-        {items: data[:items], pagination: {}, request: request, response: response}
-      elsif data.is_a?(Array)
+      if data.is_a?(Array)
         pagination = pagination_from_headers(response.env.response_headers)
         {items: data, pagination: pagination, request: request, response: response}
+      elsif data[:items].present? && data[:items].is_a?(Array)
+        {items: data[:items], pagination: {}, request: request, response: response}
       else
         {items: [data], pagination: {}, request: request, response: response}
       end

--- a/app/models/megaphone/api.rb
+++ b/app/models/megaphone/api.rb
@@ -1,15 +1,16 @@
 module Megaphone
   class Api
-    attr_accessor :token, :network_id, :endpoint_url
+    attr_accessor :token, :network_id, :organization_id, :endpoint_url
 
     DEFAULT_ENDPOINT = "https://cms.megaphone.fm/api"
 
     PAGINATION_HEADERS = %w[link x-per-page x-page x-total]
     PAGINATION_LINKS = %i[first last next previous]
 
-    def initialize(token:, network_id:, endpoint_url: nil)
+    def initialize(token:, network_id:, organization_id:, endpoint_url: nil)
       @token = token
       @network_id = network_id
+      @organization_id = organization_id
       @endpoint_url = endpoint_url
     end
 

--- a/app/models/megaphone/api.rb
+++ b/app/models/megaphone/api.rb
@@ -20,6 +20,12 @@ module Megaphone
       result(request, response)
     end
 
+    def get_base(path, params = {}, headers = {})
+      request = {url: join_base_url(path), headers: headers, params: params}
+      response = get_url(request)
+      result(request, response)
+    end
+
     def post(path, body, headers = {})
       request = {url: join_url(path), headers: headers, body: outgoing_body_filter(body)}
       response = connection(request.slice(:url, :headers)).post do |req|
@@ -52,15 +58,15 @@ module Megaphone
 
     def result(request, response)
       data = incoming_body_filter(response.body)
-      if data.is_a?(Array)
+      if data[:items].present? && data[:items].is_a?(Array)
+        {items: data[:items], pagination: {}, request: request, response: response}
+      elsif data.is_a?(Array)
         pagination = pagination_from_headers(response.env.response_headers)
         {items: data, pagination: pagination, request: request, response: response}
       else
         {items: [data], pagination: {}, request: request, response: response}
       end
     end
-
-    # TODO: and we need delete...
 
     def api_base
       @endpoint_url || DEFAULT_ENDPOINT

--- a/app/models/megaphone/config.rb
+++ b/app/models/megaphone/config.rb
@@ -1,5 +1,7 @@
 module Megaphone
   class Config < ApplicationRecord
+    serialize :advertising_tags, coder: JSON
+
     belongs_to :feed
 
     validates_presence_of :token, :network_id, :organization_id

--- a/app/models/megaphone/config.rb
+++ b/app/models/megaphone/config.rb
@@ -2,10 +2,11 @@ module Megaphone
   class Config < ApplicationRecord
     belongs_to :feed
 
-    validates_presence_of :token, :network_id
+    validates_presence_of :token, :network_id, :organization_id
 
     encrypts :token
     encrypts :network_id
+    encrypts :organization_id
 
     def publish_to_megaphone?
       valid? && publish_enabled?

--- a/app/models/megaphone/model.rb
+++ b/app/models/megaphone/model.rb
@@ -12,7 +12,11 @@ module Megaphone
     end
 
     def api
-      @api ||= Megaphone::Api.new(token: config.token, network_id: config.network_id)
+      @api ||= Megaphone::Api.new(
+        token: config.token,
+        network_id: config.network_id,
+        organization_id: config.organization_id
+      )
     end
 
     def api_response_log_item

--- a/app/models/megaphone/organization_tag.rb
+++ b/app/models/megaphone/organization_tag.rb
@@ -1,0 +1,24 @@
+module Megaphone
+  class OrganizationTag
+    include Megaphone::Model
+
+    ALL_ATTRIBUTES = %i[label value podcast_count episode_count]
+
+    attr_accessor(*ALL_ATTRIBUTES)
+
+    def self.list_by_feed(feed)
+      ot = OrganizationTag.new
+      ot.config = feed.config
+      ot.list
+    end
+
+    def list
+      self.api_response = api.get_base("organizations/#{config.organization_id}/tags")
+      handle_response(api_response)
+    end
+
+    def handle_response(response)
+      response[:items].map { |item| OrganizationTag.new(item.slice(*ALL_ATTRIBUTES)) }
+    end
+  end
+end

--- a/app/models/megaphone/podcast.rb
+++ b/app/models/megaphone/podcast.rb
@@ -73,7 +73,7 @@ module Megaphone
         episode_limit: feed.display_episodes_count,
         external_id: podcast.guid,
         podcast_type: podcast.itunes_type,
-        advertising_tags: podcast.categories
+        advertising_tags: feed.config.advertising_tags || []
         # set in augury, can we get it here?
         # excluded_categories: ????? TBD,
       }

--- a/app/views/feeds/_form_megaphone_config.html.erb
+++ b/app/views/feeds/_form_megaphone_config.html.erb
@@ -11,6 +11,13 @@
       <%= form.fields_for :megaphone_config do |config_form| %>
         <div class="col-12 mb-4">
           <div class="form-floating input-group">
+            <%= config_form.text_field :organization_id, redacted: 4 %>
+            <%= config_form.label :organization_id, "Organization ID", required: true %>
+            <%= field_help_text t(".help.organization_id") %>
+          </div>
+        </div>
+        <div class="col-12 mb-4">
+          <div class="form-floating input-group">
             <%= config_form.text_field :token, redacted: 4 %>
             <%= config_form.label :token, "API Token", required: true %>
             <%= field_help_text t(".help.token") %>

--- a/app/views/feeds/_form_megaphone_config.html.erb
+++ b/app/views/feeds/_form_megaphone_config.html.erb
@@ -37,6 +37,13 @@
             <%= field_help_text t(".help.network_name") %>
           </div>
         </div>
+        <div class="col-12 mb-4">
+          <div class="form-floating input-group">
+            <%= config_form.select :advertising_tags, feed.advertising_tag_options, {include_blank: false}, multiple: true %>
+            <%= config_form.label :advertising_tags, "Advertising Tags" %>
+            <%= field_help_text t(".help.advertising_tags") %>
+          </div>
+        </div>
         <div class="col-6 mb-4">
           <div class="form-floating input-group">
             <%= form.select :episode_offset_seconds, episode_offset_options, include_blank: true %>

--- a/db/migrate/20250503181540_add_organization_id_to_megaphone_configs.rb
+++ b/db/migrate/20250503181540_add_organization_id_to_megaphone_configs.rb
@@ -1,0 +1,5 @@
+class AddOrganizationIdToMegaphoneConfigs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :megaphone_configs, :organization_id, :string
+  end
+end

--- a/db/migrate/20250503194609_add_advertising_tags_to_megaphone_configs.rb
+++ b/db/migrate/20250503194609_add_advertising_tags_to_megaphone_configs.rb
@@ -1,0 +1,5 @@
+class AddAdvertisingTagsToMegaphoneConfigs < ActiveRecord::Migration[7.2]
+  def change
+    add_column :megaphone_configs, :advertising_tags, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_03_181540) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_03_194609) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -336,6 +336,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_03_181540) do
     t.datetime "updated_at", null: false
     t.boolean "sync_blocks_rss", default: false, null: false
     t.string "organization_id"
+    t.text "advertising_tags"
   end
 
   create_table "podcast_imports", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_03_173259) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_03_181540) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
@@ -335,6 +335,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_03_173259) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "sync_blocks_rss", default: false, null: false
+    t.string "organization_id"
   end
 
   create_table "podcast_imports", force: :cascade do |t|

--- a/test/factories/megaphone_config_factory.rb
+++ b/test/factories/megaphone_config_factory.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     token { "thisisatokenforacessingtheapi" }
     network_id { "this-is-a-network-id" }
     network_name { "test network" }
+    organization_id { "this-is-an-organization-id" }
     feed
   end
 end

--- a/test/models/megaphone/api_test.rb
+++ b/test/models/megaphone/api_test.rb
@@ -4,9 +4,12 @@ require "securerandom"
 describe Megaphone::Api do
   let(:token) { SecureRandom.uuid }
   let(:network_id) { "this-is-a-network-id" }
-  let(:api) { Megaphone::Api.new(token: token, network_id: network_id) }
+  let(:organization_id) { "this-is-an-organization-id" }
+  let(:api) { Megaphone::Api.new(token: token, network_id: network_id, organization_id: organization_id) }
 
-  it "assigns the api key" do
+  it "assigns the attributes" do
     assert_equal api.token, token
+    assert_equal api.network_id, network_id
+    assert_equal api.organization_id, organization_id
   end
 end

--- a/test/models/megaphone/config_test.rb
+++ b/test/models/megaphone/config_test.rb
@@ -7,6 +7,7 @@ describe Megaphone::Config do
       config = build(:megaphone_config, feed: feed)
       assert_not_nil config.token
       assert_not_nil config.network_id
+      assert_not_nil config.organization_id
       assert_not_nil config.feed_id
       assert config.valid?
     end

--- a/test/models/megaphone/organization_tag_test.rb
+++ b/test/models/megaphone/organization_tag_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+describe Megaphone::OrganizationTag do
+  let(:podcast) { create(:podcast, id: 1234) }
+  let(:public_feed) { podcast.default_feed }
+  let(:feed) { create(:megaphone_feed, podcast: podcast, private: true) }
+  let(:tags_json) do
+    {
+      items: [
+        {
+          label: "tag 1",
+          value: "tag 1",
+          podcastCount: 2,
+          episodeCount: 0
+        }
+      ]
+    }.to_json
+  end
+
+  it "can retrieve the organization tags" do
+    stub_request(:get, "https://cms.megaphone.fm/api/organizations/this-is-an-organization-id/tags")
+      .to_return(status: 200, body: tags_json, headers: {})
+
+    tags = Megaphone::OrganizationTag.list_by_feed(feed)
+    assert_equal 1, tags.size
+    assert_equal "tag 1", tags.first.label
+    assert_equal "tag 1", tags.first.value
+    assert_equal 2, tags.first.podcast_count
+    assert_equal 0, tags.first.episode_count
+  end
+end

--- a/test/models/megaphone/organization_tag_test.rb
+++ b/test/models/megaphone/organization_tag_test.rb
@@ -9,7 +9,7 @@ describe Megaphone::OrganizationTag do
       items: [
         {
           label: "tag 1",
-          value: "tag 1",
+          value: "tag_1",
           podcastCount: 2,
           episodeCount: 0
         }
@@ -24,7 +24,7 @@ describe Megaphone::OrganizationTag do
     tags = Megaphone::OrganizationTag.list_by_feed(feed)
     assert_equal 1, tags.size
     assert_equal "tag 1", tags.first.label
-    assert_equal "tag 1", tags.first.value
+    assert_equal "tag_1", tags.first.value
     assert_equal 2, tags.first.podcast_count
     assert_equal 0, tags.first.episode_count
   end


### PR DESCRIPTION
- [x] Add the organization id to the config
- [x] Retrieve tags from the API
- [x] Add advertising tags to the megaphone config
- [x] Set tags from the UI
- [x] Use the tags when creating/updating the podcast