### PR TITLE
Clean polluted Apple delivery status history

### DIFF
--- a/db/migrate/20260717000001_remove_polluted_apple_episode_delivery_statuses.rb
+++ b/db/migrate/20260717000001_remove_polluted_apple_episode_delivery_statuses.rb
@@ -1,0 +1,38 @@
+class RemovePollutedAppleEpisodeDeliveryStatuses < ActiveRecord::Migration[7.2]
+  def up
+    configured_podcast_ids = Feed.with_deleted
+      .where(id: Apple::Config.select(:feed_id))
+      .where.not(podcast_id: nil)
+      .select(:podcast_id)
+
+    configured_episode_ids = Episode.with_deleted.where(podcast_id: configured_podcast_ids).select(:id)
+    apple_sync_episode_ids = SyncLog.apple.episodes.where.not(feeder_id: nil).select(:feeder_id)
+    apple_container_episode_ids = Apple::PodcastContainer.where.not(episode_id: nil).select(:episode_id)
+
+    polluted_statuses = Integrations::EpisodeDeliveryStatus.apple
+      .joins(:episode)
+      .where(
+        delivered: [false, nil],
+        uploaded: [false, nil],
+        source_url: [nil, ""],
+        source_filename: [nil, ""],
+        source_size: nil,
+        enclosure_url: [nil, ""],
+        source_fetch_count: [nil, 0],
+        source_media_version_id: nil,
+        asset_processing_attempts: [nil, 0]
+      )
+      .where.not(episode_id: configured_episode_ids)
+      .where.not(episode_id: apple_sync_episode_ids)
+      .where.not(episode_id: apple_container_episode_ids)
+
+    polluted_statuses.delete_all
+
+    practicecast = Podcast.find_by(id: 5472)
+    Integrations::EpisodeDeliveryStatus.where(episode: practicecast.episodes).delete_all if practicecast
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Deleted polluted Apple delivery statuses cannot be restored"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_04_27_173435) do
+ActiveRecord::Schema[7.2].define(version: 2026_07_17_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"


### PR DESCRIPTION
Cleans up apple episode delivery status rows that have no configured apple show.
  
From May 2023 to March 2025: every publish wrote an Apple status, Apple config or not. See Commit 333dcfe8 (May 23, 2023, "Mark for apple reupload upon episode publish") added apple_mark_for_reupload! directly to Episode#publish! with no gating.