### PR TITLE
Filter episode guids by podcast

### DIFF
--- a/app/controllers/api/episodes_controller.rb
+++ b/app/controllers/api/episodes_controller.rb
@@ -48,7 +48,7 @@ class Api::EpisodesController < Api::BaseController
 
   def show_resource
     if params[:guid_resource]
-      resource = Episode.find_by_item_guid(params[:id])
+      resource = find_base.find_by_item_guid(params[:id])
       raise HalApi::Errors::NotFound.new if resource.nil?
 
       @episode = resource


### PR DESCRIPTION
Fixes #1262.

Use the [find_base](https://github.com/PRX/hal_api-rails/blob/main/lib/hal_api/controller/resources.rb#L82) method instead of search all episodes for a guid.