### PR TITLE
Rescue not found records in prod

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -42,4 +42,13 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  # shared handler for prod 404s (prevent logging errors)
+  def render_not_found(err)
+    if Rails.configuration.consider_all_requests_local
+      raise err
+    else
+      render file: Rails.public_path.join("404.html"), status: :not_found
+    end
+  end
 end

--- a/app/controllers/episode_media_controller.rb
+++ b/app/controllers/episode_media_controller.rb
@@ -61,6 +61,8 @@ class EpisodeMediaController < ApplicationController
     @episode.strict_validations = true
     @episode.locking_enabled = true
     @podcast = @episode.podcast
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def episode_params

--- a/app/controllers/episode_player_controller.rb
+++ b/app/controllers/episode_player_controller.rb
@@ -1,14 +1,20 @@
 class EpisodePlayerController < ApplicationController
-  def show
-    @episode = Episode.find_by_guid!(params[:episode_id])
-    @podcast = @episode.podcast
+  before_action :set_episode
 
+  def show
     authorize @episode, :show?
 
     @player_options = episode_player_params
   end
 
   private
+
+  def set_episode
+    @episode = Episode.find_by_guid!(params[:episode_id])
+    @podcast = @episode.podcast
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
+  end
 
   def episode_player_params
     nilify params

--- a/app/controllers/episode_transcripts_controller.rb
+++ b/app/controllers/episode_transcripts_controller.rb
@@ -33,6 +33,8 @@ class EpisodeTranscriptsController < ApplicationController
     @episode = Episode.find_by_guid!(params[:episode_id])
     @episode.locking_enabled = true
     @podcast = @episode.podcast
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def episode_params

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -55,6 +55,7 @@ class EpisodesController < ApplicationController
   end
 
   # GET /episodes/1/edit
+  # /episodes/ec20a58f-02e0-409e-8b4c-7bd89e52f7f7/edit
   def edit
     @episode.assign_attributes(episode_params)
     authorize @episode, :show?
@@ -127,6 +128,8 @@ class EpisodesController < ApplicationController
     @episode = Episode.find_by_guid!(params[:id])
     @episode.strict_validations = true
     @episode.locking_enabled = true
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def set_podcast

--- a/app/controllers/feeds_controller.rb
+++ b/app/controllers/feeds_controller.rb
@@ -124,6 +124,8 @@ class FeedsController < ApplicationController
   def set_feed
     @feed = Feed.find(params[:id])
     @feed.locking_enabled = true
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -53,6 +53,8 @@ class ImportsController < ApplicationController
 
   def set_podcast
     @podcast = Podcast.find(params[:podcast_id])
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def set_import

--- a/app/controllers/placements_preview_controller.rb
+++ b/app/controllers/placements_preview_controller.rb
@@ -14,6 +14,8 @@ class PlacementsPreviewController < ApplicationController
   def set_podcast
     @podcast = Podcast.find(params[:podcast_id])
     authorize @podcast, :show?
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def get_placement(original_count)

--- a/app/controllers/podcast_engagement_controller.rb
+++ b/app/controllers/podcast_engagement_controller.rb
@@ -29,6 +29,8 @@ class PodcastEngagementController < ApplicationController
     @podcast = Podcast.find(params[:podcast_id])
     @podcast.locking_enabled = true
     authorize @podcast
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   # Only allow a list of trusted parameters through.

--- a/app/controllers/podcast_metrics_controller.rb
+++ b/app/controllers/podcast_metrics_controller.rb
@@ -197,6 +197,8 @@ class PodcastMetricsController < ApplicationController
   def set_podcast
     @podcast = Podcast.find(params[:podcast_id])
     authorize @podcast, :show?
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def set_date_range

--- a/app/controllers/podcast_planner_controller.rb
+++ b/app/controllers/podcast_planner_controller.rb
@@ -30,6 +30,8 @@ class PodcastPlannerController < ApplicationController
   # Use callbacks to share common setup or constraints between actions.
   def set_podcast
     @podcast = Podcast.find(params[:podcast_id])
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def set_beginning_of_week

--- a/app/controllers/podcast_player_controller.rb
+++ b/app/controllers/podcast_player_controller.rb
@@ -1,13 +1,19 @@
 class PodcastPlayerController < ApplicationController
-  def show
-    @podcast = Podcast.find(params[:podcast_id])
+  before_action :set_podcast
 
+  def show
     authorize @podcast, :show?
 
     @player_options = podcast_player_params
   end
 
   private
+
+  def set_podcast
+    @podcast = Podcast.find(params[:podcast_id])
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
+  end
 
   def podcast_player_params
     nilify params

--- a/app/controllers/podcasts_controller.rb
+++ b/app/controllers/podcasts_controller.rb
@@ -138,6 +138,8 @@ class PodcastsController < ApplicationController
   def set_podcast
     @podcast = Podcast.find(params[:id])
     @podcast.locking_enabled = true
+  rescue ActiveRecord::RecordNotFound => e
+    render_not_found(e)
   end
 
   def published_episodes(date_range)


### PR DESCRIPTION
Noticed some log level=50 errors in the prod logs.

Looks like right now, any raised `ActiveRecord::RecordNotFound` will log both a level=30 info for the request, _and_ a level=50 for the raised error:

```
ActiveRecord::RecordNotFound (Couldn't find Episode with [WHERE \"episodes\".\"deleted_at\" IS NULL AND \"episodes\".\"guid\" = $1]):

app/controllers/episodes_controller.rb:127:in 'EpisodesController#set_episode'
config/application.rb:87:in 'Feeder::Application::HealthCheckMiddleware#call
```

I thought about using a global `rescue_from` in the ApplicationController, but was worried (A) that's pretty broad, and (B) that also impacts the API controllers.  And `hal_api-rails` has its own logic for rescuing them.

So went for the focused solution - just rescue everything inside each controller `set_episode` block.