### PR TITLE
Add full size preview to image modal

### DIFF
--- a/app/views/images/_complete.html.erb
+++ b/app/views/images/_complete.html.erb
@@ -17,10 +17,12 @@
 
   <div class="card-body">
     <div class="prx-uploads-image mb-4">
-      <%= image_tag image.url, alt: image.alt_text %>
+      <button type="button" class="btn m-0 p-0 border-0" data-bs-toggle="modal" data-bs-target="#image-modal-<%= image.id %>">
+        <%= image_tag image.url, alt: image.alt_text %>
+      </button>
 
       <% if image.width.present? && image.height.present? %>
-        <aside><%= image.width %>x<%= image.height %></aside>
+        <aside class="bg-light text-dark"><%= image.width %>x<%= image.height %></aside>
       <% end %>
     </div>
 

--- a/app/views/images/_modal.html.erb
+++ b/app/views/images/_modal.html.erb
@@ -1,11 +1,14 @@
-<div id="<%= id %>" class="modal" tabindex="-1">
-  <div class="modal-dialog modal-dialog-centered modal-sm">
+<div id="<%= id %>" class="modal" tabindex="-1" data-bs-theme="dark">
+  <div class="modal-dialog modal-dialog-centered modal-fullscreen bg-dark">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title"><%= title %></h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="<%= t("images.label.close") %>"></button>
       </div>
-      <div class="modal-body">
+      <div class="modal-body text-center">
+        <%= image_tag image.url, alt: image.alt_text %>
+      </div>
+      <div class="modal-footer">
         <table class="table table-sm m-0">
           <tbody>
             <tr>


### PR DESCRIPTION
Since we had a modal already for images, I thought we'd repurpose it to include a full size preview of the image.

Click either on the info icon or the image itself to see a full-sized modal of the image.


https://github.com/user-attachments/assets/5891c52d-d02c-4be9-bcd8-572d5a2ff1ac


