### PR TITLE
Guard asset state

### DIFF
--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -144,8 +144,10 @@ module Apple
 
         # Wait for the audio asset to be processed by Apple
         wait_for_asset_state(eps) do |ready_eps|
-          ready_eps, errored = ready_eps.partition(&:audio_asset_state_success?)
+          errored, ready_eps = ready_eps.partition(&:audio_asset_state_error?)
+          ready_eps = ready_eps.select(&:audio_asset_state_success?)
           error_audio_state_eps.concat(errored)
+          mark_asset_state_failures_for_reupload!(errored)
 
           log_asset_wait_duration!(ready_eps)
           # Publish the ready episodes
@@ -154,7 +156,7 @@ module Apple
           mark_as_delivered!(ready_eps)
         end
 
-        raise_for_asset_state_failure!(error_audio_state_eps) if error_audio_state_eps.any?
+        raise_asset_state_failure_retry!(error_audio_state_eps) if error_audio_state_eps.any?
       end
     end
 
@@ -255,6 +257,11 @@ module Apple
     end
 
     def raise_for_asset_state_failure!(failure_eps)
+      mark_asset_state_failures_for_reupload!(failure_eps)
+      raise_asset_state_failure_retry!(failure_eps)
+    end
+
+    def mark_asset_state_failures_for_reupload!(failure_eps)
       failure_eps.each do |ep|
         Rails.logger.error("Apple hosted audio asset state FAILURE, marking for reupload",
           {episode_id: ep.feeder_id,
@@ -262,7 +269,9 @@ module Apple
 
         ep.apple_mark_for_reupload!
       end
+    end
 
+    def raise_asset_state_failure_retry!(failure_eps)
       raise Apple::RetryPublishingError.new(
         "Found FAILURE appleHostedAudioAssetState on #{failure_eps.length} episodes, marked for reupload"
       )

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -145,7 +145,6 @@ module Apple
         # Wait for the audio asset to be processed by Apple
         wait_for_asset_state(eps) do |ready_eps|
           errored, ready_eps = ready_eps.partition(&:audio_asset_state_error?)
-          ready_eps = ready_eps.select(&:audio_asset_state_success?)
           error_audio_state_eps.concat(errored)
           mark_asset_state_failures_for_reupload!(errored)
 

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -140,14 +140,25 @@ module Apple
 
         wait_for_upload_processing(eps)
 
-        # Wait for the audio asset to be processed by Apple
-        wait_for_asset_state(eps) do |ready_eps|
+        error_audio_state_eps = []
+
+        # Wait for the audio asset to be processed by Apple.
+        # ready_eps are partitioned into SUCCESS (ready_eps) and FAILURE
+        # (error_audio_state_eps) — these are the only two terminal states.
+        wait_for_asset_state(eps) do |finished_eps|
+          ready_eps, errored = finished_eps.partition(&:audio_asset_state_success?)
+          error_audio_state_eps.concat(errored)
+
           log_asset_wait_duration!(ready_eps)
           # Publish the ready episodes
           publish_drafting!(ready_eps)
           # Then mark them as delivered
           mark_as_delivered!(ready_eps)
         end
+
+        # If Apple returned FAILURE for any episode's audio asset state,
+        # mark them for reupload and retry the publishing routine.
+        raise_for_asset_state_failure!(error_audio_state_eps) if error_audio_state_eps.any?
       end
     end
 
@@ -245,6 +256,20 @@ module Apple
           "Found #{state_name} state on #{problem_pdfs.length} podcast delivery files, episodes marked for reupload"
         )
       end
+    end
+
+    def raise_for_asset_state_failure!(failure_eps)
+      failure_eps.each do |ep|
+        Rails.logger.error("Apple hosted audio asset state FAILURE, marking for reupload",
+          {episode_id: ep.feeder_id,
+           audio_asset_state: ep.audio_asset_state})
+
+        ep.apple_mark_for_reupload!
+      end
+
+      raise Apple::RetryPublishingError.new(
+        "Found FAILURE appleHostedAudioAssetState on #{failure_eps.length} episodes, marked for reupload"
+      )
     end
 
     def wait_for_versioned_source_metadata(eps)

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -142,11 +142,9 @@ module Apple
 
         error_audio_state_eps = []
 
-        # Wait for the audio asset to be processed by Apple.
-        # ready_eps are partitioned into SUCCESS (ready_eps) and FAILURE
-        # (error_audio_state_eps) — these are the only two terminal states.
-        wait_for_asset_state(eps) do |finished_eps|
-          ready_eps, errored = finished_eps.partition(&:audio_asset_state_success?)
+        # Wait for the audio asset to be processed by Apple
+        wait_for_asset_state(eps) do |ready_eps|
+          ready_eps, errored = ready_eps.partition(&:audio_asset_state_success?)
           error_audio_state_eps.concat(errored)
 
           log_asset_wait_duration!(ready_eps)
@@ -156,8 +154,6 @@ module Apple
           mark_as_delivered!(ready_eps)
         end
 
-        # If Apple returned FAILURE for any episode's audio asset state,
-        # mark them for reupload and retry the publishing routine.
         raise_for_asset_state_failure!(error_audio_state_eps) if error_audio_state_eps.any?
       end
     end

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -273,7 +273,7 @@ module Apple
       end
 
       raise Apple::RetryPublishingError.new(
-        "Found FAILURE appleHostedAudioAssetState on #{failure_eps.length} episodes, marked for reupload"
+        "Found FAILURE appleHostedAudioAssetState on #{failure_eps.length} episodes #{failure_eps.map(&:feeder_id)}, marked for reupload"
       )
     end
 

--- a/app/models/apple/publisher.rb
+++ b/app/models/apple/publisher.rb
@@ -262,18 +262,26 @@ module Apple
 
     def mark_asset_state_failures_for_reupload!(failure_eps)
       failure_eps.each do |ep|
-        Rails.logger.error("Apple hosted audio asset state FAILURE, marking for reupload",
-          {episode_id: ep.feeder_id,
-           audio_asset_state: ep.audio_asset_state})
-
         ep.apple_mark_for_reupload!
       end
     end
 
     def raise_asset_state_failure_retry!(failure_eps)
+      failure_eps.each do |ep|
+        Rails.logger.error("Found FAILURE appleHostedAudioAssetState episode, marked for reupload",
+          apple_episode_log_context(ep).merge(audio_asset_state: ep.audio_asset_state))
+      end
+
       raise Apple::RetryPublishingError.new(
         "Found FAILURE appleHostedAudioAssetState on #{failure_eps.length} episodes, marked for reupload"
       )
+    end
+
+    def apple_episode_log_context(ep)
+      {
+        episode_id: ep.feeder_id,
+        episode_guid: ep.guid
+      }
     end
 
     def wait_for_versioned_source_metadata(eps)

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -803,6 +803,69 @@ describe Apple::Publisher do
       assert reupload_called, "FAILURE episode must be marked for reupload"
     end
 
+    it "marks FAILURE episodes for reupload before a later asset-state timeout" do
+      episode_waiting = build(:uploaded_apple_episode, show: apple_publisher.show)
+      reupload_called = false
+
+      wait_for_stub = ->(_remaining, wait_timeout:, wait_interval:, &block) {
+        block.call([episode_failure, episode_waiting])
+        [true, [episode_waiting]]
+      }
+
+      episode_failure.stub(:audio_asset_state_success?, false) do
+        episode_failure.stub(:audio_asset_state, "FAILURE") do
+          episode_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
+            apple_publisher.stub(:increment_asset_wait!, ->(*) {}) do
+              apple_publisher.stub(:wait_for_upload_processing, ->(*) {}) do
+                Apple::Publisher.stub(:wait_for, wait_for_stub) do
+                  Apple::Episode.stub(:probe_asset_state, ->(_api, _eps) { [[episode_failure], [episode_waiting]] }) do
+                    apple_publisher.stub(:check_for_stuck_episodes, ->(*) {}) do
+                      apple_publisher.stub(:log_asset_wait_duration!, ->(*) {}) do
+                        apple_publisher.stub(:publish_drafting!, ->(*) {}) do
+                          apple_publisher.stub(:mark_as_delivered!, ->(*) {}) do
+                            assert_raises(Apple::AssetStateTimeoutError) do
+                              apple_publisher.process_delivery!([episode_failure, episode_waiting])
+                            end
+                          end
+                        end
+                      end
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      assert reupload_called, "FAILURE episode must be marked even when another episode times out later"
+    end
+
+    it "does not treat ready non-FAILURE episodes as asset-state failures" do
+      episode_non_failure = build(:uploaded_apple_episode, show: apple_publisher.show)
+      published_called = false
+      delivered_called = false
+      reupload_called = false
+
+      episode_non_failure.stub(:audio_asset_state_success?, false) do
+        episode_non_failure.stub(:audio_asset_state_error?, false) do
+          episode_non_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
+            with_common_stubs([episode_non_failure]) do
+              apple_publisher.stub(:publish_drafting!, ->(eps) { published_called = true if eps.any? }) do
+                apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_called = true if eps.any? }) do
+                  apple_publisher.process_delivery!([episode_non_failure])
+                end
+              end
+            end
+          end
+        end
+      end
+
+      refute published_called, "only SUCCESS episodes should be published"
+      refute delivered_called, "only SUCCESS episodes should be marked delivered"
+      refute reupload_called, "only FAILURE episodes should be marked for reupload"
+    end
+
     it "publishes SUCCESS episodes and raises for FAILURE in a mixed batch" do
       published_with = nil
       delivered_with = nil

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -820,7 +820,7 @@ describe Apple::Publisher do
         "FAILURE episode must be marked even when another episode times out later"
     end
 
