### PR TITLE
HOTFIX: planning calendar colors

### DIFF
--- a/app/assets/stylesheets/app/calendar.scss
+++ b/app/assets/stylesheets/app/calendar.scss
@@ -18,10 +18,32 @@
       line-height: 1;
     }
 
+    tbody {
+      tr:nth-of-type(odd) {
+        .bg-primary {
+          --bs-table-bg-type: $primary;
+        }
+
+        .bg-danger {
+          --bs-table-bg-type: $danger;
+        }
+
+        .bg-warning {
+          --bs-table-bg-type: $warning;
+        }
+      }
+    }
+
     .day.current-month:hover {
       background-color: $primary !important;
       color: $light;
       cursor: pointer;
     }
+  }
+}
+
+@include color-mode(dark) {
+  .simple-calendar :is(thead th, td) {
+    border-color: $border-color-dark;
   }
 }


### PR DESCRIPTION
closes #1265 

- the global styles table striping classes overrode the custom context backgrounds for calendar drafts

Fixed:
![Screenshot 2025-06-02 at 3 37 50 PM](https://github.com/user-attachments/assets/f93ce908-7270-4585-8d05-e46fcb549968)
![Screenshot 2025-06-02 at 3 38 14 PM](https://github.com/user-attachments/assets/b9a401ad-c8fc-4fc8-8f2d-1c4e95d0722b)
