### PR TITLE
No need for a feed title now that we have the label

### DIFF
--- a/app/models/feeds/megaphone_feed.rb
+++ b/app/models/feeds/megaphone_feed.rb
@@ -8,7 +8,7 @@ class Feeds::MegaphoneFeed < Feed
 
   validate :must_have_token, :audio_format_must_be_mp3
 
-  validates_presence_of :audio_format, :slug, :title, :tokens
+  validates_presence_of :audio_format, :slug, :tokens
 
   before_validation :set_tokens
 


### PR DESCRIPTION
The feed was still validating for a title, but it doesn't need to be set.