-    it "does not treat ready non-FAILURE episodes as asset-state failures" do
+    it "publishes ready non-FAILURE episodes" do
       episode_non_failure = uploaded_apple_episode_with_asset_state("UNSPECIFIED")
       refute episode_non_failure.feeder_episode.apple_needs_delivery?
 
@@ -829,8 +829,8 @@ describe Apple::Publisher do
         ready_eps: [episode_non_failure]
       )
 
-      assert_empty calls[:published], "only SUCCESS episodes should be published"
-      assert_empty calls[:delivered], "only SUCCESS episodes should be marked delivered"
+      assert_equal [episode_non_failure], calls[:published]
+      assert_equal [episode_non_failure], calls[:delivered]
       refute episode_non_failure.feeder_episode.apple_needs_delivery?,
         "only FAILURE episodes should be marked for reupload"
     end

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -20,6 +20,19 @@ describe Apple::Publisher do
     public_feed.save!
   end
 
+  def uploaded_apple_episode_with_asset_state(asset_state)
+    feeder_episode = create(:episode)
+
+    build(:uploaded_apple_episode,
+      show: apple_publisher.show,
+      feeder_episode: feeder_episode,
+      api_response: build(:apple_episode_api_response,
+        publishing_state: "PUBLISH",
+        item_guid: feeder_episode.item_guid,
+        apple_hosted_audio_asset_container_id: "456",
+        apple_hosted_audio_state: asset_state))
+  end
+
   describe ".initialize" do
     it "should build a publisher with the correct feeds" do
       assert_equal apple_publisher.public_feed, public_feed
