### PR TITLE
fix(css): mute bg color of prx-blank-lines in dark mode

### DIFF
--- a/app/assets/stylesheets/shared/layout.scss
+++ b/app/assets/stylesheets/shared/layout.scss
@@ -91,7 +91,7 @@ h1 {
   }
 
   .prx-blank-lines {
-    background-color: $navy;
+    background-color: $gray-800;
   }
 
   .prx-border-thick {


### PR DESCRIPTION
Change the `.prx-blank-lines` background color to a muted neutral color. Embed preview should now standout more and be the primary focused element in that "in content" preview layout.

<img width="1567" height="1097" alt="image" src="https://github.com/user-attachments/assets/9cdff782-7d37-4777-8e48-6313306d55ee" />
