### PR TITLE
Start and end times for cuepoints must be floats in json

### DIFF
--- a/app/models/megaphone/cuepoint.rb
+++ b/app/models/megaphone/cuepoint.rb
@@ -57,7 +57,10 @@ module Megaphone
     end
 
     def as_json_for_create
-      as_json(only: CREATE_ATTRIBUTES.map(&:to_s))
+      h = as_json(only: CREATE_ATTRIBUTES.map(&:to_s))
+      h["start_time"] = h["start_time"].to_f if h.key?("start_time")
+      h["end_time"] = h["end_time"].to_f if h.key?("end_time")
+      h
     end
   end
 end

--- a/test/models/megaphone/cuepoint_test.rb
+++ b/test/models/megaphone/cuepoint_test.rb
@@ -33,4 +33,27 @@ describe Megaphone::Cuepoint do
       assert_nil cuepoints[2].max_duration
     end
   end
+  describe "#as_json_for_create" do
+    it "returns the correct JSON with float for big decimals" do
+      cuepoint = Megaphone::Cuepoint.new(
+        cuepoint_type: "midroll",
+        ad_count: 1,
+        start_time: 30.1234,
+        ad_sources: [:auto],
+        action: :insert,
+        is_active: true,
+        max_duration: 30
+      )
+      expected_json = {
+        "cuepoint_type" => "midroll",
+        "ad_count" => 1,
+        "start_time" => 30.1234,
+        "ad_sources" => ["auto"],
+        "action" => "insert",
+        "is_active" => true,
+        "max_duration" => 30
+      }
+      assert_equal expected_json, cuepoint.as_json_for_create
+    end
+  end
 end

--- a/test/models/megaphone/episode_test.rb
+++ b/test/models/megaphone/episode_test.rb
@@ -123,7 +123,7 @@ describe Megaphone::Episode do
       stub_request(:get, "https://cms.megaphone.fm/api/networks/this-is-a-network-id/podcasts/mp-123-456/episodes/megaphone-episode-guid")
         .to_return(status: 200, body: audio_ready_json, headers: {})
 
-      cp_json = "[{\"cuepointType\":\"postroll\",\"adCount\":1,\"startTime\":\"48.0\",\"adSources\":[\"promo\"],\"action\":\"insert\",\"isActive\":true,\"maxDuration\":120}]"
+      cp_json = "[{\"cuepointType\":\"postroll\",\"adCount\":1,\"startTime\":48.0,\"adSources\":[\"promo\"],\"action\":\"insert\",\"isActive\":true,\"maxDuration\":120}]"
       stub_request(:put, "https://cms.megaphone.fm/api/episodes/megaphone-episode-guid/cuepoints_batch")
         .with(body: cp_json)
         .to_return(status: 200, body: cp_json, headers: {})


### PR DESCRIPTION
this is a limited fix, another option would be to change the behavior of BigDecimal as_json to always convert to_f rather than just affecting these specific attributes in this one model

and another option is to use Oj for this, which has an explicit option for bigdecimal_as_decimal https://www.ohler.com/oj/doc/Oj.html