### PR TITLE
Even better latest_media_version query

### DIFF
--- a/app/models/concerns/episode_media.rb
+++ b/app/models/concerns/episode_media.rb
@@ -94,13 +94,7 @@ module EpisodeMedia
   end
 
   def cut_media_version!
-    latest_version =
-      if latest_media_version.loaded?
-        latest_media_version[-1]
-      else
-        media_versions.latest(id).first
-      end
-
+    latest_version = latest_media_version[-1]
     latest_media = latest_version&.media_version_resources || []
     latest_ids = latest_media.map(&:media_resource_id)
 

--- a/app/models/media_version.rb
+++ b/app/models/media_version.rb
@@ -4,13 +4,7 @@ class MediaVersion < ApplicationRecord
   has_many :media_version_resources, dependent: :destroy
   has_many :media_resources, -> { with_deleted.order("position ASC, created_at DESC") }, through: :media_version_resources
 
-  scope :latest, ->(episode_ids = nil) do
-    if episode_ids.present?
-      where("id IN (SELECT MAX(id) FROM media_versions WHERE episode_id IN (?) GROUP BY episode_id)", episode_ids)
-    else
-      where("id IN (SELECT MAX(id) FROM media_versions GROUP BY episode_id)")
-    end
-  end
+  scope :latest, -> { where("id IN (SELECT max(id) FROM media_versions mv WHERE mv.episode_id = media_versions.episode_id)") }
 
   validates :media_version_resources, length: {minimum: 1}
 end


### PR DESCRIPTION
Rely on aliases instead of using different SQL for index/show.

In other words... this works for both `Episode.find(...).latest_media_version` and `Episode.limit(100).includes(:latest_media_version)`.