### PR TITLE
No scrolling on number fields

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -37,6 +37,13 @@ document.addEventListener("turbo:before-cache", function () {
   }
 })
 
+// no scrolling on number fields
+document.addEventListener("wheel", () => {
+  if (document.activeElement.type === "number") {
+    document.activeElement.blur()
+  }
+})
+
 document.addEventListener("trix-file-accept", (event) => {
   event.preventDefault()
 })


### PR DESCRIPTION
Fixes #1465.

If someone scrolls on a number field, just blur it.  So the values don't change.