@@ -708,190 +721,132 @@ describe Apple::Publisher do
   end
 
   describe "#raise_for_asset_state_failure!" do
-    let(:episode1) { build(:uploaded_apple_episode, show: apple_publisher.show) }
-    let(:episode2) { build(:uploaded_apple_episode, show: apple_publisher.show) }
+    let(:episode1) { uploaded_apple_episode_with_asset_state(Apple::Episode::AUDIO_ASSET_FAILURE) }
+    let(:episode2) { uploaded_apple_episode_with_asset_state(Apple::Episode::AUDIO_ASSET_FAILURE) }
 
     it "marks each failure episode for reupload and raises RetryPublishingError" do
-      reupload_calls = []
-      ep1_reupload = -> { reupload_calls << episode1.feeder_id }
-      ep2_reupload = -> { reupload_calls << episode2.feeder_id }
-
-      episode1.stub(:audio_asset_state, "FAILURE") do
-        episode1.stub(:apple_mark_for_reupload!, ep1_reupload) do
-          episode2.stub(:audio_asset_state, "FAILURE") do
-            episode2.stub(:apple_mark_for_reupload!, ep2_reupload) do
-              error = assert_raises(Apple::RetryPublishingError) do
-                apple_publisher.raise_for_asset_state_failure!([episode1, episode2])
-              end
-              assert_match(/Found FAILURE appleHostedAudioAssetState on 2 episodes/, error.message)
-            end
-          end
-        end
+      error = assert_raises(Apple::RetryPublishingError) do
+        apple_publisher.raise_for_asset_state_failure!([episode1, episode2])
       end
 
