### PR TITLE
Handle different ad breaks

### DIFF
--- a/app/models/concerns/metadata_breaks.rb
+++ b/app/models/concerns/metadata_breaks.rb
@@ -10,7 +10,7 @@ module MetadataBreaks
     (tags || []).each do |tag|
       breaks += tag[:value].scan(MATCH_TAGS_REGEX).flatten
     end
-    breaks.map { |b| parse_break(b) }.compact.sort { |a, b| Array(a).first <=> Array(b).first }.uniq
+    breaks.map { |b| parse_break(b) }.compact.sort { |a, b| Array(a).first.to_f <=> Array(b).first.to_f }.uniq
   end
 
   # look for a comma, and use as start of the break and duration
@@ -22,7 +22,7 @@ module MetadataBreaks
       if duration_time > 0.0
         end_time = start_time.to_f + duration_time
         [start_time, end_time]
-      else
+      elsif !start_time.nil? && start_time > 0.0
         start_time
       end
     else

--- a/test/models/concerns/metadata_breaks_test.rb
+++ b/test/models/concerns/metadata_breaks_test.rb
@@ -25,6 +25,14 @@ describe TestMetadataBreaks do
       result = metadata_breaks.breaks_from_tags(tags)
       assert_equal [1.0, 30.0], result
     end
+
+    it "handles 0 values" do
+      tags = [
+        {key: "comment", value: "PREROLL_1;POSTROLL_1;AIS_AD_BREAK_1=0,0;"}
+      ]
+      result = metadata_breaks.breaks_from_tags(tags)
+      assert_equal [], result
+    end
   end
 
   describe "#parse_break" do

--- a/test/models/uncut_test.rb
+++ b/test/models/uncut_test.rb
@@ -220,7 +220,16 @@ describe Uncut do
   describe "#ad_breaks=" do
     it "converts ad breaks to segmentations" do
       uncut.ad_breaks = nil
-      assert_nil uncut.segmentation
+      assert_equal [[nil, nil]], uncut.segmentation
+
+      uncut.ad_breaks = []
+      assert_equal [[nil, nil]], uncut.segmentation
+
+      uncut.ad_breaks = [nil]
+      assert_equal [[nil, nil]], uncut.segmentation
+
+      uncut.ad_breaks = [0.0]
+      assert_equal [[nil, nil]], uncut.segmentation
 
       uncut.ad_breaks = [2]
       assert_equal [[nil, 2], [2, nil]], uncut.segmentation


### PR DESCRIPTION
Handles cases where ad breaks are 0, or nil, or variations on those.
Generally handle more cases of when the data for breaks includes non-breaks, such as midrolls marked at 0 time