### PR TITLE
Vary DTR user agent

### DIFF
--- a/app/models/megaphone/episode.rb
+++ b/app/models/megaphone/episode.rb
@@ -427,7 +427,10 @@ module Megaphone
         location: nil,
         size: nil
       }.with_indifferent_access
-      resp = Faraday.head(enclosure)
+
+      headers = {"User-Agent" => "PRX-Feeder-Megaphone/1.0 (Rails-#{Rails.env}) #{SecureRandom.alphanumeric(10)}"}
+      resp = Faraday.head(enclosure, nil, headers)
+
       if resp.status == 302
         info[:media_version] = resp.env.response_headers["x-episode-media-version"].to_i
         info[:location] = resp.env.response_headers["location"]

--- a/test/models/megaphone/episode_test.rb
+++ b/test/models/megaphone/episode_test.rb
@@ -72,6 +72,7 @@ describe Megaphone::Episode do
       arrangement_url = "#{base_url}/#{arrangement_filename}"
 
       stub_request(:head, "https://dovetail.prxu.org/#{feeder_podcast.id}/#{feed.slug}/#{media_episode.guid}/audio.mp3?auth=#{feed.tokens.first.token}")
+        .with { |req| req.headers["User-Agent"].match?(/PRX-Feeder-Megaphone\/1.0 \(Rails-test\) [[:alnum:]]+/) }
         .to_return(status: 302, body: "", headers: {
           "x-episode-media-version" => media_episode.media_version_id,
           "location" => source_url,
@@ -149,6 +150,7 @@ describe Megaphone::Episode do
       source_url = "#{base_url}/audio.mp3"
 
       stub_request(:head, "https://dovetail.prxu.org/#{feeder_podcast.id}/#{feed.slug}/#{media_episode.guid}/audio.mp3?auth=#{feed.tokens.first.token}")
+        .with { |req| req.headers["User-Agent"].match?(/PRX-Feeder-Megaphone\/1.0 \(Rails-test\) [[:alnum:]]+/) }
         .to_return(status: 302, body: "", headers: {
           "x-episode-media-version" => media_episode.media_version_id - 1,
           "location" => source_url,


### PR DESCRIPTION
Avoid hitting the recent-decision cache when requesting DTR mp3s.  To make sure the media-version is accurate.

Related to https://github.com/PRX/dovetail-router.prx.org/issues/375