-      assert_equal [episode1.feeder_id, episode2.feeder_id].sort, reupload_calls.sort
+      assert_match(/Found FAILURE appleHostedAudioAssetState on 2 episodes/, error.message)
+      assert episode1.feeder_episode.apple_needs_delivery?
+      assert episode2.feeder_episode.apple_needs_delivery?
     end
   end
 
   describe "#process_delivery! asset state guard" do
-    let(:episode_success) { build(:uploaded_apple_episode, show: apple_publisher.show) }
-    let(:episode_failure) { build(:uploaded_apple_episode, show: apple_publisher.show) }
+    let(:episode_success) { uploaded_apple_episode_with_asset_state(Apple::Episode::AUDIO_ASSET_SUCCESS) }
+    let(:episode_failure) { uploaded_apple_episode_with_asset_state(Apple::Episode::AUDIO_ASSET_FAILURE) }
 
-    # Drive wait_for_asset_state's wait loop once with the supplied eps, no timeout.
-    let(:wait_for_asset_state_stub) do
-      original = apple_publisher.method(:wait_for_asset_state)
-      ->(eps, **_kwargs, &block) {
-        original.call(eps, wait_timeout: 0.seconds, wait_interval: 0.seconds, &block)
+    def with_asset_state_probe(ready_eps:, waiting_eps: [], timeout_waiting_eps: nil)
+      wait_for_stub = ->(remaining_eps, **_kwargs, &block) {
+        block.call(remaining_eps)
+        timeout_waiting_eps ? [true, timeout_waiting_eps] : [false, []]
       }
-    end
 
-    def with_common_stubs(probe_eps)
       apple_publisher.stub(:increment_asset_wait!, ->(*) {}) do
         apple_publisher.stub(:wait_for_upload_processing, ->(*) {}) do
-          apple_publisher.stub(:wait_for_asset_state, wait_for_asset_state_stub) do
-            apple_publisher.stub(:log_asset_wait_duration!, ->(*) {}) do
-              Apple::Episode.stub(:probe_asset_state, ->(_api, _eps) { [probe_eps, []] }) do
-                yield
-              end
-            end
-          end
-        end
-      end
-    end
-
-    it "publishes only SUCCESS episodes and does not raise when all SUCCESS" do
-      published_with = nil
-      delivered_with = nil
-
-      episode_success.stub(:audio_asset_state_success?, true) do
-        with_common_stubs([episode_success]) do
-          apple_publisher.stub(:publish_drafting!, ->(eps) { published_with = eps }) do
-            apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_with = eps }) do
-              apple_publisher.process_delivery!([episode_success])
-            end
-          end
-        end
-      end
-
-      assert_equal [episode_success], published_with
-      assert_equal [episode_success], delivered_with
-    end
-
-    it "raises RetryPublishingError and skips publish when all FAILURE" do
-      published_called = false
-      delivered_called = false
-      reupload_called = false
-
-      episode_failure.stub(:audio_asset_state_success?, false) do
-        episode_failure.stub(:audio_asset_state, "FAILURE") do
-          episode_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
-            with_common_stubs([episode_failure]) do
-              apple_publisher.stub(:publish_drafting!, ->(eps) { published_called = true if eps.any? }) do
-                apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_called = true if eps.any? }) do
-                  assert_raises(Apple::RetryPublishingError) do
-                    apple_publisher.process_delivery!([episode_failure])
-                  end
+          apple_publisher.stub(:log_asset_wait_duration!, ->(*) {}) do
+            apple_publisher.stub(:check_for_stuck_episodes, ->(*) {}) do
+              Apple::Publisher.stub(:wait_for, wait_for_stub) do
+                Apple::Episode.stub(:probe_asset_state, ->(_api, _eps) { [ready_eps, waiting_eps] }) do
+                  yield
                 end
               end
             end
           end
         end
       end
