### PR TITLE
Update podcast clips

### DIFF
--- a/app/controllers/podcast_clips_controller.rb
+++ b/app/controllers/podcast_clips_controller.rb
@@ -15,10 +15,19 @@ class PodcastClipsController < ApplicationController
   def show
   end
 
+  def update
+    if @clip.update(update_clip_params)
+      redirect_to podcast_clip_path(@podcast, @clip), notice: t(".notice")
+    else
+      flash.now[:error] = t(".error")
+      render :show, status: :unprocessable_entity
+    end
+  end
+
   def attach
-    if (ep = attach_to_episode(clip_params[:episode]))
+    if (ep = attach_to_episode(attach_clip_params[:episode]))
       redirect_to episode_media_path(ep), notice: t(".attached")
-    elsif (ep = create_new_episode(clip_params[:title], clip_params[:released_at]))
+    elsif (ep = create_new_episode(attach_clip_params[:title], attach_clip_params[:released_at]))
       redirect_to episode_media_path(ep), notice: t(".created")
     elsif request.referrer&.ends_with?("/clips")
       redirect_to podcast_clips_path(@podcast), alert: t(".alert")
@@ -29,7 +38,11 @@ class PodcastClipsController < ApplicationController
 
   private
 
-  def clip_params
+  def update_clip_params
+    nilify(params.fetch(:stream_resource, {}).permit(%i[segmentation]))
+  end
+
+  def attach_clip_params
     nilify(params.fetch(:stream_resource, {}).permit(%i[episode title released_at]))
   end
 

--- a/app/models/stream_resource.rb
+++ b/app/models/stream_resource.rb
@@ -132,6 +132,18 @@ class StreamResource < ApplicationRecord
     [[offset_start, offset_end]]
   end
 
+  def segmentation=(seg)
+    seg = JSON.safe_parse(seg) if seg.is_a?(String)
+
+    # move the actual start, so start_at is this far into the clip
+    offset_start = seg.try(:dig, 0, 0).to_f
+    self.actual_start_at = start_at - offset_start if start_at
+
+    # NOTE: the UI shows an end offset, but you can't set it - we just
+    # move it based on where you put the start + file-duration
+    self.actual_end_at = actual_start_at + duration if actual_start_at && duration
+  end
+
   def offset_start
     segmentation[0]&.first.to_f
   end

--- a/config/initializers/extensions.rb
+++ b/config/initializers/extensions.rb
@@ -33,3 +33,11 @@ class Array
     map { |v| v.try(:with_indifferent_access) || v }
   end
 end
+
+module JSON
+  def self.safe_parse(val)
+    parse(val)
+  rescue
+    nil
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1410,6 +1410,9 @@ en:
       title: "Clip - %{time}"
     tabs:
       edit: Clip Editor
+    update:
+      error: Unable to save
+      notice: Clip updated
   podcast_engagement:
     form:
       <<: *form

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     resources :imports, only: [:index, :show, :create]
     resource :planner, only: [:show, :create], controller: :podcast_planner
     resource :stream, only: [:show, :update], controller: :podcast_stream
-    resources :clips, only: [:index, :show], controller: :podcast_clips do
+    resources :clips, only: [:index, :show, :update], controller: :podcast_clips do
       post "attach", on: :member
     end
     resources :feeds, except: [:edit] do

--- a/test/controllers/podcast_clips_controller_test.rb
+++ b/test/controllers/podcast_clips_controller_test.rb
@@ -29,6 +29,18 @@ class PodcastClipsControllerTest < ActionDispatch::IntegrationTest
     assert_response :forbidden
   end
 
+  it "updates a clip" do
+    put podcast_clip_url(podcast, clip), params: {stream_resource: {segmentation: "[[123,45678]]"}}
+    assert_redirected_to podcast_clip_url(podcast, clip)
+    assert_equal [[123, 3723]], clip.reload.segmentation
+  end
+
+  it "authorizes updating" do
+    podcast.update(prx_account_uri: "/api/v1/accounts/456")
+    put podcast_clip_url(podcast, clip), params: {stream_resource: {segmentation: ""}}
+    assert_response :forbidden
+  end
+
   it "attaches to existing episodes" do
     ep = create(:episode, podcast: podcast)
     assert_nil ep.uncut

--- a/test/models/stream_resource_test.rb
+++ b/test/models/stream_resource_test.rb
@@ -181,4 +181,36 @@ describe StreamResource do
       assert_equal 1740, res.offset_duration
     end
   end
+
+  describe "#segmentation=" do
+    let(:res) { StreamResource.new(start_at: "2026-02-06T02:00Z", end_at: "2026-02-06T03:00Z", duration: 70.minutes) }
+
+    it "sets the start offset, and calculates the end" do
+      res.segmentation = nil
+      assert_equal [[0, 3600]], res.segmentation
+
+      res.segmentation = [[99, "ignored"]]
+      assert_equal [[99, 3699]], res.segmentation
+
+      res.segmentation = [[600, "ignored"]]
+      assert_equal [[600, 4200]], res.segmentation
+      assert_equal 0, res.missing_seconds
+
+      # eventually we start missing seconds
+      res.segmentation = [[601, "ignored"]]
+      assert_equal [[601, 4200]], res.segmentation
+      assert_equal 1, res.missing_seconds
+    end
+
+    it "json decodes" do
+      res.segmentation = ""
+      assert_equal [[0, 3600]], res.segmentation
+
+      res.segmentation = "[[10, 3610]]"
+      assert_equal [[10, 3610]], res.segmentation
+
+      res.segmentation = "[not json"
+      assert_equal [[0, 3600]], res.segmentation
+    end
+  end
 end


### PR DESCRIPTION
Fixes #1492.  Adds the `podcast_clips#update` action.

<img width="2912" height="1480" alt="image" src="https://github.com/user-attachments/assets/95110415-09e9-4f3e-8a42-48012ed4db30" />

NOTE: this reuses the episode Uncut media UI.  Which does let you trim both the start/end of the file.  However... we already know the exact duration of these, and that we were attempting to capture 1 hour.

So for now, I just ignore the end offset, if you set it.  And the clip end is always the start + file-duration.  You're just marking where the hour starts.  If/when we get to #1426, should revisit this.