### PR TITLE
Fixup multiple calls to archive and unarchive

### DIFF
--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -147,7 +147,7 @@ module Apple
     def archive!(eps = episodes_to_archive)
       Rails.logger.tagged("Apple::Publisher##{__method__}") do
         eps.each_slice(PUBLISH_CHUNK_LEN) do |chunked_eps|
-          res = Apple::Episode.archive(api, show, eps)
+          res = Apple::Episode.archive(api, show, chunked_eps)
           Rails.logger.info("Archived #{res.length} episodes.")
         end
       end
@@ -156,7 +156,7 @@ module Apple
     def unarchive!(eps = episodes_to_unarchive)
       Rails.logger.tagged("Apple::Publisher##{__method__}") do
         eps.each_slice(PUBLISH_CHUNK_LEN) do |chunked_eps|
-          res = Apple::Episode.unarchive(api, show, eps)
+          res = Apple::Episode.unarchive(api, show, chunked_eps)
           Rails.logger.info("Un-Archived #{res.length} episodes.")
         end
       end


### PR DESCRIPTION
Fixes a problem where we're iterating over chunks but referencing the captured reference to the whole set.