+    end
 
-      refute published_called, "publish_drafting! must not receive FAILURE episodes"
-      refute delivered_called, "mark_as_delivered! must not receive FAILURE episodes"
-      assert reupload_called, "FAILURE episode must be marked for reupload"
+    def capture_process_delivery_calls(eps, ready_eps:, waiting_eps: [], timeout_waiting_eps: nil, raises: nil)
+      calls = {published: [], delivered: []}
+
+      with_asset_state_probe(ready_eps: ready_eps, waiting_eps: waiting_eps, timeout_waiting_eps: timeout_waiting_eps) do
+        apple_publisher.stub(:publish_drafting!, ->(eps) { calls[:published].concat(eps) }) do
+          apple_publisher.stub(:mark_as_delivered!, ->(eps) { calls[:delivered].concat(eps) }) do
+            if raises
+              assert_raises(raises) do
+                apple_publisher.process_delivery!(eps)
+              end
+            else
+              apple_publisher.process_delivery!(eps)
+            end
+          end
+        end
+      end
+
+      calls
+    end
+
+    it "publishes only SUCCESS episodes and does not raise when all SUCCESS" do
+      calls = capture_process_delivery_calls(
+        [episode_success],
+        ready_eps: [episode_success]
+      )
+
+      assert_equal [episode_success], calls[:published]
+      assert_equal [episode_success], calls[:delivered]
+    end
+
+    it "raises RetryPublishingError and skips publish when all FAILURE" do
+      refute episode_failure.feeder_episode.apple_needs_delivery?
+
+      calls = capture_process_delivery_calls(
+        [episode_failure],
+        ready_eps: [episode_failure],
+        raises: Apple::RetryPublishingError
+      )
+
+      assert_empty calls[:published], "publish_drafting! must not receive FAILURE episodes"
+      assert_empty calls[:delivered], "mark_as_delivered! must not receive FAILURE episodes"
+      assert episode_failure.feeder_episode.apple_needs_delivery?, "FAILURE episode must be marked for reupload"
     end
 
     it "marks FAILURE episodes for reupload before a later asset-state timeout" do
       episode_waiting = build(:uploaded_apple_episode, show: apple_publisher.show)
-      reupload_called = false
+      refute episode_failure.feeder_episode.apple_needs_delivery?
 
-      wait_for_stub = ->(_remaining, wait_timeout:, wait_interval:, &block) {
-        block.call([episode_failure, episode_waiting])
-        [true, [episode_waiting]]
-      }
+      capture_process_delivery_calls(
+        [episode_failure, episode_waiting],
+        ready_eps: [episode_failure],
+        waiting_eps: [episode_waiting],
+        timeout_waiting_eps: [episode_waiting],
+        raises: Apple::AssetStateTimeoutError
+      )
 
