### PR TITLE
Prevent json indexing on html error response

### DIFF
--- a/app/models/apple/api.rb
+++ b/app/models/apple/api.rb
@@ -223,6 +223,12 @@ module Apple
       resp
     end
 
+    def response!(resp)
+      response(resp).tap do |wrapped_response|
+        handle_api_error(resp) if wrapped_response.dig("api_response", "err")
+      end
+    end
+
     def handle_api_error(resp)
       raise Apple::ApiError.new("Apple API Error", resp)
     end

--- a/app/models/apple/show.rb
+++ b/app/models/apple/show.rb
@@ -144,7 +144,7 @@ module Apple
           integration: :apple,
           feeder_id: public_feed.id,
           feeder_type: :feeds,
-          external_id: apple_json["api_response"]["val"]["data"]["id"],
+          external_id: apple_json.dig("api_response", "val", "data", "id"),
           api_response: apple_json
         )
       end
@@ -155,7 +155,7 @@ module Apple
       Rails.logger.info("Creating show", show_data: data)
       resp = api.post("shows", data)
 
-      api.response(resp)
+      api.response!(resp)
     end
 
     def update_show!(sync)
@@ -168,7 +168,7 @@ module Apple
       # api.response(resp)
 
       resp = api.get("shows/#{sync.external_id}")
-      api.response(resp)
+      api.response!(resp)
     end
 
     def create_or_update_show(sync)

--- a/test/models/apple/api_test.rb
+++ b/test/models/apple/api_test.rb
@@ -202,6 +202,28 @@ describe Apple::Api do
     end
   end
 
+  describe "#response!" do
+    it "returns the wrapped api response when the http response is ok" do
+      http_response = OpenStruct.new(code: "200", body: {data: {id: "123"}}.to_json)
+
+      api_response = api.response!(http_response)
+
+      assert_equal true, api_response["api_response"]["ok"]
+      assert_equal "123", api_response["api_response"]["val"]["data"]["id"]
+    end
+
+    it "raises an api error when the http response is not ok" do
+      http_response = OpenStruct.new(code: "503", body: "<html>503 Service Unavailable</html>")
+
+      error = assert_raises(Apple::ApiError) do
+        api.response!(http_response)
+      end
+
+      assert_includes error.message, "HTTP resp code:503"
+      assert_includes error.message, "503 Service Unavailable"
+    end
+  end
+
   describe "#unwrap_bridge_response" do
     let(:ok_row) { {api_response: {ok: true, err: false, val: {data: {status: 200}}}}.with_indifferent_access }
     let(:not_found_row) { {api_response: {ok: false, err: true, val: {data: {status: 404}}}}.with_indifferent_access }

--- a/test/models/apple/show_test.rb
+++ b/test/models/apple/show_test.rb
@@ -228,6 +228,21 @@ describe Apple::Show do
       end
     end
 
+    it "raises an api error when show sync returns an http error" do
+      apple_show.sync_log.update!(api_response: {"before" => true})
+      response = OpenStruct.new(body: "<html>503 Service Unavailable</html>", code: "503")
+
+      apple_show.api.stub(:get, response) do
+        error = assert_raises(Apple::ApiError) do
+          apple_show.sync!
+        end
+
+        assert_includes error.message, "HTTP resp code:503"
+        assert_includes error.message, "503 Service Unavailable"
+        assert_equal({"before" => true}, apple_show.sync_log.reload.api_response)
+      end
+    end
+
     it "logs an incomplete sync record if the upsert fails" do
       raises_exception = ->(_arg) { raise Apple::ApiError.new("Error", OpenStruct.new(code: 200, body: "body")) }
 


### PR DESCRIPTION
Fallout from the June 1 batch.  This adds a guard on the local non-bridge api handling to guard against indexing into a response that is a 5xx.