### PR TITLE
Exec app process from bin/application

### DIFF
--- a/bin/application
+++ b/bin/application
@@ -72,11 +72,7 @@ ApplicationRun () {
     ApplicationUpdate
   fi
 
-  if [ -n "$CMD" ] ; then
-    exec $CMD $CMD_ARGS
-  else
-    $CMD_ARGS
-  fi
+  exec $CMD $CMD_ARGS
 }
 
 ApplicationParseOpts $*

--- a/bin/application
+++ b/bin/application
@@ -72,7 +72,11 @@ ApplicationRun () {
     ApplicationUpdate
   fi
 
-  $CMD $CMD_ARGS
+  if [ -n "$CMD" ] ; then
+    exec $CMD $CMD_ARGS
+  else
+    $CMD_ARGS
+  fi
 }
 
 ApplicationParseOpts $*


### PR DESCRIPTION
Multi-repo changeset

bin/application is the container ENTRYPOINT and starts the app as a child process without exec, so the app never receives the SIGTERM that ECS sends on task stop. Where the task definition sets InitProcessEnabled, docker-init forwards SIGTERM only to the wrapper shell, and the app is SIGKILLed when the shell exits. Where it doesn't, the wrapper shell is PID 1, ignores SIGTERM, and the task waits out the full StopTimeout before SIGKILL. Either way there is no graceful shutdown: workers are killed mid-job and web servers never drain.

This execs the selected app process so it receives SIGTERM directly. Callers that previously supplied exec themselves are updated to remove the now-redundant argument.