-      episode_failure.stub(:audio_asset_state_success?, false) do
-        episode_failure.stub(:audio_asset_state, "FAILURE") do
-          episode_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
-            apple_publisher.stub(:increment_asset_wait!, ->(*) {}) do
-              apple_publisher.stub(:wait_for_upload_processing, ->(*) {}) do
-                Apple::Publisher.stub(:wait_for, wait_for_stub) do
-                  Apple::Episode.stub(:probe_asset_state, ->(_api, _eps) { [[episode_failure], [episode_waiting]] }) do
-                    apple_publisher.stub(:check_for_stuck_episodes, ->(*) {}) do
-                      apple_publisher.stub(:log_asset_wait_duration!, ->(*) {}) do
-                        apple_publisher.stub(:publish_drafting!, ->(*) {}) do
-                          apple_publisher.stub(:mark_as_delivered!, ->(*) {}) do
-                            assert_raises(Apple::AssetStateTimeoutError) do
-                              apple_publisher.process_delivery!([episode_failure, episode_waiting])
-                            end
-                          end
-                        end
-                      end
-                    end
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
-
-      assert reupload_called, "FAILURE episode must be marked even when another episode times out later"
+      assert episode_failure.feeder_episode.apple_needs_delivery?,
+        "FAILURE episode must be marked even when another episode times out later"
     end
 
     it "does not treat ready non-FAILURE episodes as asset-state failures" do
-      episode_non_failure = build(:uploaded_apple_episode, show: apple_publisher.show)
-      published_called = false
-      delivered_called = false
-      reupload_called = false
+      episode_non_failure = uploaded_apple_episode_with_asset_state("UNSPECIFIED")
+      refute episode_non_failure.feeder_episode.apple_needs_delivery?
 
-      episode_non_failure.stub(:audio_asset_state_success?, false) do
-        episode_non_failure.stub(:audio_asset_state_error?, false) do
-          episode_non_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
-            with_common_stubs([episode_non_failure]) do
-              apple_publisher.stub(:publish_drafting!, ->(eps) { published_called = true if eps.any? }) do
-                apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_called = true if eps.any? }) do
-                  apple_publisher.process_delivery!([episode_non_failure])
-                end
-              end
-            end
-          end
-        end
-      end
+      calls = capture_process_delivery_calls(
+        [episode_non_failure],
+        ready_eps: [episode_non_failure]
+      )
 
-      refute published_called, "only SUCCESS episodes should be published"
-      refute delivered_called, "only SUCCESS episodes should be marked delivered"
-      refute reupload_called, "only FAILURE episodes should be marked for reupload"
+      assert_empty calls[:published], "only SUCCESS episodes should be published"
+      assert_empty calls[:delivered], "only SUCCESS episodes should be marked delivered"
+      refute episode_non_failure.feeder_episode.apple_needs_delivery?,
+        "only FAILURE episodes should be marked for reupload"
     end
 
     it "publishes SUCCESS episodes and raises for FAILURE in a mixed batch" do
-      published_with = nil
-      delivered_with = nil
-      reupload_called = false
+      refute episode_failure.feeder_episode.apple_needs_delivery?
 
-      episode_success.stub(:audio_asset_state_success?, true) do
-        episode_failure.stub(:audio_asset_state_success?, false) do
-          episode_failure.stub(:audio_asset_state, "FAILURE") do
-            episode_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
-              with_common_stubs([episode_success, episode_failure]) do
-                apple_publisher.stub(:publish_drafting!, ->(eps) { published_with = eps }) do
-                  apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_with = eps }) do
-                    assert_raises(Apple::RetryPublishingError) do
-                      apple_publisher.process_delivery!([episode_success, episode_failure])
-                    end
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
+      calls = capture_process_delivery_calls(
+        [episode_success, episode_failure],
+        ready_eps: [episode_success, episode_failure],
+        raises: Apple::RetryPublishingError
+      )
 
