### PR TITLE
No alert dialogs in prod

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -13,7 +13,11 @@ LocalTime.start()
 
 // debugging turbo
 document.addEventListener("turbo:frame-missing", function (event) {
-  alert("FRAME MISSING!!!!!!!!!!!!!")
+  if (document.body.dataset.env === "production") {
+    console.error("FRAME MISSING!!!!!!!!!!!!!")
+  } else {
+    alert("FRAME MISSING!!!!!!!!!!!!!")
+  }
   // event.detail.response.text().then(
   //   text => console.log('GOT TEXT:', text),
   //   err => console.log('GOT ERR:', err)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <%= render "layouts/color_mode" %>
   </head>
 
-  <body data-controller="blank-field confirm-field popover">
+  <body data-controller="blank-field confirm-field popover" data-env="<%= Rails.env.to_s %>">
     <%= render "layouts/nav" %>
     <%= render "layouts/subnav" if current_user %>
     <%= render "layouts/alerts" %>


### PR DESCRIPTION
Just log to the console in prod, rather than the annoying "frame missing" alert dialogs.