### PR TITLE
add scheduled badges to draft card

### DIFF
--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -67,7 +67,7 @@
                 <div class="episode-card-inner inside-card flex-row justify-content-between">
                   <h2 class="h5 episode-card-title episode-card-text"><%= link_to ep.title, episode_path(ep) %></h2>
                   <% if ep.publishing_status == "scheduled" %>
-                    <span class="badge bg-success">Scheduled</span>
+                    <span class="badge bg-success"><%= t("helpers.label.episode.publishing_statuses.scheduled") %></span>
                   <% end %>
                 </div>
               </div>

--- a/app/views/podcasts/show.html.erb
+++ b/app/views/podcasts/show.html.erb
@@ -64,8 +64,11 @@
                     <%= local_date(ep.published_or_released_date, format: :short) %>
                   <% end %>
                 </p>
-                <div class="episode-card-inner inside-card">
+                <div class="episode-card-inner inside-card flex-row justify-content-between">
                   <h2 class="h5 episode-card-title episode-card-text"><%= link_to ep.title, episode_path(ep) %></h2>
+                  <% if ep.publishing_status == "scheduled" %>
+                    <span class="badge bg-success">Scheduled</span>
+                  <% end %>
                 </div>
               </div>
             <% end %>


### PR DESCRIPTION
closes #1468 

- Adds a scheduled badge to scheduled episodes on the draft card on on the podcast overview page