### PR TITLE
Include Feeds in auth'd Podcasts API

### DIFF
--- a/app/controllers/api/auth/podcasts_controller.rb
+++ b/app/controllers/api/auth/podcasts_controller.rb
@@ -29,4 +29,8 @@ class Api::Auth::PodcastsController < Api::PodcastsController
       super
     end
   end
+
+  def included(resources)
+    super.includes(:feeds)
+  end
 end

--- a/app/representers/api/auth/podcast_representer.rb
+++ b/app/representers/api/auth/podcast_representer.rb
@@ -1,6 +1,15 @@
 class Api::Auth::PodcastRepresenter < Api::PodcastRepresenter
   property :deleted_at, writeable: false
 
+  # TODO: this should probably be embedded, but zooms aren't working!
+  # update when we move off hal_api-rails (probably to halbuilder)
+  collection :feeds, writeable: false do
+    property :id
+    property :label
+    property :slug
+    property :private
+  end
+
   def self_url(podcast)
     api_authorization_podcast_path(podcast)
   end

--- a/test/representers/api/auth/podcast_representer_test.rb
+++ b/test/representers/api/auth/podcast_representer_test.rb
@@ -5,6 +5,15 @@ describe Api::Auth::PodcastRepresenter do
   let(:representer) { Api::Auth::PodcastRepresenter.new(podcast) }
   let(:json) { JSON.parse(representer.to_json) }
 
+  it "has a feeds property" do
+    assert json.key?("feeds")
+    assert_equal 1, json["feeds"].count
+    assert_equal podcast.default_feed.id, json["feeds"][0]["id"]
+    assert_equal "Default RSS Feed", json["feeds"][0]["label"]
+    assert_equal false, json["feeds"][0]["private"]
+    assert_nil json["feeds"][0]["slug"]
+  end
+
   it "has authorized links" do
     assert_equal json["_links"]["self"]["href"], "/api/v1/authorization/podcasts/#{podcast.id}"
     assert_match("/api/v1/authorization/podcasts/#{podcast.id}/episodes", json["_links"]["prx:episodes"]["href"])


### PR DESCRIPTION
To do https://github.com/PRX/augury.prx.org/issues/1901, we need some way to scrape feed data from the augury API.

Rather than standing up a new `/api/v1/authorization/feeds?since=` endpoint, seemed easier to just return with the podcast.  Since feeds always `touch: true` the podcast.