### PR TITLE
Load newer openssl version to fix CLR error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,7 @@ gem "hyperresource", github: "PRX/hyperresource", branch: "master"
 gem "mutex_m"
 gem "net-http"
 gem "parallel"
+gem "openssl", "~> 3.3.1"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,6 +341,7 @@ GEM
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
     oj (3.13.23)
+    openssl (3.3.2)
     ostruct (0.6.0)
     ougai (1.9.1)
       oj (~> 3.10)
@@ -624,6 +625,7 @@ DEPENDENCIES
   net-http
   newrelic_rpm
   oauth2 (~> 1.4.7)
+  openssl (~> 3.3.1)
   ostruct
   ougai
   ougai-formatters-customizable


### PR DESCRIPTION
fixes issue with ruby default bundled openssl version
https://www.rubyonmac.dev/certificate-verify-failed-unable-to-get-certificate-crl-openssl-ssl-sslerror