### PR TITLE
hide private feed url when the Public Feed URL is set

### DIFF
--- a/app/views/feeds/_form_distribution.html.erb
+++ b/app/views/feeds/_form_distribution.html.erb
@@ -32,7 +32,7 @@
       </div>
 
       <% if feed.persisted? %>
-        <div class="col-12 mb-4 <%= "d-none" unless feed.public? %>" data-feed-tokens-target="showPublic">
+        <div class="col-12 mb-4 <%= "d-none" if feed.private? || feed.url.present? %>" data-feed-tokens-target="showPublic">
           <div class="form-floating input-group">
             <%= form.text_field :published_url, value: feed.published_public_url, disabled: true %>
             <%= form.label :published_url %>


### PR DESCRIPTION
closes #1312 

- Hides the Private URL Feed field when the feed is public and the Public Feed URL is set

When Public Feed URL is NOT set on feed
<img width="459" height="409" alt="Screenshot 2026-05-04 at 4 20 23 PM" src="https://github.com/user-attachments/assets/fca683e2-9f0e-40c0-9ddd-760e01c49752" />

When feed Public Feed URL is set on feed
<img width="455" height="317" alt="Screenshot 2026-05-04 at 4 20 12 PM" src="https://github.com/user-attachments/assets/06d2bab1-9043-4e73-9555-24848ecc71ed" />
