### PR TITLE
Migrate existing keys

### DIFF
--- a/app/models/apple/key.rb
+++ b/app/models/apple/key.rb
@@ -8,6 +8,8 @@ module Apple
     validates :key_id, presence: true, length: {minimum: 10}
     validates_presence_of :key_pem_b64
 
+    encrypts :key_pem_b64
+
     validate :provider_id_is_valid, if: :provider_id?
     validate :ec_key_format, if: :key_pem_b64?
     validate :must_have_working_key

--- a/db/migrate/20260427173435_add_encryption_to_key_pem_b64.rb
+++ b/db/migrate/20260427173435_add_encryption_to_key_pem_b64.rb
@@ -1,0 +1,24 @@
+class AddEncryptionToKeyPemB64 < ActiveRecord::Migration[7.2]
+  def up
+    Apple::Key.reset_column_information
+    encrypted_type = Apple::Key.type_for_attribute("key_pem_b64")
+
+    connection.select_all(<<~SQL.squish).each do |row|
+      SELECT id, key_pem_b64
+      FROM apple_keys
+      WHERE key_pem_b64 IS NOT NULL
+    SQL
+      raw_key_pem_b64 = row.fetch("key_pem_b64")
+      next if encrypted_type.encrypted?(raw_key_pem_b64)
+
+      Apple::Key.where(id: row.fetch("id")).update_all(
+        key_pem_b64: raw_key_pem_b64,
+        updated_at: Time.current
+      )
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Apple key PEM values cannot be decrypted safely by this migration"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_02_20_205546) do
+ActiveRecord::Schema[7.2].define(version: 2026_04_27_173435) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"

--- a/test/models/apple/key_test.rb
+++ b/test/models/apple/key_test.rb
@@ -47,6 +47,29 @@ describe Apple::Config do
       assert_equal c.key_pem, "hello"
     end
 
+    it "encrypts the base64 key at rest" do
+      key_pem_b64 = Base64.encode64(test_file("/fixtures/apple_podcasts_connect_keyfile.pem"))
+      key = create(:apple_key, key_pem_b64: key_pem_b64)
+
+      raw_key_pem_b64 = Apple::Key.connection.select_value(
+        "SELECT key_pem_b64 FROM apple_keys WHERE id = #{key.id}"
+      )
+
+      refute_equal key_pem_b64, raw_key_pem_b64
+      assert Apple::Key.type_for_attribute("key_pem_b64").encrypted?(raw_key_pem_b64)
+      assert_equal key_pem_b64, key.reload.key_pem_b64
+      assert_equal test_file("/fixtures/apple_podcasts_connect_keyfile.pem"), key.key_pem
+    end
+
+    it "builds an api from a key with encrypted pem data" do
+      key = create(:apple_key)
+      api = Apple::Api.from_key(key.reload)
+
+      assert_equal key.provider_id, api.provider_id
+      assert_equal key.key_id, api.key_id
+      assert_equal key.key_pem, api.key
+    end
+
     it "requires correct format of apple key" do
       k1 = build(:apple_key)
       k2 = build(:apple_key, key_pem_b64: Base64.encode64("not a valid pem"))


### PR DESCRIPTION
This PR brings the Apple side of the integrations up to match the Megaphone side. Adds a `encrypts :key_pem_b64` to the Apple::Key model def.