### PR TITLE
Load strategy classes after config set

### DIFF
--- a/config/initializers/say_when.rb
+++ b/config/initializers/say_when.rb
@@ -1,6 +1,4 @@
 require "say_when"
-require "say_when/processor/active_job_strategy"
-require "say_when/storage/active_record_strategy"
 
 # Specify a logger for SayWhen
 SayWhen.logger = Rails.logger
@@ -15,6 +13,10 @@ SayWhen.configure do |options|
   options[:processor_strategy] = :active_job
 
   options[:queue] = :feeder_default
+
+  # now that it is configured, load the strategies
+  require "say_when/processor/active_job_strategy"
+  require "say_when/storage/active_record_strategy"
 end
 
 begin


### PR DESCRIPTION
Issue seems to be that the active job class can't be loaded until after the queue name is configured, so this change does the class loading as soon as that config is set in the say when init