-      assert_equal [episode_success], published_with, "only SUCCESS episodes should be published"
-      assert_equal [episode_success], delivered_with, "only SUCCESS episodes should be marked delivered"
-      assert reupload_called, "FAILURE episode must be marked for reupload"
+      assert_equal [episode_success], calls[:published], "only SUCCESS episodes should be published"
+      assert_equal [episode_success], calls[:delivered], "only SUCCESS episodes should be marked delivered"
+      assert episode_failure.feeder_episode.apple_needs_delivery?, "FAILURE episode must be marked for reupload"
     end
   end
 

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -707,6 +707,131 @@ describe Apple::Publisher do
     end
   end
 
+  describe "#raise_for_asset_state_failure!" do
+    let(:episode1) { build(:uploaded_apple_episode, show: apple_publisher.show) }
+    let(:episode2) { build(:uploaded_apple_episode, show: apple_publisher.show) }
+
+    it "marks each failure episode for reupload and raises RetryPublishingError" do
+      reupload_calls = []
+      ep1_reupload = -> { reupload_calls << episode1.feeder_id }
+      ep2_reupload = -> { reupload_calls << episode2.feeder_id }
+
+      episode1.stub(:audio_asset_state, "FAILURE") do
+        episode1.stub(:apple_mark_for_reupload!, ep1_reupload) do
+          episode2.stub(:audio_asset_state, "FAILURE") do
+            episode2.stub(:apple_mark_for_reupload!, ep2_reupload) do
+              error = assert_raises(Apple::RetryPublishingError) do
+                apple_publisher.raise_for_asset_state_failure!([episode1, episode2])
+              end
+              assert_match(/Found FAILURE appleHostedAudioAssetState on 2 episodes/, error.message)
+            end
+          end
+        end
+      end
+
+      assert_equal [episode1.feeder_id, episode2.feeder_id].sort, reupload_calls.sort
+    end
+  end
+
+  describe "#process_delivery! asset state guard" do
+    let(:episode_success) { build(:uploaded_apple_episode, show: apple_publisher.show) }
+    let(:episode_failure) { build(:uploaded_apple_episode, show: apple_publisher.show) }
+
+    # Drive wait_for_asset_state's wait loop once with the supplied eps, no timeout.
+    let(:wait_for_asset_state_stub) do
+      original = apple_publisher.method(:wait_for_asset_state)
+      ->(eps, **_kwargs, &block) {
+        original.call(eps, wait_timeout: 0.seconds, wait_interval: 0.seconds, &block)
+      }
+    end
+
+    def with_common_stubs(probe_eps)
+      apple_publisher.stub(:increment_asset_wait!, ->(*) {}) do
+        apple_publisher.stub(:wait_for_upload_processing, ->(*) {}) do
+          apple_publisher.stub(:wait_for_asset_state, wait_for_asset_state_stub) do
+            apple_publisher.stub(:log_asset_wait_duration!, ->(*) {}) do
+              Apple::Episode.stub(:probe_asset_state, ->(_api, _eps) { [probe_eps, []] }) do
+                yield
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "publishes only SUCCESS episodes and does not raise when all SUCCESS" do
+      published_with = nil
+      delivered_with = nil
+
+      episode_success.stub(:audio_asset_state_success?, true) do
+        with_common_stubs([episode_success]) do
+          apple_publisher.stub(:publish_drafting!, ->(eps) { published_with = eps }) do
+            apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_with = eps }) do
+              apple_publisher.process_delivery!([episode_success])
+            end
+          end
+        end
+      end
+
+      assert_equal [episode_success], published_with
+      assert_equal [episode_success], delivered_with
+    end
+
+    it "raises RetryPublishingError and skips publish when all FAILURE" do
+      published_called = false
+      delivered_called = false
+      reupload_called = false
+
+      episode_failure.stub(:audio_asset_state_success?, false) do
+        episode_failure.stub(:audio_asset_state, "FAILURE") do
+          episode_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
+            with_common_stubs([episode_failure]) do
+              apple_publisher.stub(:publish_drafting!, ->(eps) { published_called = true if eps.any? }) do
+                apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_called = true if eps.any? }) do
+                  assert_raises(Apple::RetryPublishingError) do
+                    apple_publisher.process_delivery!([episode_failure])
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      refute published_called, "publish_drafting! must not receive FAILURE episodes"
+      refute delivered_called, "mark_as_delivered! must not receive FAILURE episodes"
+      assert reupload_called, "FAILURE episode must be marked for reupload"
+    end
+
+    it "publishes SUCCESS episodes and raises for FAILURE in a mixed batch" do
+      published_with = nil
+      delivered_with = nil
+      reupload_called = false
+
+      episode_success.stub(:audio_asset_state_success?, true) do
+        episode_failure.stub(:audio_asset_state_success?, false) do
+          episode_failure.stub(:audio_asset_state, "FAILURE") do
+            episode_failure.stub(:apple_mark_for_reupload!, -> { reupload_called = true }) do
+              with_common_stubs([episode_success, episode_failure]) do
+                apple_publisher.stub(:publish_drafting!, ->(eps) { published_with = eps }) do
+                  apple_publisher.stub(:mark_as_delivered!, ->(eps) { delivered_with = eps }) do
+                    assert_raises(Apple::RetryPublishingError) do
+                      apple_publisher.process_delivery!([episode_success, episode_failure])
+                    end
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+
+      assert_equal [episode_success], published_with, "only SUCCESS episodes should be published"
+      assert_equal [episode_success], delivered_with, "only SUCCESS episodes should be marked delivered"
+      assert reupload_called, "FAILURE episode must be marked for reupload"
+    end
+  end
+
   describe "#raise_delivery_processing_errors" do
     let(:apple_episode) { build(:apple_episode, show: apple_publisher.show) }
     let(:asset_processing_state) { "COMPLETED" }
