### PR TITLE
Trim more rss strings

### DIFF
--- a/app/models/imports/episode_rss_import.rb
+++ b/app/models/imports/episode_rss_import.rb
@@ -75,7 +75,7 @@ class EpisodeRssImport < EpisodeImport
   end
 
   def update_episode_with_entry!
-    episode.clean_title = entry[:itunes_title]
+    episode.clean_title = clean_title(entry[:itunes_title])
     episode.description = entry_description(entry)
     episode.episode_number = entry[:itunes_episode]
     episode.published_at = entry[:published]

--- a/app/models/imports/podcast_rss_import.rb
+++ b/app/models/imports/podcast_rss_import.rb
@@ -138,7 +138,7 @@ class PodcastRssImport < PodcastImport
     guids = []
     to_import = []
     feed.entries.each do |entry|
-      guid = entry.entry_id
+      guid = clean_string(entry.entry_id)
       entry_hash = entry.to_h.as_json.with_indifferent_access
 
       if new_episodes_only && existing_guids.include?(guid)


### PR DESCRIPTION
Fixes #1279.  Fixes #1280.

We were missing some string trimming.  Which in the case of the item `<guid>`, was resulting in us trying to import a bunch of dup episodes.

Which then failed on a validation error, as the EpisodeImport ignores its own `ep_import.guid`, and [re-cleans the string](https://github.com/PRX/feeder.prx.org/blob/main/app/models/imports/episode_rss_import.rb#L89) itself.