### PR TITLE
Add episode publish offset for apple feeds

### DIFF
--- a/app/helpers/feeds_helper.rb
+++ b/app/helpers/feeds_helper.rb
@@ -3,6 +3,10 @@ module FeedsHelper
     I18n.t("feeds.helper.episode_offset_options").invert.to_a
   end
 
+  def apple_episode_offset_options
+    I18n.t("feeds.helper.apple_episode_offset_options").invert.to_a
+  end
+
   def audio_format_options
     AudioFormatValidator::FORMATS.map do |value|
       [I18n.t(value, scope: [:feeds, :helper, :audio_format_options]), value]

--- a/app/models/feeds/apple_subscription.rb
+++ b/app/models/feeds/apple_subscription.rb
@@ -132,6 +132,10 @@ class Feeds::AppleSubscription < Feed
     publish_to_apple?
   end
 
+  def serve_drafts
+    publish_integration?
+  end
+
   def publish_to_apple?
     !!apple_config&.publish_to_apple?
   end

--- a/app/views/feeds/_form_apple_config.html.erb
+++ b/app/views/feeds/_form_apple_config.html.erb
@@ -57,6 +57,14 @@
 
         <div class="col-6 mt-4">
           <div class="form-floating input-group">
+            <%= form.select :episode_offset_seconds, apple_episode_offset_options, include_blank: true %>
+            <%= form.label :episode_offset_seconds %>
+            <%= field_help_text t(".help.episode_offset_seconds") %>
+          </div>
+        </div>
+
+        <div class="col-6 mt-4">
+          <div class="form-floating input-group">
             <%= form.number_field :display_episodes_count %>
             <%= form.label :display_episodes_count %>
             <%= field_help_text t(".help.display_episodes_count") %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -928,6 +928,7 @@ en:
         display_episodes_count: You can optionally limit the number of episodes that Paid Subscribers will see in Apple Podcasts. Leave this field blank to include all.
         publish_enabled: Enable automatically publishing and updating episodes in this feed to Apple?
         sync_blocks_rss: Block publishing to the default feed RSS until the Apple episode is published?
+        episode_offset_seconds: How early should episodes be published to subscribers?
     form_audio_format:
       title: Audio Format
       help:
@@ -993,6 +994,19 @@ en:
       help:
         locked: This feed is locked, to make changes please <a href="https://help.prx.org/hc/en-us">contact PRX support.</a>
     helper:
+      apple_episode_offset_options:
+        "-86400": 1 day early
+        "-172800": 2 days early
+        "-259200": 3 days early
+        "-345600": 4 days early
+        "-432000": 5 days early
+        "-518400": 6 days early
+        "-604800": 1 week early
+        "-1209600": 2 weeks early
+        "-1814400": 3 weeks early
+        "-2419200": 4 weeks early
+        "-3024000": 5 weeks early
+        "-3628800": 6 weeks early
       episode_offset_options:
         "-300": 5 minutes early
         "-900": 15 minutes early


### PR DESCRIPTION
fixes #1380 and #1215 

I added options only for publishing early to subscribers, and made it multiples of days or weeks:

<img width="417" height="395" alt="image" src="https://github.com/user-attachments/assets/287aed32-41b4-42a7-a965-228f9ceda6e0" />

Also enabled `serve_drafts` for Apple feeds so DTR will not look at publish date for serving audio when it is for the Apple feed.