@@ -1137,7 +1262,8 @@ describe Apple::Publisher do
         pdf = OpenStruct.new(api_marked_as_uploaded?: true)
         OpenStruct.new(
           feeder_id: i,
-          podcast_delivery_files: [pdf]
+          podcast_delivery_files: [pdf],
+          audio_asset_state_success?: true
         )
       }
 

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -733,6 +733,21 @@ describe Apple::Publisher do
       assert episode1.feeder_episode.apple_needs_delivery?
       assert episode2.feeder_episode.apple_needs_delivery?
     end
+
+    it "logs each failure episode id and guid" do
+      logs = capture_json_logs do
+        assert_raises(Apple::RetryPublishingError) do
+          apple_publisher.raise_for_asset_state_failure!([episode1, episode2])
+        end
+      end
+
+      failure_logs = logs.select { |l| l[:msg] == "Found FAILURE appleHostedAudioAssetState episode, marked for reupload" }
+      failure_log_episodes = failure_logs.map { |l| [l[:episode_id], l[:episode_guid]] }
+
+      assert_equal 2, failure_logs.length
+      assert_includes failure_log_episodes, [episode1.feeder_id, episode1.guid]
+      assert_includes failure_log_episodes, [episode2.feeder_id, episode2.guid]
+    end
   end
 
   describe "#process_delivery! asset state guard" do

--- a/test/models/apple/publisher_test.rb
+++ b/test/models/apple/publisher_test.rb
@@ -730,6 +730,7 @@ describe Apple::Publisher do
       end
 
       assert_match(/Found FAILURE appleHostedAudioAssetState on 2 episodes/, error.message)
+      assert_includes error.message, [episode1.feeder_id, episode2.feeder_id].to_s
       assert episode1.feeder_episode.apple_needs_delivery?
       assert episode2.feeder_episode.apple_needs_delivery?
     end


### PR DESCRIPTION
closes https://github.com/PRX/feeder.prx.org/issues/1462

Sets up a guard before publishing against asset states settling into ERROR 